### PR TITLE
[190] Support guided single-operand placement steps

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
@@ -1,6 +1,7 @@
 package org.cescfe.numpairs.feature.tutorial
 
 import androidx.annotation.StringRes
+import org.cescfe.numpairs.domain.puzzle.model.OperandSlot
 import org.cescfe.numpairs.domain.puzzle.model.Operator
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.domain.puzzle.model.PuzzleCompletionState
@@ -118,6 +119,14 @@ sealed interface TutorialHighlightTarget {
             }
         }
     }
+
+    data class TileOperandSlot(val tileIndex: Int, val slot: OperandSlot) : TutorialHighlightTarget {
+        init {
+            require(tileIndex >= 0) {
+                "Tutorial tile operand slot highlight index must be non-negative."
+            }
+        }
+    }
 }
 
 sealed interface TutorialRequiredAction {
@@ -128,6 +137,18 @@ sealed interface TutorialRequiredAction {
             }
             require(value > 0) {
                 "Tutorial strip entry action value must be positive."
+            }
+        }
+    }
+
+    data class PlaceTileOperand(val tileIndex: Int, val slot: OperandSlot, val stripEntryId: Int) :
+        TutorialRequiredAction {
+        init {
+            require(tileIndex >= 0) {
+                "Tutorial tile operand action index must be non-negative."
+            }
+            require(stripEntryId >= 0) {
+                "Tutorial tile operand strip entry id must be non-negative."
             }
         }
     }
@@ -197,6 +218,28 @@ sealed interface TutorialStepCompletionPredicate {
 
             return stripItem.label == value.toString() &&
                 stripItem.visualStyle == StripItemVisualStyle.PLAYER_ENTERED
+        }
+    }
+
+    data class TileOperandPlaced(val tileIndex: Int, val slot: OperandSlot, val value: Int) :
+        TutorialStepCompletionPredicate {
+        init {
+            require(tileIndex >= 0) {
+                "Tutorial tile operand completion index must be non-negative."
+            }
+            require(value > 0) {
+                "Tutorial tile operand completion value must be positive."
+            }
+        }
+
+        override fun isSatisfiedBy(uiState: GameUiState): Boolean {
+            val tile = uiState.tiles.getOrNull(tileIndex) ?: return false
+            val operandLabel = when (slot) {
+                OperandSlot.LEFT -> tile.leftOperandLabel
+                OperandSlot.RIGHT -> tile.rightOperandLabel
+            }
+
+            return operandLabel == value.toString()
         }
     }
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -123,12 +123,14 @@ private fun TutorialInstructionSurface(
     }
 }
 
-private fun TutorialStep.toInteractionPolicy(scenario: TutorialScenario, uiState: GameUiState?): GameInteractionPolicy =
-    requiredAction.toInteractionPolicy(
-        scenario = scenario,
-        uiState = uiState,
-        highlightedStripEntryIds = highlightedStripEntryIds(scenario = scenario)
-    )
+internal fun TutorialStep.toInteractionPolicy(
+    scenario: TutorialScenario,
+    uiState: GameUiState?
+): GameInteractionPolicy = requiredAction.toInteractionPolicy(
+    scenario = scenario,
+    uiState = uiState,
+    highlightedStripEntryIds = highlightedStripEntryIds(scenario = scenario)
+)
 
 private fun TutorialRequiredAction.toInteractionPolicy(
     scenario: TutorialScenario,
@@ -147,6 +149,7 @@ private fun TutorialRequiredAction.toInteractionPolicy(
         canConfirmTileOperand = { _, _, _ -> false },
         canConfirmTileOperator = { _, _ -> false }
     )
+    is TutorialRequiredAction.PlaceTileOperand -> toInteractionPolicy()
     is TutorialRequiredAction.CompleteTileExpression -> toInteractionPolicy(
         scenario = scenario,
         highlightedStripEntryIds = highlightedStripEntryIds
@@ -161,6 +164,20 @@ private fun TutorialRequiredAction.toInteractionPolicy(
     )
     TutorialRequiredAction.CompleteScenario -> GameInteractionPolicy.AllowAll
 }
+
+private fun TutorialRequiredAction.PlaceTileOperand.toInteractionPolicy(): GameInteractionPolicy =
+    GameInteractionPolicy(
+        canTapStripItem = { false },
+        canConfirmStripItemEntry = { _, _ -> false },
+        canTapTileLeftOperand = { index -> index == tileIndex && slot == OperandSlot.LEFT },
+        canTapTileRightOperand = { index -> index == tileIndex && slot == OperandSlot.RIGHT },
+        canTapTileOperator = { false },
+        canTapTileReset = { false },
+        canConfirmTileOperand = { index, selectedSlot, selectedStripEntryId ->
+            index == tileIndex && selectedSlot == slot && selectedStripEntryId == stripEntryId
+        },
+        canConfirmTileOperator = { _, _ -> false }
+    )
 
 private fun TutorialRequiredAction.CompleteTileExpression.toInteractionPolicy(
     scenario: TutorialScenario,
@@ -299,12 +316,13 @@ private fun TutorialStep.highlightedStripEntryIds(scenario: TutorialScenario): S
             TutorialHighlightTarget.HiddenTileExpressions,
             TutorialHighlightTarget.StripArea,
             is TutorialHighlightTarget.TileExpressionSlots,
+            is TutorialHighlightTarget.TileOperandSlot,
             is TutorialHighlightTarget.Tiles -> Unit
         }
     }
 }
 
-private fun TutorialStep.toHighlightState(scenario: TutorialScenario, uiState: GameUiState?): GameHighlightState {
+internal fun TutorialStep.toHighlightState(scenario: TutorialScenario, uiState: GameUiState?): GameHighlightState {
     val orderedAction = requiredAction as? TutorialRequiredAction.CompleteTileExpressionsInOrder
 
     if (orderedAction != null) {
@@ -347,6 +365,12 @@ private fun TutorialStep.toHighlightState(scenario: TutorialScenario, uiState: G
             is TutorialHighlightTarget.TileExpressionSlots -> {
                 tileExpressionSlots += expressionSlotHighlights(target.tileIndex)
             }
+            is TutorialHighlightTarget.TileOperandSlot -> {
+                tileExpressionSlots += GameTileExpressionSlotHighlight(
+                    tileIndex = target.tileIndex,
+                    slot = target.slot.toGameTileExpressionSlot()
+                )
+            }
             is TutorialHighlightTarget.Tiles -> {
                 tileIndexes += target.indexes
             }
@@ -358,6 +382,11 @@ private fun TutorialStep.toHighlightState(scenario: TutorialScenario, uiState: G
         tileIndexes = tileIndexes,
         tileExpressionSlots = tileExpressionSlots
     )
+}
+
+private fun OperandSlot.toGameTileExpressionSlot(): GameTileExpressionSlot = when (this) {
+    OperandSlot.LEFT -> GameTileExpressionSlot.LEFT_OPERAND
+    OperandSlot.RIGHT -> GameTileExpressionSlot.RIGHT_OPERAND
 }
 
 private fun expressionSlotHighlights(tileIndex: Int): Set<GameTileExpressionSlotHighlight> = setOf(

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialSingleOperandActionTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialSingleOperandActionTest.kt
@@ -1,0 +1,176 @@
+package org.cescfe.numpairs.feature.tutorial
+
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.domain.puzzle.model.OperandSlot
+import org.cescfe.numpairs.feature.game.GameTileExpressionSlot
+import org.cescfe.numpairs.feature.game.GameTileExpressionSlotHighlight
+import org.cescfe.numpairs.feature.game.presentation.GameUiState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TutorialSingleOperandActionTest {
+    private val scenario = TutorialContent.scenario(TutorialScenarioId.TWO_PAIR_PRACTICE)
+    private val step = TutorialStep(
+        order = 1,
+        scenarioId = scenario.id,
+        playerFacingCopyResId = R.string.tutorial_step_one_copy,
+        highlightedTargets = listOf(
+            TutorialHighlightTarget.StripEntries(indexes = listOf(REQUIRED_STRIP_ENTRY_ID)),
+            TutorialHighlightTarget.TileOperandSlot(
+                tileIndex = TARGET_TILE_INDEX,
+                slot = OperandSlot.LEFT
+            )
+        ),
+        requiredAction = TutorialRequiredAction.PlaceTileOperand(
+            tileIndex = TARGET_TILE_INDEX,
+            slot = OperandSlot.LEFT,
+            stripEntryId = REQUIRED_STRIP_ENTRY_ID
+        ),
+        completionPredicate = TutorialStepCompletionPredicate.TileOperandPlaced(
+            tileIndex = TARGET_TILE_INDEX,
+            slot = OperandSlot.LEFT,
+            value = REQUIRED_VALUE
+        )
+    )
+
+    @Test
+    fun single_operand_models_reject_invalid_indexes_and_values() {
+        assertThrows(IllegalArgumentException::class.java) {
+            TutorialRequiredAction.PlaceTileOperand(
+                tileIndex = -1,
+                slot = OperandSlot.LEFT,
+                stripEntryId = REQUIRED_STRIP_ENTRY_ID
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            TutorialRequiredAction.PlaceTileOperand(
+                tileIndex = TARGET_TILE_INDEX,
+                slot = OperandSlot.LEFT,
+                stripEntryId = -1
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            TutorialStepCompletionPredicate.TileOperandPlaced(
+                tileIndex = -1,
+                slot = OperandSlot.LEFT,
+                value = REQUIRED_VALUE
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            TutorialStepCompletionPredicate.TileOperandPlaced(
+                tileIndex = TARGET_TILE_INDEX,
+                slot = OperandSlot.LEFT,
+                value = 0
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            TutorialHighlightTarget.TileOperandSlot(
+                tileIndex = -1,
+                slot = OperandSlot.LEFT
+            )
+        }
+    }
+
+    @Test
+    fun single_operand_step_completes_only_when_the_target_slot_contains_the_required_value() {
+        val initialState = GameUiState.from(scenario.initialPuzzle)
+        val wrongValueState = initialState.withOperandLabel(
+            tileIndex = TARGET_TILE_INDEX,
+            slot = OperandSlot.LEFT,
+            label = "2"
+        )
+        val wrongSlotState = initialState.withOperandLabel(
+            tileIndex = TARGET_TILE_INDEX,
+            slot = OperandSlot.RIGHT,
+            label = REQUIRED_VALUE.toString()
+        )
+        val completedState = initialState.withOperandLabel(
+            tileIndex = TARGET_TILE_INDEX,
+            slot = OperandSlot.LEFT,
+            label = REQUIRED_VALUE.toString()
+        )
+
+        assertFalse(step.isComplete(initialState))
+        assertFalse(step.isComplete(wrongValueState))
+        assertFalse(step.isComplete(wrongSlotState))
+        assertTrue(step.isComplete(completedState))
+    }
+
+    @Test
+    fun single_operand_policy_allows_only_the_target_slot_and_required_strip_entry() {
+        val policy = step.toInteractionPolicy(
+            scenario = scenario,
+            uiState = GameUiState.from(scenario.initialPuzzle)
+        )
+
+        assertFalse(policy.canTapStripItem(REQUIRED_STRIP_ENTRY_ID))
+        assertFalse(policy.canConfirmStripItemEntry(REQUIRED_STRIP_ENTRY_ID, REQUIRED_VALUE))
+        assertTrue(policy.canTapTileLeftOperand(TARGET_TILE_INDEX))
+        assertFalse(policy.canTapTileRightOperand(TARGET_TILE_INDEX))
+        assertFalse(policy.canTapTileLeftOperand(1))
+        assertFalse(policy.canTapTileOperator(TARGET_TILE_INDEX))
+        assertFalse(policy.canTapTileReset(TARGET_TILE_INDEX))
+        assertTrue(
+            policy.canConfirmTileOperand(
+                TARGET_TILE_INDEX,
+                OperandSlot.LEFT,
+                REQUIRED_STRIP_ENTRY_ID
+            )
+        )
+        assertFalse(policy.canConfirmTileOperand(TARGET_TILE_INDEX, OperandSlot.RIGHT, REQUIRED_STRIP_ENTRY_ID))
+        assertFalse(policy.canConfirmTileOperand(TARGET_TILE_INDEX, OperandSlot.LEFT, 1))
+        assertFalse(policy.canConfirmTileOperand(1, OperandSlot.LEFT, REQUIRED_STRIP_ENTRY_ID))
+    }
+
+    @Test
+    fun single_operand_highlights_focus_the_required_number_and_exact_operand_slot() {
+        val highlightState = step.toHighlightState(
+            scenario = scenario,
+            uiState = GameUiState.from(scenario.initialPuzzle)
+        )
+
+        assertEquals(setOf(REQUIRED_STRIP_ENTRY_ID), highlightState.stripEntryIndexes)
+        assertEquals(emptySet<Int>(), highlightState.tileIndexes)
+        assertEquals(
+            setOf(
+                GameTileExpressionSlotHighlight(
+                    tileIndex = TARGET_TILE_INDEX,
+                    slot = GameTileExpressionSlot.LEFT_OPERAND
+                )
+            ),
+            highlightState.tileExpressionSlots
+        )
+        assertFalse(
+            highlightState.isTileExpressionSlotHighlighted(
+                tileIndex = TARGET_TILE_INDEX,
+                slot = GameTileExpressionSlot.OPERATOR
+            )
+        )
+        assertFalse(
+            highlightState.isTileExpressionSlotHighlighted(
+                tileIndex = TARGET_TILE_INDEX,
+                slot = GameTileExpressionSlot.RIGHT_OPERAND
+            )
+        )
+    }
+}
+
+private fun GameUiState.withOperandLabel(tileIndex: Int, slot: OperandSlot, label: String): GameUiState = copy(
+    tiles = tiles.toMutableList().apply {
+        val tile = get(tileIndex)
+        set(
+            tileIndex,
+            when (slot) {
+                OperandSlot.LEFT -> tile.copy(leftOperandLabel = label)
+                OperandSlot.RIGHT -> tile.copy(rightOperandLabel = label)
+            }
+        )
+    }
+)
+
+private const val TARGET_TILE_INDEX = 0
+private const val REQUIRED_STRIP_ENTRY_ID = 0
+private const val REQUIRED_VALUE = 1


### PR DESCRIPTION
## Summary

- add a reusable Tutorial action and completion predicate for one operand placement
- restrict interaction to the intended tile slot and strip-entry identity
- support exact operand-slot highlighting and focused unit coverage

## Testing

- ./gradlew testDebugUnitTest spotlessCheck compileDebugAndroidTestKotlin

Closes #401