### PR TITLE
[199] Continue the guided introduction into final validation

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
@@ -38,6 +38,24 @@ class AppNavigationLearningFlowTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
+    fun menuTutorialLaunchesTheCombinedIntroductionAndBackReturnsToMenu() {
+        setContent(puzzleProvider = QueueGeneratedPuzzleProvider(samplePuzzle))
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.TUTORIAL_BUTTON)
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.INSTRUCTION_SURFACE)
+            .assertIsDisplayed()
+
+        pressBackUnconditionally()
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+    }
+
+    @Test
     fun inGameLearningActionsOpenTutorialOverlaysAndReturnToCurrentFourPairsScreen() {
         val puzzleProvider = QueueGeneratedPuzzleProvider(samplePuzzle)
         setContent(puzzleProvider = puzzleProvider)

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -17,12 +17,14 @@ import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.concurrent.atomic.AtomicInteger
 import org.cescfe.numpairs.R
 import org.cescfe.numpairs.domain.puzzle.model.Operator
 import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
 import org.cescfe.numpairs.feature.game.ui.semantics.GameHighlightedKey
 import org.cescfe.numpairs.feature.tutorial.ui.TutorialScreenTestTags
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -178,6 +180,54 @@ class TutorialRouteTest {
     }
 
     @Test
+    fun stageThreeReportsGuidedCompletionExactlyOnceWithoutShowingSuccess() {
+        val completionCount = AtomicInteger(0)
+        setContent(onTutorialCompleted = { completionCount.incrementAndGet() })
+
+        completeStageTwo()
+        enterStripValue(index = 1, value = "3")
+
+        composeTestRule.waitUntil(timeoutMillis = TUTORIAL_STEP_WAIT_TIMEOUT_MS) {
+            completionCount.get() == 1
+        }
+        composeTestRule.mainClock.advanceTimeBy(TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS)
+
+        assertEquals(1, completionCount.get())
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun guidedIntroductionTransitionsFromStageThreeIntoCleanFinalValidation() {
+        val completionCount = AtomicInteger(0)
+        setGuidedIntroductionContent(onIntroductionCompleted = { completionCount.incrementAndGet() })
+
+        completeStageTwo()
+        enterStripValue(index = 1, value = "3")
+
+        composeTestRule.waitUntil(timeoutMillis = TUTORIAL_STEP_WAIT_TIMEOUT_MS) {
+            composeTestRule
+                .onAllNodes(hasText(string(R.string.final_validation_screen_title)))
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+
+        assertEquals(0, completionCount.get())
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.INSTRUCTION_SURFACE)
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.STEP_INDICATOR)
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.stripItem(1))
+            .assertContentDescriptionEquals(string(R.string.strip_item_hidden_content_description))
+        assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(1))
+        assertTileExpressionSlotsNotHighlighted(tileIndex = 0)
+    }
+
+    @Test
     fun solvingTipsPracticeHighlightsExpectedActionsAndCompletesWithSuccessOverlay() {
         setSolvingTipsPracticeTutorialContent()
 
@@ -220,10 +270,22 @@ class TutorialRouteTest {
             .assertIsDisplayed()
     }
 
-    private fun setContent() {
+    private fun setContent(onTutorialCompleted: (() -> Unit)? = null) {
         composeTestRule.setContent {
             NumPairsTheme {
-                TutorialRoute()
+                TutorialRoute(onTutorialCompleted = onTutorialCompleted)
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+    }
+
+    private fun setGuidedIntroductionContent(onIntroductionCompleted: () -> Unit) {
+        composeTestRule.setContent {
+            NumPairsTheme {
+                GuidedIntroductionRoute(onIntroductionCompleted = onIntroductionCompleted)
             }
         }
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/GuidedIntroductionRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/GuidedIntroductionRoute.kt
@@ -1,0 +1,41 @@
+package org.cescfe.numpairs.feature.tutorial
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+@Composable
+fun GuidedIntroductionRoute(
+    modifier: Modifier = Modifier,
+    onIntroductionCompleted: () -> Unit = {},
+    onNavigateBack: () -> Unit = {}
+) {
+    var phase by rememberSaveable { mutableStateOf(GuidedIntroductionPhase.GUIDED_STAGES) }
+    val currentOnIntroductionCompleted by rememberUpdatedState(onIntroductionCompleted)
+
+    when (phase) {
+        GuidedIntroductionPhase.GUIDED_STAGES -> TutorialRoute(
+            modifier = modifier,
+            mode = TutorialMode.LEARN_BASICS,
+            onTutorialCompleted = {
+                phase = GuidedIntroductionPhase.FINAL_VALIDATION
+            },
+            onNavigateBack = onNavigateBack
+        )
+        GuidedIntroductionPhase.FINAL_VALIDATION -> FinalValidationRoute(
+            modifier = modifier,
+            onValidationSolved = currentOnIntroductionCompleted,
+            onNavigateBack = onNavigateBack,
+            onReturnToMenuRequested = onNavigateBack
+        )
+    }
+}
+
+private enum class GuidedIntroductionPhase {
+    GUIDED_STAGES,
+    FINAL_VALIDATION
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -38,20 +39,31 @@ import org.cescfe.numpairs.ui.theme.NumPairsComponents
 fun TutorialRoute(
     modifier: Modifier = Modifier,
     mode: TutorialMode = TutorialMode.LEARN_BASICS,
+    onTutorialCompleted: (() -> Unit)? = null,
     onNavigateBack: () -> Unit = {}
 ) {
     val steps = TutorialContent.stepsFor(mode)
     var currentStepIndex by rememberSaveable(mode) { mutableIntStateOf(0) }
+    var hasReportedCompletion by rememberSaveable(mode) { mutableStateOf(false) }
     var latestGameUiState by remember(mode) { mutableStateOf<GameUiState?>(null) }
+    val currentOnTutorialCompleted by rememberUpdatedState(onTutorialCompleted)
     val currentStep = steps[currentStepIndex]
     val currentScenario = TutorialContent.scenario(currentStep.scenarioId)
 
     LaunchedEffect(currentStepIndex, latestGameUiState) {
         val uiState = latestGameUiState ?: return@LaunchedEffect
 
-        if (currentStepIndex < steps.lastIndex && currentStep.isComplete(uiState)) {
+        if (!currentStep.isComplete(uiState)) {
+            return@LaunchedEffect
+        }
+
+        if (currentStepIndex < steps.lastIndex) {
             delay(TUTORIAL_STEP_ADVANCE_DELAY)
-            currentStepIndex = (currentStepIndex + 1).coerceAtMost(steps.lastIndex)
+            currentStepIndex += 1
+        } else if (!hasReportedCompletion && currentOnTutorialCompleted != null) {
+            delay(TUTORIAL_STEP_ADVANCE_DELAY)
+            hasReportedCompletion = true
+            currentOnTutorialCompleted?.invoke()
         }
     }
 
@@ -61,7 +73,7 @@ fun TutorialRoute(
         modifier = modifier,
         gameSessionKey = "$TUTORIAL_GAME_SESSION_KEY:$mode:${currentScenario.id}",
         puzzleResetKey = mode to currentScenario.id,
-        isSuccessOverlayEnabled = currentStepIndex == steps.lastIndex,
+        isSuccessOverlayEnabled = currentStepIndex == steps.lastIndex && onTutorialCompleted == null,
         interactionPolicy = currentStep.toInteractionPolicy(
             scenario = currentScenario,
             uiState = latestGameUiState

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -16,7 +16,7 @@ import org.cescfe.numpairs.feature.generated.GeneratedModeRoute
 import org.cescfe.numpairs.feature.generated.GeneratedModes
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
 import org.cescfe.numpairs.feature.menu.MenuRoute
-import org.cescfe.numpairs.feature.tutorial.TutorialRoute
+import org.cescfe.numpairs.feature.tutorial.GuidedIntroductionRoute
 
 sealed interface AppDestination {
     data object Menu : AppDestination
@@ -56,7 +56,7 @@ fun AppNavigation(
                 currentDestination = AppDestination.GeneratedMode(modeId = GeneratedModes.EIGHT_PAIRS.id)
             }
         )
-        AppDestination.Tutorial -> TutorialRoute(
+        AppDestination.Tutorial -> GuidedIntroductionRoute(
             modifier = modifier,
             onNavigateBack = navigateToMenu
         )


### PR DESCRIPTION
## Summary

- report completion once after the final guided Stage 3 action and suppress intermediate success feedback
- add a coordinator that transitions from guided stages into a clean unguided validation session
- launch the combined experience from the Tutorial menu destination while preserving separate in-game learning overlays

## Verification

- `./gradlew spotlessApply testDebugUnitTest spotlessCheck compileDebugAndroidTestKotlin`
- Instrumented tests were compiled only; no emulator was started.

Closes #418