### PR TITLE
[194] Continue Learn basics with Stage 2 complementary pairs

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -69,7 +69,7 @@ class TutorialRouteTest {
     }
 
     @Test
-    fun stageOneAllowsOnlyTheRequiredNumberAndAdvancesIntoACleanPracticeScenario() {
+    fun stageOneAllowsOnlyTheRequiredNumberAndAdvancesIntoACleanStageTwoScenario() {
         setContent()
 
         composeTestRule
@@ -91,10 +91,10 @@ class TutorialRouteTest {
 
         waitForStep(stepIndex = 1)
         assertStepDisplayed(stepIndex = 1)
-        assertTwoPairPracticeScenarioDisplayed()
+        assertComplementaryPairScenarioDisplayed()
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.stripItem(1))
-            .assertContentDescriptionEquals(string(R.string.strip_item_hidden_content_description))
+            .assertContentDescriptionEquals(string(R.string.strip_item_known_content_description, "3"))
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.tileLeftOperand(0), useUnmergedTree = true)
             .assertContentDescriptionEquals(string(R.string.tile_left_operand_hidden_content_description))
@@ -104,21 +104,10 @@ class TutorialRouteTest {
     }
 
     @Test
-    fun guidedActionsAdvanceAutomaticallyAndPreserveTheTwoPairPracticeState() {
+    fun stageTwoGuidesTheSumBeforeTheComplementaryProductAndPreservesState() {
         setContent()
 
         completeStageOne()
-        enterStripValue(index = 1, value = "2")
-        waitForStep(stepIndex = 2)
-        assertStepDisplayed(stepIndex = 2)
-        composeTestRule
-            .onNodeWithTag(GameScreenTestTags.stripItem(1))
-            .assertContentDescriptionEquals(
-                string(
-                    R.string.strip_item_player_entered_content_description,
-                    "2"
-                )
-            )
         assertUnmergedNodeNotHighlighted(testTag = GameScreenTestTags.tile(0))
         assertHighlighted(testTag = GameScreenTestTags.tileLeftOperand(0), useUnmergedTree = true)
         assertHighlighted(testTag = GameScreenTestTags.tileOperator(0), useUnmergedTree = true)
@@ -129,9 +118,14 @@ class TutorialRouteTest {
             .performScrollTo()
             .assertHasNoClickAction()
         completeTile(tileIndex = 0, leftStripEntryId = 0, operator = Operator.ADDITION, rightStripEntryId = 1)
-        waitForStep(stepIndex = 3)
-        assertStepDisplayed(stepIndex = 3)
+        waitForStep(stepIndex = 2)
+        assertStepDisplayed(stepIndex = 2)
         assertTileExpression(tileIndex = 0, operator = Operator.ADDITION)
+        assertTileExpressionSlotsNotHighlighted(tileIndex = 0)
+        assertTileExpressionSlotsHighlighted(tileIndex = 1)
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY)
+            .assertDoesNotExist()
 
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.tileReset(0), useUnmergedTree = true)
@@ -139,24 +133,22 @@ class TutorialRouteTest {
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.tileOperator(0), useUnmergedTree = true)
             .assertHasNoClickAction()
-        completeTile(tileIndex = 1, leftStripEntryId = 0, operator = Operator.MULTIPLICATION, rightStripEntryId = 1)
-        waitForStep(stepIndex = 4)
-        assertStepDisplayed(stepIndex = 4)
-        assertTwoPairPracticeScenarioDisplayed()
-        assertTileExpression(tileIndex = 0, operator = Operator.ADDITION)
-        assertTileExpression(tileIndex = 1, operator = Operator.MULTIPLICATION)
     }
 
     @Test
-    fun finishingTheTwoPairPracticePuzzleShowsSuccessOverlayOnTheLearnBasicsCompletionStep() {
+    fun completingBothStageTwoExpressionsShowsTheLearnBasicsSuccessOverlay() {
         setContent()
 
-        completeGuidedTwoPairSteps()
-        completeTwoPairPracticeRemainder()
+        completeStageOne()
+        completeTile(tileIndex = 0, leftStripEntryId = 0, operator = Operator.ADDITION, rightStripEntryId = 1)
+        waitForStep(stepIndex = 2)
+        completeTile(tileIndex = 1, leftStripEntryId = 0, operator = Operator.MULTIPLICATION, rightStripEntryId = 1)
         composeTestRule.mainClock.advanceTimeBy(TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS)
 
-        assertStepDisplayed(stepIndex = 4)
-        assertTwoPairPracticeScenarioDisplayed()
+        assertStepDisplayed(stepIndex = 2)
+        assertComplementaryPairScenarioDisplayed()
+        assertTileExpression(tileIndex = 0, operator = Operator.ADDITION)
+        assertTileExpression(tileIndex = 1, operator = Operator.MULTIPLICATION)
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY)
             .assertIsDisplayed()
@@ -229,16 +221,6 @@ class TutorialRouteTest {
             .assertIsDisplayed()
     }
 
-    private fun completeGuidedTwoPairSteps() {
-        completeStageOne()
-        enterStripValue(index = 1, value = "2")
-        waitForStep(stepIndex = 2)
-        completeTile(tileIndex = 0, leftStripEntryId = 0, operator = Operator.ADDITION, rightStripEntryId = 1)
-        waitForStep(stepIndex = 3)
-        completeTile(tileIndex = 1, leftStripEntryId = 0, operator = Operator.MULTIPLICATION, rightStripEntryId = 1)
-        waitForStep(stepIndex = 4)
-    }
-
     private fun completeStageOne() {
         chooseTileOperand(
             tileIndex = 0,
@@ -249,11 +231,6 @@ class TutorialRouteTest {
             .onNodeWithTag(GameScreenTestTags.tileOperandOption(0), useUnmergedTree = true)
             .performClick()
         waitForStep(stepIndex = 1)
-    }
-
-    private fun completeTwoPairPracticeRemainder() {
-        completeTile(tileIndex = 2, leftStripEntryId = 2, operator = Operator.ADDITION, rightStripEntryId = 3)
-        completeTile(tileIndex = 3, leftStripEntryId = 2, operator = Operator.MULTIPLICATION, rightStripEntryId = 3)
     }
 
     private fun enterStripValue(index: Int, value: String) {
@@ -334,8 +311,8 @@ class TutorialRouteTest {
     private fun assertTileExpression(
         tileIndex: Int,
         operator: Operator,
-        leftValue: String = "1",
-        rightValue: String = "2"
+        leftValue: String = "2",
+        rightValue: String = "3"
     ) {
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.tileLeftOperand(tileIndex), useUnmergedTree = true)
@@ -396,28 +373,28 @@ class TutorialRouteTest {
             .assertDoesNotExist()
     }
 
-    private fun assertTwoPairPracticeScenarioDisplayed() {
+    private fun assertComplementaryPairScenarioDisplayed() {
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.stripItem(0))
             .performScrollTo()
             .assertContentDescriptionEquals(
                 string(
                     R.string.strip_item_known_content_description,
-                    "1"
+                    "2"
                 )
             )
         composeTestRule
-            .onNodeWithTag(GameScreenTestTags.stripItem(3))
+            .onNodeWithTag(GameScreenTestTags.stripItem(1))
             .assertContentDescriptionEquals(
                 string(
                     R.string.strip_item_known_content_description,
-                    "4"
+                    "3"
                 )
             )
-        assertTileResult(tileIndex = 2, result = 7)
-        assertTileResult(tileIndex = 3, result = 12)
+        assertTileResult(tileIndex = 0, result = 5)
+        assertTileResult(tileIndex = 1, result = 6)
         composeTestRule
-            .onNodeWithTag(GameScreenTestTags.tile(4), useUnmergedTree = true)
+            .onNodeWithTag(GameScreenTestTags.tile(2), useUnmergedTree = true)
             .assertDoesNotExist()
     }
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContent.kt
@@ -9,7 +9,7 @@ object TutorialContent {
     )
 
     val learnBasicsSteps: List<TutorialStep> = listOf(StageOneNumberPlacementContent.step) +
-        LearnBasicsTutorialContent.steps
+        StageTwoComplementaryPairContent.steps
     val solvingTipsPracticeSteps: List<TutorialStep> = SolvingTipsPracticeContent.steps
     val steps: List<TutorialStep> = learnBasicsSteps + solvingTipsPracticeSteps
 

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/StageTwoComplementaryPairContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/StageTwoComplementaryPairContentTest.kt
@@ -91,10 +91,11 @@ class StageTwoComplementaryPairContentTest {
     }
 
     @Test
-    fun registers_stage_two_without_activating_it() {
+    fun exposes_stage_two_through_the_active_learn_basics_sequence() {
         assertEquals(scenario, TutorialContent.scenario(TutorialScenarioId.COMPLEMENTARY_PAIR))
-        assertFalse(
-            TutorialContent.learnBasicsSteps.any { step ->
+        assertEquals(
+            steps,
+            TutorialContent.learnBasicsSteps.filter { step ->
                 step.scenarioId == TutorialScenarioId.COMPLEMENTARY_PAIR
             }
         )

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -37,7 +37,7 @@ class TutorialContentTest {
         assertEquals(
             setOf(
                 TutorialScenarioId.NUMBER_PLACEMENT,
-                TutorialScenarioId.TWO_PAIR_PRACTICE
+                TutorialScenarioId.COMPLEMENTARY_PAIR
             ),
             TutorialContent.stepsFor(TutorialMode.LEARN_BASICS).map(TutorialStep::scenarioId).toSet()
         )
@@ -136,10 +136,8 @@ class TutorialContentTest {
         assertEquals(
             listOf(
                 TutorialScenarioId.NUMBER_PLACEMENT,
-                TutorialScenarioId.TWO_PAIR_PRACTICE,
-                TutorialScenarioId.TWO_PAIR_PRACTICE,
-                TutorialScenarioId.TWO_PAIR_PRACTICE,
-                TutorialScenarioId.TWO_PAIR_PRACTICE
+                TutorialScenarioId.COMPLEMENTARY_PAIR,
+                TutorialScenarioId.COMPLEMENTARY_PAIR
             ),
             TutorialContent.learnBasicsSteps.map(TutorialStep::scenarioId)
         )
@@ -148,7 +146,7 @@ class TutorialContentTest {
     @Test
     fun learn_basics_guides_the_player_through_core_rules_before_normal_completion() {
         val numberPlacementScenario = TutorialContent.scenario(TutorialScenarioId.NUMBER_PLACEMENT)
-        val scenario = TutorialContent.scenario(TutorialScenarioId.TWO_PAIR_PRACTICE)
+        val scenario = TutorialContent.scenario(TutorialScenarioId.COMPLEMENTARY_PAIR)
         val steps = TutorialContent.stepsFor(TutorialMode.LEARN_BASICS)
         val numberPlacementCompletedPuzzle = numberPlacementScenario.initialPuzzle.copy(
             board = Board(
@@ -158,7 +156,7 @@ class TutorialContentTest {
             )
         )
 
-        assertEquals(listOf(1, 2, 3, 4, 5), steps.map(TutorialStep::order))
+        assertEquals(listOf(1, 2, 3), steps.map(TutorialStep::order))
 
         steps[0].assertGuidedAction(
             expectedHighlights = listOf(
@@ -176,15 +174,6 @@ class TutorialContentTest {
 
         steps[1].assertGuidedAction(
             expectedHighlights = listOf(
-                TutorialHighlightTarget.StripEntries(indexes = listOf(1))
-            ),
-            expectedAction = TutorialRequiredAction.EnterStripValue(stripEntryIndex = 1, value = 2),
-            incompletePuzzle = scenario.initialPuzzle,
-            completePuzzle = scenario.initialPuzzle.withStripValue(index = 1, value = 2)
-        )
-
-        steps[2].assertGuidedAction(
-            expectedHighlights = listOf(
                 TutorialHighlightTarget.TileExpressionSlots(tileIndex = 0)
             ),
             expectedAction = TutorialRequiredAction.CompleteTileExpression(
@@ -197,7 +186,7 @@ class TutorialContentTest {
             completePuzzle = scenario.initialPuzzle.withSolvedScenarioTiles(scenario, 0)
         )
 
-        steps[3].assertGuidedAction(
+        steps[2].assertGuidedAction(
             expectedHighlights = listOf(
                 TutorialHighlightTarget.TileExpressionSlots(tileIndex = 1)
             ),
@@ -208,17 +197,12 @@ class TutorialContentTest {
                 rightStripEntryId = 1
             ),
             incompletePuzzle = scenario.initialPuzzle,
-            completePuzzle = scenario.initialPuzzle.withSolvedScenarioTiles(scenario, 1)
-        )
-
-        steps[4].assertGuidedAction(
-            expectedHighlights = listOf(
-                TutorialHighlightTarget.TileExpressionSlots(tileIndex = 2),
-                TutorialHighlightTarget.TileExpressionSlots(tileIndex = 3)
-            ),
-            expectedAction = TutorialRequiredAction.CompleteScenario,
-            incompletePuzzle = scenario.initialPuzzle,
             completePuzzle = scenario.solvedPuzzle
+        )
+        assertFalse(
+            steps[2].isComplete(
+                GameUiState.from(scenario.initialPuzzle.withSolvedScenarioTiles(scenario, 0))
+            )
         )
     }
 
@@ -302,10 +286,6 @@ private fun Tile.hasHiddenExpression(): Boolean = expression.leftOperand == Expr
 private fun Expression.withoutEntryIds(): Expression = copy(
     leftOperand = (leftOperand as Expression.Operand.Known).copy(stripEntryId = null),
     rightOperand = (rightOperand as Expression.Operand.Known).copy(stripEntryId = null)
-)
-
-private fun Puzzle.withStripValue(index: Int, value: Int): Puzzle = copy(
-    strip = strip.withUpdatedEntry(index = index, value = value)
 )
 
 private fun Puzzle.withSolvedScenarioTiles(scenario: TutorialScenario, vararg tileIndexes: Int): Puzzle = copy(


### PR DESCRIPTION
## Summary

- continue Learn basics from Stage 1 into the dedicated Stage 2 scenario
- guide the sum before its complementary product while preserving Stage 2 state
- finish the walkthrough only after both intended expressions are complete
- replace legacy basic steps while preserving Solving Tips Practice

## Validation

- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`

Closes #408