### PR TITLE
[195] Author the Stage 3 hidden-strip-value scenario

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/StageThreeHiddenStripValueContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/StageThreeHiddenStripValueContent.kt
@@ -1,0 +1,69 @@
+package org.cescfe.numpairs.feature.tutorial
+
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+
+internal object StageThreeHiddenStripValueContent {
+    val scenario: TutorialScenario = hiddenStripValueScenario()
+
+    val step: TutorialStep = TutorialStep(
+        order = 4,
+        scenarioId = TutorialScenarioId.HIDDEN_STRIP_VALUE,
+        playerFacingCopyResId = R.string.tutorial_stage_three_hidden_strip_value_copy,
+        highlightedTargets = listOf(
+            TutorialHighlightTarget.StripEntries(indexes = listOf(HIDDEN_STRIP_ENTRY_INDEX)),
+            TutorialHighlightTarget.Tiles(indexes = listOf(CLUE_TILE_INDEX))
+        ),
+        requiredAction = TutorialRequiredAction.EnterStripValue(
+            stripEntryIndex = HIDDEN_STRIP_ENTRY_INDEX,
+            value = HIDDEN_STRIP_VALUE
+        ),
+        completionPredicate = TutorialStepCompletionPredicate.StripValueEntered(
+            stripEntryIndex = HIDDEN_STRIP_ENTRY_INDEX,
+            value = HIDDEN_STRIP_VALUE
+        )
+    )
+
+    private fun hiddenStripValueScenario(): TutorialScenario {
+        val stripValues = listOf(2, HIDDEN_STRIP_VALUE)
+        val solvedPuzzle = solvedPuzzle(
+            stripValues = stripValues,
+            tileDefinitions = listOf(
+                TileDefinition(
+                    leftStripEntryId = 0,
+                    operator = Operator.ADDITION,
+                    rightStripEntryId = HIDDEN_STRIP_ENTRY_INDEX
+                ),
+                TileDefinition(
+                    leftStripEntryId = 0,
+                    operator = Operator.MULTIPLICATION,
+                    rightStripEntryId = HIDDEN_STRIP_ENTRY_INDEX
+                )
+            )
+        )
+
+        return TutorialScenario(
+            id = TutorialScenarioId.HIDDEN_STRIP_VALUE,
+            stripValues = stripValues,
+            initialPuzzle = puzzle(
+                stripItems = listOf(
+                    StripItem.Known(stripValues[0]),
+                    StripItem.Hidden
+                ),
+                tiles = solvedPuzzle.board.tiles
+            ),
+            solvedPuzzle = solvedPuzzle,
+            intendedPairs = listOf(
+                TutorialIntendedPair(
+                    firstStripEntryId = 0,
+                    secondStripEntryId = HIDDEN_STRIP_ENTRY_INDEX
+                )
+            )
+        )
+    }
+
+    private const val HIDDEN_STRIP_ENTRY_INDEX = 1
+    private const val HIDDEN_STRIP_VALUE = 3
+    private const val CLUE_TILE_INDEX = 0
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContent.kt
@@ -4,6 +4,7 @@ object TutorialContent {
     val scenarios: List<TutorialScenario> = listOf(
         StageOneNumberPlacementContent.scenario,
         StageTwoComplementaryPairContent.scenario,
+        StageThreeHiddenStripValueContent.scenario,
         LearnBasicsTutorialContent.scenario,
         SolvingTipsPracticeContent.scenario
     )

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
@@ -45,6 +45,7 @@ data class TutorialScenario(
 enum class TutorialScenarioId {
     NUMBER_PLACEMENT,
     COMPLEMENTARY_PAIR,
+    HIDDEN_STRIP_VALUE,
     TWO_PAIR_PRACTICE,
     SOLVING_TIPS_PRACTICE
 }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -27,6 +27,7 @@
     <string name="tutorial_stage_one_place_number_copy">Col·loca el 2 en l’espai d’operand buit.</string>
     <string name="tutorial_stage_two_complete_sum_copy">Completa la suma amb 2 i 3.</string>
     <string name="tutorial_stage_two_complete_product_copy">Utilitza la mateixa parella per completar-ne el producte.</string>
+    <string name="tutorial_stage_three_hidden_strip_value_copy">L’expressió resolta revela el valor que falta a la sèrie. Introdueix 3.</string>
     <string name="tutorial_step_one_copy">L’objectiu principal és descobrir tots els elements desconeguts. Endevina els valors ocults per a completar una llista ascendent d’enters positius.</string>
     <string name="tutorial_step_two_copy">Combina dos números de la sèrie per a formar una expressió matemàtica que done com a resultat el valor visible de la casella. Completa la casella ressaltada amb dos operands i un operador.</string>
     <string name="tutorial_step_three_copy">Cada parella ha de formar una suma i un producte. Usa la mateixa parella per a completar la seua casella de producte.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -27,6 +27,7 @@
     <string name="tutorial_stage_one_place_number_copy">Coloca el 2 en el espacio de operando vacío.</string>
     <string name="tutorial_stage_two_complete_sum_copy">Completa la suma con 2 y 3.</string>
     <string name="tutorial_stage_two_complete_product_copy">Usa la misma pareja para completar su producto.</string>
+    <string name="tutorial_stage_three_hidden_strip_value_copy">La expresión resuelta revela el valor que falta en la serie. Introduce 3.</string>
     <string name="tutorial_step_one_copy">El objetivo principal es descubrir todos los elementos desconocidos. Adivina los valores ocultos para completar una lista ascendente de enteros positivos.</string>
     <string name="tutorial_step_two_copy">Combina dos números de la serie para formar una expresión matemática que dé como resultado el valor visible de la casilla. Completa la casilla resaltada con dos operandos y un operador.</string>
     <string name="tutorial_step_three_copy">Cada par debe formar una suma y un producto. Usa el mismo par para completar su casilla de producto.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="tutorial_stage_one_place_number_copy">Place 2 in the empty operand slot.</string>
     <string name="tutorial_stage_two_complete_sum_copy">Complete the sum with 2 and 3.</string>
     <string name="tutorial_stage_two_complete_product_copy">Use the same pair to complete its product.</string>
+    <string name="tutorial_stage_three_hidden_strip_value_copy">The solved expression reveals the missing strip value. Enter 3.</string>
     <string name="tutorial_step_one_copy">The main objective is to discover all unknown elements. Guess hidden values to complete an ascending list of positive integers.</string>
     <string name="tutorial_step_two_copy">Combine two numbers from the strip to form a mathematical expression that evaluates to the visible tile result. Fill the highlighted tile with two operands and one operator.</string>
     <string name="tutorial_step_three_copy">Each pair must form one sum and one product. Use the same pair to complete its product tile.</string>

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/StageThreeHiddenStripValueContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/StageThreeHiddenStripValueContentTest.kt
@@ -1,0 +1,98 @@
+package org.cescfe.numpairs.feature.tutorial
+
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.OperandSlot
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.PuzzleCompletionState
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.cescfe.numpairs.feature.game.presentation.GameUiState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StageThreeHiddenStripValueContentTest {
+    private val scenario = StageThreeHiddenStripValueContent.scenario
+    private val step = StageThreeHiddenStripValueContent.step
+
+    @Test
+    fun authors_one_hidden_strip_value_revealed_by_a_resolved_expression() {
+        val clueTile = scenario.initialPuzzle.board.tiles[0]
+
+        assertEquals(TutorialScenarioId.HIDDEN_STRIP_VALUE, scenario.id)
+        assertEquals(listOf(2, 3), scenario.stripValues)
+        assertEquals(listOf(StripItem.Known(2), StripItem.Hidden), scenario.initialPuzzle.strip.items)
+        assertEquals(1, scenario.initialPuzzle.strip.items.count { item -> item == StripItem.Hidden })
+        assertEquals(Expression.Operand.Known(value = 2, stripEntryId = 0), clueTile.expression.leftOperand)
+        assertEquals(Operator.ADDITION, clueTile.expression.operator)
+        assertEquals(Expression.Operand.Known(value = 3, stripEntryId = 1), clueTile.expression.rightOperand)
+        assertEquals(5, clueTile.result)
+        assertEquals(PuzzleCompletionState.INCOMPLETE, scenario.initialPuzzle.completionState)
+        assertEquals(PuzzleCompletionState.SOLVED, scenario.solvedPuzzle.completionState)
+        assertEquals(
+            listOf(TutorialIntendedPair(firstStripEntryId = 0, secondStripEntryId = 1)),
+            scenario.intendedPairs
+        )
+    }
+
+    @Test
+    fun focuses_the_hidden_entry_and_relevant_clue() {
+        assertEquals(4, step.order)
+        assertEquals(TutorialScenarioId.HIDDEN_STRIP_VALUE, step.scenarioId)
+        assertEquals(
+            listOf(
+                TutorialHighlightTarget.StripEntries(indexes = listOf(1)),
+                TutorialHighlightTarget.Tiles(indexes = listOf(0))
+            ),
+            step.highlightedTargets
+        )
+
+        val highlightState = step.toHighlightState(scenario = scenario, uiState = null)
+
+        assertEquals(setOf(1), highlightState.stripEntryIndexes)
+        assertEquals(setOf(0), highlightState.tileIndexes)
+        assertTrue(highlightState.tileExpressionSlots.isEmpty())
+    }
+
+    @Test
+    fun allows_only_the_correct_hidden_strip_entry_value() {
+        val policy = step.toInteractionPolicy(scenario = scenario, uiState = null)
+
+        assertTrue(policy.canTapStripItem(1))
+        assertFalse(policy.canTapStripItem(0))
+        assertTrue(policy.canConfirmStripItemEntry(1, 3))
+        assertFalse(policy.canConfirmStripItemEntry(1, 4))
+        assertFalse(policy.canConfirmStripItemEntry(0, 2))
+        assertFalse(policy.canTapTileLeftOperand(0))
+        assertFalse(policy.canTapTileRightOperand(0))
+        assertFalse(policy.canTapTileOperator(0))
+        assertFalse(policy.canTapTileReset(0))
+        assertFalse(policy.canConfirmTileOperand(0, OperandSlot.LEFT, 0))
+        assertFalse(policy.canConfirmTileOperator(0, Operator.ADDITION))
+    }
+
+    @Test
+    fun completes_only_after_three_is_player_entered() {
+        val incorrectPuzzle = scenario.initialPuzzle.copy(
+            strip = scenario.initialPuzzle.strip.withUpdatedEntry(index = 1, value = 4)
+        )
+        val completedPuzzle = scenario.initialPuzzle.copy(
+            strip = scenario.initialPuzzle.strip.withUpdatedEntry(index = 1, value = 3)
+        )
+
+        assertFalse(step.isComplete(GameUiState.from(scenario.initialPuzzle)))
+        assertFalse(step.isComplete(GameUiState.from(incorrectPuzzle)))
+        assertTrue(step.isComplete(GameUiState.from(completedPuzzle)))
+        assertEquals(PuzzleCompletionState.SOLVED, completedPuzzle.completionState)
+    }
+
+    @Test
+    fun registers_stage_three_without_activating_it() {
+        assertEquals(scenario, TutorialContent.scenario(TutorialScenarioId.HIDDEN_STRIP_VALUE))
+        assertFalse(
+            TutorialContent.learnBasicsSteps.any { activeStep ->
+                activeStep.scenarioId == TutorialScenarioId.HIDDEN_STRIP_VALUE
+            }
+        )
+    }
+}

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -21,6 +21,7 @@ class TutorialContentTest {
             listOf(
                 TutorialScenarioId.NUMBER_PLACEMENT,
                 TutorialScenarioId.COMPLEMENTARY_PAIR,
+                TutorialScenarioId.HIDDEN_STRIP_VALUE,
                 TutorialScenarioId.TWO_PAIR_PRACTICE,
                 TutorialScenarioId.SOLVING_TIPS_PRACTICE
             ),


### PR DESCRIPTION
## Summary

- add a dedicated Stage 3 scenario with one hidden strip value
- use resolved sum and product expressions to reveal the missing value
- restrict the lesson to entering 3 in the intended strip entry
- localize and test the focused clue without activating the scenario yet

## Validation

- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`

Closes #411