### PR TITLE
[193] Author the Stage 2 complementary-pair scenario

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/StageTwoComplementaryPairContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/StageTwoComplementaryPairContent.kt
@@ -1,0 +1,97 @@
+package org.cescfe.numpairs.feature.tutorial
+
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+
+internal object StageTwoComplementaryPairContent {
+    val scenario: TutorialScenario = complementaryPairScenario()
+
+    private val additionExpression = TutorialRequiredAction.CompleteTileExpression(
+        tileIndex = ADDITION_TILE_INDEX,
+        leftStripEntryId = FIRST_STRIP_ENTRY_ID,
+        operator = Operator.ADDITION,
+        rightStripEntryId = SECOND_STRIP_ENTRY_ID
+    )
+    private val multiplicationExpression = TutorialRequiredAction.CompleteTileExpression(
+        tileIndex = MULTIPLICATION_TILE_INDEX,
+        leftStripEntryId = FIRST_STRIP_ENTRY_ID,
+        operator = Operator.MULTIPLICATION,
+        rightStripEntryId = SECOND_STRIP_ENTRY_ID
+    )
+
+    val steps: List<TutorialStep> = listOf(
+        TutorialStep(
+            order = 2,
+            scenarioId = TutorialScenarioId.COMPLEMENTARY_PAIR,
+            playerFacingCopyResId = R.string.tutorial_stage_two_complete_sum_copy,
+            highlightedTargets = listOf(
+                TutorialHighlightTarget.TileExpressionSlots(tileIndex = ADDITION_TILE_INDEX)
+            ),
+            requiredAction = additionExpression,
+            completionPredicate = additionExpression.toCompletionPredicate()
+        ),
+        TutorialStep(
+            order = 3,
+            scenarioId = TutorialScenarioId.COMPLEMENTARY_PAIR,
+            playerFacingCopyResId = R.string.tutorial_stage_two_complete_product_copy,
+            highlightedTargets = listOf(
+                TutorialHighlightTarget.TileExpressionSlots(tileIndex = MULTIPLICATION_TILE_INDEX)
+            ),
+            requiredAction = multiplicationExpression,
+            completionPredicate = TutorialStepCompletionPredicate.TileExpressionsCompleted(
+                expressions = listOf(
+                    additionExpression.toCompletionPredicate(),
+                    multiplicationExpression.toCompletionPredicate()
+                )
+            )
+        )
+    )
+
+    private fun complementaryPairScenario(): TutorialScenario {
+        val stripValues = listOf(2, 3)
+
+        return TutorialScenario(
+            id = TutorialScenarioId.COMPLEMENTARY_PAIR,
+            stripValues = stripValues,
+            initialPuzzle = puzzle(
+                stripItems = stripValues.map(StripItem::Known),
+                tiles = hiddenTiles(results = listOf(5, 6))
+            ),
+            solvedPuzzle = solvedPuzzle(
+                stripValues = stripValues,
+                tileDefinitions = listOf(
+                    TileDefinition(
+                        leftStripEntryId = FIRST_STRIP_ENTRY_ID,
+                        operator = Operator.ADDITION,
+                        rightStripEntryId = SECOND_STRIP_ENTRY_ID
+                    ),
+                    TileDefinition(
+                        leftStripEntryId = FIRST_STRIP_ENTRY_ID,
+                        operator = Operator.MULTIPLICATION,
+                        rightStripEntryId = SECOND_STRIP_ENTRY_ID
+                    )
+                )
+            ),
+            intendedPairs = listOf(
+                TutorialIntendedPair(
+                    firstStripEntryId = FIRST_STRIP_ENTRY_ID,
+                    secondStripEntryId = SECOND_STRIP_ENTRY_ID
+                )
+            )
+        )
+    }
+
+    private fun TutorialRequiredAction.CompleteTileExpression.toCompletionPredicate() =
+        TutorialStepCompletionPredicate.TileExpressionCompleted(
+            tileIndex = tileIndex,
+            leftValue = scenario.stripValues[leftStripEntryId],
+            operator = operator,
+            rightValue = scenario.stripValues[rightStripEntryId]
+        )
+
+    private const val FIRST_STRIP_ENTRY_ID = 0
+    private const val SECOND_STRIP_ENTRY_ID = 1
+    private const val ADDITION_TILE_INDEX = 0
+    private const val MULTIPLICATION_TILE_INDEX = 1
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContent.kt
@@ -3,6 +3,7 @@ package org.cescfe.numpairs.feature.tutorial
 object TutorialContent {
     val scenarios: List<TutorialScenario> = listOf(
         StageOneNumberPlacementContent.scenario,
+        StageTwoComplementaryPairContent.scenario,
         LearnBasicsTutorialContent.scenario,
         SolvingTipsPracticeContent.scenario
     )

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
@@ -44,6 +44,7 @@ data class TutorialScenario(
 
 enum class TutorialScenarioId {
     NUMBER_PLACEMENT,
+    COMPLEMENTARY_PAIR,
     TWO_PAIR_PRACTICE,
     SOLVING_TIPS_PRACTICE
 }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -25,6 +25,8 @@
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Pas %1$d de %2$d</string>
     <string name="tutorial_stage_one_place_number_copy">Col·loca el 2 en l’espai d’operand buit.</string>
+    <string name="tutorial_stage_two_complete_sum_copy">Completa la suma amb 2 i 3.</string>
+    <string name="tutorial_stage_two_complete_product_copy">Utilitza la mateixa parella per completar-ne el producte.</string>
     <string name="tutorial_step_one_copy">L’objectiu principal és descobrir tots els elements desconeguts. Endevina els valors ocults per a completar una llista ascendent d’enters positius.</string>
     <string name="tutorial_step_two_copy">Combina dos números de la sèrie per a formar una expressió matemàtica que done com a resultat el valor visible de la casella. Completa la casella ressaltada amb dos operands i un operador.</string>
     <string name="tutorial_step_three_copy">Cada parella ha de formar una suma i un producte. Usa la mateixa parella per a completar la seua casella de producte.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -25,6 +25,8 @@
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Paso %1$d de %2$d</string>
     <string name="tutorial_stage_one_place_number_copy">Coloca el 2 en el espacio de operando vacío.</string>
+    <string name="tutorial_stage_two_complete_sum_copy">Completa la suma con 2 y 3.</string>
+    <string name="tutorial_stage_two_complete_product_copy">Usa la misma pareja para completar su producto.</string>
     <string name="tutorial_step_one_copy">El objetivo principal es descubrir todos los elementos desconocidos. Adivina los valores ocultos para completar una lista ascendente de enteros positivos.</string>
     <string name="tutorial_step_two_copy">Combina dos números de la serie para formar una expresión matemática que dé como resultado el valor visible de la casilla. Completa la casilla resaltada con dos operandos y un operador.</string>
     <string name="tutorial_step_three_copy">Cada par debe formar una suma y un producto. Usa el mismo par para completar su casilla de producto.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Step %1$d of %2$d</string>
     <string name="tutorial_stage_one_place_number_copy">Place 2 in the empty operand slot.</string>
+    <string name="tutorial_stage_two_complete_sum_copy">Complete the sum with 2 and 3.</string>
+    <string name="tutorial_stage_two_complete_product_copy">Use the same pair to complete its product.</string>
     <string name="tutorial_step_one_copy">The main objective is to discover all unknown elements. Guess hidden values to complete an ascending list of positive integers.</string>
     <string name="tutorial_step_two_copy">Combine two numbers from the strip to form a mathematical expression that evaluates to the visible tile result. Fill the highlighted tile with two operands and one operator.</string>
     <string name="tutorial_step_three_copy">Each pair must form one sum and one product. Use the same pair to complete its product tile.</string>

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/StageTwoComplementaryPairContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/StageTwoComplementaryPairContentTest.kt
@@ -1,0 +1,126 @@
+package org.cescfe.numpairs.feature.tutorial
+
+import org.cescfe.numpairs.domain.puzzle.model.Board
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.OperandSlot
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.PuzzleCompletionState
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.cescfe.numpairs.feature.game.presentation.GameUiState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StageTwoComplementaryPairContentTest {
+    private val scenario = StageTwoComplementaryPairContent.scenario
+    private val steps = StageTwoComplementaryPairContent.steps
+
+    @Test
+    fun authors_one_obvious_sum_product_pair_with_hidden_expressions() {
+        assertEquals(TutorialScenarioId.COMPLEMENTARY_PAIR, scenario.id)
+        assertEquals(listOf(2, 3), scenario.stripValues)
+        assertEquals(listOf(StripItem.Known(2), StripItem.Known(3)), scenario.initialPuzzle.strip.items)
+        assertEquals(listOf(5, 6), scenario.initialPuzzle.board.tiles.map { tile -> tile.result })
+        assertTrue(
+            scenario.initialPuzzle.board.tiles.all { tile ->
+                tile.expression.leftOperand == Expression.Operand.Hidden &&
+                    tile.expression.operator == Operator.Hidden &&
+                    tile.expression.rightOperand == Expression.Operand.Hidden
+            }
+        )
+        assertEquals(PuzzleCompletionState.INCOMPLETE, scenario.initialPuzzle.completionState)
+        assertEquals(PuzzleCompletionState.SOLVED, scenario.solvedPuzzle.completionState)
+        assertEquals(
+            listOf(TutorialIntendedPair(firstStripEntryId = 0, secondStripEntryId = 1)),
+            scenario.intendedPairs
+        )
+    }
+
+    @Test
+    fun guides_the_sum_before_the_complementary_product() {
+        assertEquals(listOf(2, 3), steps.map(TutorialStep::order))
+        assertEquals(
+            listOf(
+                TutorialHighlightTarget.TileExpressionSlots(tileIndex = 0),
+                TutorialHighlightTarget.TileExpressionSlots(tileIndex = 1)
+            ),
+            steps.flatMap(TutorialStep::highlightedTargets)
+        )
+        assertEquals(
+            completeExpression(tileIndex = 0, operator = Operator.ADDITION),
+            steps[0].requiredAction
+        )
+        assertEquals(
+            completeExpression(tileIndex = 1, operator = Operator.MULTIPLICATION),
+            steps[1].requiredAction
+        )
+    }
+
+    @Test
+    fun requires_both_intended_expressions_before_stage_completion() {
+        val additionCompleted = scenario.initialPuzzle.withSolvedTiles(0)
+        val multiplicationCompleted = scenario.initialPuzzle.withSolvedTiles(1)
+
+        assertFalse(steps[1].isComplete(GameUiState.from(scenario.initialPuzzle)))
+        assertFalse(steps[1].isComplete(GameUiState.from(additionCompleted)))
+        assertFalse(steps[1].isComplete(GameUiState.from(multiplicationCompleted)))
+        assertTrue(steps[1].isComplete(GameUiState.from(scenario.solvedPuzzle)))
+    }
+
+    @Test
+    fun each_step_accepts_only_its_intended_tile_entries_and_operator() {
+        steps.forEachIndexed { index, step ->
+            val expectedOperator = if (index == 0) Operator.ADDITION else Operator.MULTIPLICATION
+            val policy = step.toInteractionPolicy(scenario = scenario, uiState = null)
+
+            assertTrue(policy.canTapTileLeftOperand(index))
+            assertTrue(policy.canTapTileRightOperand(index))
+            assertTrue(policy.canTapTileOperator(index))
+            assertFalse(policy.canTapTileLeftOperand(1 - index))
+            assertFalse(policy.canTapStripItem(0))
+            assertFalse(policy.canTapTileReset(index))
+            assertTrue(policy.canConfirmTileOperand(index, OperandSlot.LEFT, 0))
+            assertTrue(policy.canConfirmTileOperand(index, OperandSlot.RIGHT, 1))
+            assertFalse(policy.canConfirmTileOperand(index, OperandSlot.LEFT, 1))
+            assertFalse(policy.canConfirmTileOperand(index, OperandSlot.RIGHT, 0))
+            assertTrue(policy.canConfirmTileOperator(index, expectedOperator))
+            assertFalse(policy.canConfirmTileOperator(index, otherOperator(expectedOperator)))
+        }
+    }
+
+    @Test
+    fun registers_stage_two_without_activating_it() {
+        assertEquals(scenario, TutorialContent.scenario(TutorialScenarioId.COMPLEMENTARY_PAIR))
+        assertFalse(
+            TutorialContent.learnBasicsSteps.any { step ->
+                step.scenarioId == TutorialScenarioId.COMPLEMENTARY_PAIR
+            }
+        )
+    }
+
+    private fun completeExpression(tileIndex: Int, operator: Operator): TutorialRequiredAction.CompleteTileExpression =
+        TutorialRequiredAction.CompleteTileExpression(
+            tileIndex = tileIndex,
+            leftStripEntryId = 0,
+            operator = operator,
+            rightStripEntryId = 1
+        )
+
+    private fun Puzzle.withSolvedTiles(vararg tileIndexes: Int): Puzzle = copy(
+        board = Board(
+            tiles = board.tiles.toMutableList().apply {
+                tileIndexes.forEach { tileIndex ->
+                    set(tileIndex, scenario.solvedPuzzle.board.tiles[tileIndex])
+                }
+            }
+        )
+    )
+
+    private fun otherOperator(operator: Operator): Operator = when (operator) {
+        Operator.Addition -> Operator.MULTIPLICATION
+        Operator.Multiplication -> Operator.ADDITION
+        Operator.Hidden -> error("Stage 2 never uses the hidden operator.")
+    }
+}

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -20,6 +20,7 @@ class TutorialContentTest {
         assertEquals(
             listOf(
                 TutorialScenarioId.NUMBER_PLACEMENT,
+                TutorialScenarioId.COMPLEMENTARY_PAIR,
                 TutorialScenarioId.TWO_PAIR_PRACTICE,
                 TutorialScenarioId.SOLVING_TIPS_PRACTICE
             ),


### PR DESCRIPTION
## Summary

- add a dedicated one-pair Stage 2 scenario using 2 and 3
- guide the sum before the complementary product with exact interaction restrictions
- require both expressions for Stage 2 completion and localize the focused copy
- register the scenario without changing the active Learn basics sequence

## Validation

- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`

Closes #407