### PR TITLE
[196] Continue Learn basics with Stage 3 strip deduction

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -136,19 +136,42 @@ class TutorialRouteTest {
     }
 
     @Test
-    fun completingBothStageTwoExpressionsShowsTheLearnBasicsSuccessOverlay() {
+    fun completingBothStageTwoExpressionsAdvancesIntoACleanStageThreeScenario() {
         setContent()
 
         completeStageOne()
         completeTile(tileIndex = 0, leftStripEntryId = 0, operator = Operator.ADDITION, rightStripEntryId = 1)
         waitForStep(stepIndex = 2)
         completeTile(tileIndex = 1, leftStripEntryId = 0, operator = Operator.MULTIPLICATION, rightStripEntryId = 1)
-        composeTestRule.mainClock.advanceTimeBy(TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS)
+        waitForStep(stepIndex = 3)
 
-        assertStepDisplayed(stepIndex = 2)
-        assertComplementaryPairScenarioDisplayed()
+        assertStepDisplayed(stepIndex = 3)
+        assertHiddenStripValueScenarioDisplayed()
         assertTileExpression(tileIndex = 0, operator = Operator.ADDITION)
         assertTileExpression(tileIndex = 1, operator = Operator.MULTIPLICATION)
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun stageThreeAllowsOnlyTheHiddenValueAndCompletesLearnBasics() {
+        setContent()
+
+        completeStageTwo()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.stripItem(0))
+            .assertHasNoClickAction()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileLeftOperand(0), useUnmergedTree = true)
+            .performScrollTo()
+            .assertHasNoClickAction()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileOperator(0), useUnmergedTree = true)
+            .assertHasNoClickAction()
+
+        enterStripValue(index = 1, value = "3")
+
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY)
             .assertIsDisplayed()
@@ -231,6 +254,14 @@ class TutorialRouteTest {
             .onNodeWithTag(GameScreenTestTags.tileOperandOption(0), useUnmergedTree = true)
             .performClick()
         waitForStep(stepIndex = 1)
+    }
+
+    private fun completeStageTwo() {
+        completeStageOne()
+        completeTile(tileIndex = 0, leftStripEntryId = 0, operator = Operator.ADDITION, rightStripEntryId = 1)
+        waitForStep(stepIndex = 2)
+        completeTile(tileIndex = 1, leftStripEntryId = 0, operator = Operator.MULTIPLICATION, rightStripEntryId = 1)
+        waitForStep(stepIndex = 3)
     }
 
     private fun enterStripValue(index: Int, value: String) {
@@ -427,6 +458,23 @@ class TutorialRouteTest {
             leftValue = "2",
             rightValue = "3"
         )
+        assertTileResult(tileIndex = 1, result = 6)
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tile(2), useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    private fun assertHiddenStripValueScenarioDisplayed() {
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.stripItem(0))
+            .performScrollTo()
+            .assertContentDescriptionEquals(string(R.string.strip_item_known_content_description, "2"))
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.stripItem(1))
+            .assertContentDescriptionEquals(string(R.string.strip_item_hidden_content_description))
+        assertTileExpression(tileIndex = 0, operator = Operator.ADDITION)
+        assertTileResult(tileIndex = 0, result = 5)
+        assertTileExpression(tileIndex = 1, operator = Operator.MULTIPLICATION)
         assertTileResult(tileIndex = 1, result = 6)
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.tile(2), useUnmergedTree = true)

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContent.kt
@@ -10,7 +10,8 @@ object TutorialContent {
     )
 
     val learnBasicsSteps: List<TutorialStep> = listOf(StageOneNumberPlacementContent.step) +
-        StageTwoComplementaryPairContent.steps
+        StageTwoComplementaryPairContent.steps +
+        StageThreeHiddenStripValueContent.step
     val solvingTipsPracticeSteps: List<TutorialStep> = SolvingTipsPracticeContent.steps
     val steps: List<TutorialStep> = learnBasicsSteps + solvingTipsPracticeSteps
 

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/StageThreeHiddenStripValueContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/StageThreeHiddenStripValueContentTest.kt
@@ -87,12 +87,8 @@ class StageThreeHiddenStripValueContentTest {
     }
 
     @Test
-    fun registers_stage_three_without_activating_it() {
+    fun exposes_stage_three_as_the_final_active_learn_basics_step() {
         assertEquals(scenario, TutorialContent.scenario(TutorialScenarioId.HIDDEN_STRIP_VALUE))
-        assertFalse(
-            TutorialContent.learnBasicsSteps.any { activeStep ->
-                activeStep.scenarioId == TutorialScenarioId.HIDDEN_STRIP_VALUE
-            }
-        )
+        assertEquals(step, TutorialContent.learnBasicsSteps.last())
     }
 }

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -38,7 +38,8 @@ class TutorialContentTest {
         assertEquals(
             setOf(
                 TutorialScenarioId.NUMBER_PLACEMENT,
-                TutorialScenarioId.COMPLEMENTARY_PAIR
+                TutorialScenarioId.COMPLEMENTARY_PAIR,
+                TutorialScenarioId.HIDDEN_STRIP_VALUE
             ),
             TutorialContent.stepsFor(TutorialMode.LEARN_BASICS).map(TutorialStep::scenarioId).toSet()
         )
@@ -138,7 +139,8 @@ class TutorialContentTest {
             listOf(
                 TutorialScenarioId.NUMBER_PLACEMENT,
                 TutorialScenarioId.COMPLEMENTARY_PAIR,
-                TutorialScenarioId.COMPLEMENTARY_PAIR
+                TutorialScenarioId.COMPLEMENTARY_PAIR,
+                TutorialScenarioId.HIDDEN_STRIP_VALUE
             ),
             TutorialContent.learnBasicsSteps.map(TutorialStep::scenarioId)
         )
@@ -148,6 +150,7 @@ class TutorialContentTest {
     fun learn_basics_guides_the_player_through_core_rules_before_normal_completion() {
         val numberPlacementScenario = TutorialContent.scenario(TutorialScenarioId.NUMBER_PLACEMENT)
         val scenario = TutorialContent.scenario(TutorialScenarioId.COMPLEMENTARY_PAIR)
+        val hiddenStripScenario = TutorialContent.scenario(TutorialScenarioId.HIDDEN_STRIP_VALUE)
         val steps = TutorialContent.stepsFor(TutorialMode.LEARN_BASICS)
         val numberPlacementCompletedPuzzle = numberPlacementScenario.initialPuzzle.copy(
             board = Board(
@@ -157,7 +160,7 @@ class TutorialContentTest {
             )
         )
 
-        assertEquals(listOf(1, 2, 3), steps.map(TutorialStep::order))
+        assertEquals(listOf(1, 2, 3, 4), steps.map(TutorialStep::order))
 
         steps[0].assertGuidedAction(
             expectedHighlights = listOf(
@@ -204,6 +207,16 @@ class TutorialContentTest {
             steps[2].isComplete(
                 GameUiState.from(scenario.initialPuzzle.withSolvedScenarioTiles(scenario, 0))
             )
+        )
+
+        steps[3].assertGuidedAction(
+            expectedHighlights = listOf(
+                TutorialHighlightTarget.StripEntries(indexes = listOf(1)),
+                TutorialHighlightTarget.Tiles(indexes = listOf(0))
+            ),
+            expectedAction = TutorialRequiredAction.EnterStripValue(stripEntryIndex = 1, value = 3),
+            incompletePuzzle = hiddenStripScenario.initialPuzzle,
+            completePuzzle = hiddenStripScenario.initialPuzzle.withStripValue(index = 1, value = 3)
         )
     }
 
@@ -287,6 +300,10 @@ private fun Tile.hasHiddenExpression(): Boolean = expression.leftOperand == Expr
 private fun Expression.withoutEntryIds(): Expression = copy(
     leftOperand = (leftOperand as Expression.Operand.Known).copy(stripEntryId = null),
     rightOperand = (rightOperand as Expression.Operand.Known).copy(stripEntryId = null)
+)
+
+private fun Puzzle.withStripValue(index: Int, value: Int): Puzzle = copy(
+    strip = strip.withUpdatedEntry(index = index, value = value)
 )
 
 private fun Puzzle.withSolvedScenarioTiles(scenario: TutorialScenario, vararg tileIndexes: Int): Puzzle = copy(


### PR DESCRIPTION
## Summary

- append Stage 3 after the completed complementary pair
- reset into the hidden-strip-value scenario without Stage 2 state leakage
- keep the final guided action restricted to entering the inferred 3
- complete the current Learn basics walkthrough only after that entry

## Validation

- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`

Closes #413