### PR TITLE
[198] Add the unguided Stage 4 validation route

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/FinalValidationRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/FinalValidationRouteTest.kt
@@ -1,0 +1,88 @@
+package org.cescfe.numpairs.feature.tutorial
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.feature.game.ui.screen.GameScreenRobot
+import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
+import org.cescfe.numpairs.feature.tutorial.ui.TutorialScreenTestTags
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FinalValidationRouteTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun shows_the_authored_puzzle_without_tutorial_guidance_or_highlights() {
+        setRoute()
+
+        val screen = GameScreenRobot(
+            activity = composeTestRule.activity,
+            interactions = composeTestRule
+        )
+        screen
+            .assertTitleDisplayed(composeTestRule.activity.getString(R.string.final_validation_screen_title))
+            .assertStripDisplayed()
+            .assertBoardDisplayed()
+            .assertStripItemDescription(
+                index = 1,
+                stringResId = R.string.strip_item_hidden_content_description
+            )
+            .assertStripItemNotHighlighted(index = 1)
+            .assertLeftOperandNotHighlighted(tileIndex = 0)
+            .assertOperatorNotHighlighted(tileIndex = 0)
+            .assertRightOperandNotHighlighted(tileIndex = 0)
+
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.INSTRUCTION_SURFACE)
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.STEP_INDICATOR)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun permits_standard_interactions_and_opens_the_static_rules_helper() {
+        setRoute()
+
+        val screen = GameScreenRobot(
+            activity = composeTestRule.activity,
+            interactions = composeTestRule
+        )
+        screen
+            .tapStripItem(index = 1)
+            .assertStripEntryInputDisplayed()
+            .replaceStripValue("3")
+            .submitStripEntryInput()
+            .tapTileLeftOperand(index = 0)
+            .assertOperandSelectorDisplayed()
+
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            activity.onBackPressedDispatcher.onBackPressed()
+        }
+
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.RULES_HELPER_ACTION)
+            .assertIsDisplayed()
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.RULES_HELPER_DIALOG)
+            .assertIsDisplayed()
+    }
+
+    private fun setRoute() {
+        composeTestRule.setContent {
+            NumPairsTheme {
+                FinalValidationRoute()
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/FinalValidationRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/FinalValidationRoute.kt
@@ -1,0 +1,68 @@
+package org.cescfe.numpairs.feature.tutorial
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.feature.game.GameCompletionActions
+import org.cescfe.numpairs.feature.game.GameHighlightState
+import org.cescfe.numpairs.feature.game.GameInteractionPolicy
+import org.cescfe.numpairs.feature.game.GameRoute
+import org.cescfe.numpairs.feature.game.presentation.PuzzleOutcomeUiState
+
+@Composable
+fun FinalValidationRoute(
+    modifier: Modifier = Modifier,
+    onValidationSolved: () -> Unit = {},
+    onNavigateBack: () -> Unit = {},
+    onReturnToMenuRequested: () -> Unit = onNavigateBack
+) {
+    val scenario = FinalValidationContent.scenario
+    var validationSession by rememberSaveable { mutableIntStateOf(0) }
+    val solvedReporter = remember(validationSession) { FinalValidationSolvedReporter() }
+    val currentOnValidationSolved by rememberUpdatedState(onValidationSolved)
+
+    GameRoute(
+        title = stringResource(R.string.final_validation_screen_title),
+        initialPuzzle = scenario.initialPuzzle,
+        modifier = modifier,
+        gameSessionKey = FINAL_VALIDATION_GAME_SESSION_KEY,
+        puzzleResetKey = validationSession,
+        completionActions = GameCompletionActions(
+            onNewPuzzleRequested = {
+                validationSession += 1
+            },
+            onReturnToMenuRequested = onReturnToMenuRequested
+        ),
+        isRulesHelperEnabled = true,
+        interactionPolicy = GameInteractionPolicy.AllowAll,
+        highlightState = GameHighlightState.None,
+        onGameUiStateChanged = { uiState ->
+            if (solvedReporter.shouldReport(uiState.puzzleOutcome)) {
+                currentOnValidationSolved()
+            }
+        },
+        onNavigateBack = onNavigateBack
+    )
+}
+
+internal class FinalValidationSolvedReporter {
+    private var hasReportedSolved = false
+
+    fun shouldReport(puzzleOutcome: PuzzleOutcomeUiState?): Boolean {
+        if (puzzleOutcome != PuzzleOutcomeUiState.Solved || hasReportedSolved) {
+            return false
+        }
+
+        hasReportedSolved = true
+        return true
+    }
+}
+
+private const val FINAL_VALIDATION_GAME_SESSION_KEY = "FinalValidationRoute"

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -36,6 +36,7 @@
     <string name="tutorial_solving_tips_step_two_copy">Les caselles de producte només poden usar factors del seu resultat. Troba dos valors de la sèrie que multipliquen fins a obtindre el producte i després usa la mateixa parella per a completar la suma corresponent.</string>
     <string name="tutorial_previous_step_button">Arrere</string>
     <string name="tutorial_next_step_button">Següent</string>
+    <string name="final_validation_screen_title">Comprovació final</string>
 
     <!-- Game screen: board and strip -->
     <string name="board_content_description">Tauler</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -36,6 +36,7 @@
     <string name="tutorial_solving_tips_step_two_copy">Las casillas de producto solo pueden usar factores de su resultado. Encuentra dos valores de la serie que multipliquen hasta obtener el producto y luego usa el mismo par para completar su suma correspondiente.</string>
     <string name="tutorial_previous_step_button">Atrás</string>
     <string name="tutorial_next_step_button">Siguiente</string>
+    <string name="final_validation_screen_title">Comprobación final</string>
 
     <!-- Game screen: board and strip -->
     <string name="board_content_description">Tablero</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="tutorial_solving_tips_step_two_copy">Product tiles can only use factors of their result. Find two strip values that multiply to the product, then use the same pair to complete its matching sum.</string>
     <string name="tutorial_previous_step_button">Back</string>
     <string name="tutorial_next_step_button">Next</string>
+    <string name="final_validation_screen_title">Final check</string>
 
     <!-- Game screen: board and strip -->
     <string name="board_content_description">Board</string>

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/FinalValidationSolvedReporterTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/FinalValidationSolvedReporterTest.kt
@@ -1,0 +1,38 @@
+package org.cescfe.numpairs.feature.tutorial
+
+import org.cescfe.numpairs.domain.puzzle.model.PuzzleCompletionState
+import org.cescfe.numpairs.feature.game.presentation.PuzzleOutcomeUiState
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FinalValidationSolvedReporterTest {
+    @Test
+    fun `incomplete and invalid states are not reported`() {
+        val reporter = FinalValidationSolvedReporter()
+
+        assertFalse(reporter.shouldReport(puzzleOutcome = null))
+        assertFalse(
+            reporter.shouldReport(
+                puzzleOutcome = PuzzleOutcomeUiState.Invalid(PuzzleCompletionState.INCORRECT_TILES)
+            )
+        )
+    }
+
+    @Test
+    fun `solved state is reported exactly once`() {
+        val reporter = FinalValidationSolvedReporter()
+
+        assertTrue(reporter.shouldReport(PuzzleOutcomeUiState.Solved))
+        assertFalse(reporter.shouldReport(PuzzleOutcomeUiState.Solved))
+    }
+
+    @Test
+    fun `a new validation session can report solved again`() {
+        val firstSession = FinalValidationSolvedReporter()
+        val secondSession = FinalValidationSolvedReporter()
+
+        assertTrue(firstSession.shouldReport(PuzzleOutcomeUiState.Solved))
+        assertTrue(secondSession.shouldReport(PuzzleOutcomeUiState.Solved))
+    }
+}


### PR DESCRIPTION
## Summary

- add a dedicated final-validation route backed by the authored Stage 4 puzzle
- retain unrestricted game interactions, ordinary completion feedback, replay, navigation, and static rules help without tutorial guidance
- report solved validation sessions exactly once and cover reporting and presentation behavior

## Verification

- `./gradlew spotlessApply testDebugUnitTest spotlessCheck compileDebugAndroidTestKotlin`
- Instrumented tests were compiled only; no emulator was started.

Closes #417