### PR TITLE
[200] Persist versioned onboarding state

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
         applicationId = "org.cescfe.numpairs"
         minSdk = 26
         targetSdk = 37
-        versionCode = 1
+        versionCode = 2
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,14 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.NumPairs">
+        <receiver
+            android:name=".data.onboarding.PreV6UpgradeReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepository.kt
@@ -1,0 +1,71 @@
+package org.cescfe.numpairs.data.onboarding
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.intPreferencesKey
+import java.io.IOException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+class DataStoreOnboardingRepository(private val dataStore: DataStore<Preferences>) : OnboardingRepository {
+    override val onboardingState: Flow<OnboardingState> = dataStore.data
+        .catch { throwable ->
+            if (throwable is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw throwable
+            }
+        }
+        .map { preferences ->
+            OnboardingState(
+                isInitialized = preferences[PreferenceKeys.IS_INITIALIZED] ?: false,
+                completedVersion = preferences[PreferenceKeys.COMPLETED_VERSION] ?: 0,
+                lastCompletedStage = OnboardingStageCheckpoint.fromPersistedValue(
+                    preferences[PreferenceKeys.LAST_COMPLETED_STAGE] ?: 0
+                )
+            )
+        }
+
+    override suspend fun initialize(installationKind: OnboardingInstallationKind) {
+        dataStore.edit { preferences ->
+            if (preferences[PreferenceKeys.IS_INITIALIZED] == true) {
+                return@edit
+            }
+
+            preferences[PreferenceKeys.IS_INITIALIZED] = true
+            preferences[PreferenceKeys.COMPLETED_VERSION] = when (installationKind) {
+                OnboardingInstallationKind.FRESH_INSTALL -> 0
+                OnboardingInstallationKind.PRE_V6_UPGRADE -> REQUIRED_ONBOARDING_VERSION
+            }
+            preferences[PreferenceKeys.LAST_COMPLETED_STAGE] = OnboardingStageCheckpoint.NONE.persistedValue
+        }
+    }
+
+    override suspend fun recordStageCompleted(stage: OnboardingStageCheckpoint) {
+        require(stage != OnboardingStageCheckpoint.NONE) {
+            "A completed onboarding stage cannot be NONE."
+        }
+
+        dataStore.edit { preferences ->
+            val currentValue = preferences[PreferenceKeys.LAST_COMPLETED_STAGE] ?: 0
+            preferences[PreferenceKeys.LAST_COMPLETED_STAGE] = maxOf(currentValue, stage.persistedValue)
+        }
+    }
+
+    override suspend fun markRequiredVersionCompleted() {
+        dataStore.edit { preferences ->
+            val currentVersion = preferences[PreferenceKeys.COMPLETED_VERSION] ?: 0
+            preferences[PreferenceKeys.COMPLETED_VERSION] = maxOf(currentVersion, REQUIRED_ONBOARDING_VERSION)
+        }
+    }
+
+    private object PreferenceKeys {
+        val IS_INITIALIZED = booleanPreferencesKey("onboarding_is_initialized")
+        val COMPLETED_VERSION = intPreferencesKey("onboarding_completed_version")
+        val LAST_COMPLETED_STAGE = intPreferencesKey("onboarding_last_completed_stage")
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/FilePreV6UpgradeMarker.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/FilePreV6UpgradeMarker.kt
@@ -1,0 +1,25 @@
+package org.cescfe.numpairs.data.onboarding
+
+import java.io.File
+import java.io.IOException
+
+class FilePreV6UpgradeMarker(private val markerFile: File) : PreV6UpgradeMarker {
+    override fun isMarked(): Boolean = markerFile.isFile
+
+    override fun mark() {
+        runCatching {
+            markerFile.parentFile?.mkdirs()
+            markerFile.createNewFile()
+        }.onFailure { throwable ->
+            if (throwable !is IOException) {
+                throw throwable
+            }
+        }
+    }
+
+    override fun clear() {
+        if (markerFile.exists() && !markerFile.delete()) {
+            throw IOException("Could not clear the pre-v6 upgrade marker.")
+        }
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingInitialization.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingInitialization.kt
@@ -1,0 +1,29 @@
+package org.cescfe.numpairs.data.onboarding
+
+class OnboardingInitializer(
+    private val repository: OnboardingRepository,
+    private val preV6UpgradeMarker: PreV6UpgradeMarker
+) {
+    suspend fun initialize() {
+        val isPreV6Upgrade = preV6UpgradeMarker.isMarked()
+        repository.initialize(
+            installationKind = if (isPreV6Upgrade) {
+                OnboardingInstallationKind.PRE_V6_UPGRADE
+            } else {
+                OnboardingInstallationKind.FRESH_INSTALL
+            }
+        )
+
+        if (isPreV6Upgrade) {
+            preV6UpgradeMarker.clear()
+        }
+    }
+}
+
+interface PreV6UpgradeMarker {
+    fun isMarked(): Boolean
+
+    fun mark()
+
+    fun clear()
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingPreferencesDataStore.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingPreferencesDataStore.kt
@@ -1,0 +1,14 @@
+package org.cescfe.numpairs.data.onboarding
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+internal const val ONBOARDING_PREFERENCES_DATA_STORE_FILE = "datastore/onboarding.preferences_pb"
+
+private const val ONBOARDING_PREFERENCES_DATA_STORE_NAME = "onboarding"
+
+internal val Context.onboardingPreferencesDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = ONBOARDING_PREFERENCES_DATA_STORE_NAME
+)

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingRepository.kt
@@ -1,0 +1,18 @@
+package org.cescfe.numpairs.data.onboarding
+
+import kotlinx.coroutines.flow.Flow
+
+interface OnboardingRepository {
+    val onboardingState: Flow<OnboardingState>
+
+    suspend fun initialize(installationKind: OnboardingInstallationKind)
+
+    suspend fun recordStageCompleted(stage: OnboardingStageCheckpoint)
+
+    suspend fun markRequiredVersionCompleted()
+}
+
+enum class OnboardingInstallationKind {
+    FRESH_INSTALL,
+    PRE_V6_UPGRADE
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingRuntime.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingRuntime.kt
@@ -1,0 +1,18 @@
+package org.cescfe.numpairs.data.onboarding
+
+import android.content.Context
+
+data class OnboardingRuntime(val repository: OnboardingRepository, val initializer: OnboardingInitializer)
+
+fun createOnboardingRuntime(context: Context): OnboardingRuntime {
+    val applicationContext = context.applicationContext
+    val repository = DataStoreOnboardingRepository(applicationContext.onboardingPreferencesDataStore)
+
+    return OnboardingRuntime(
+        repository = repository,
+        initializer = OnboardingInitializer(
+            repository = repository,
+            preV6UpgradeMarker = applicationContext.preV6UpgradeMarker()
+        )
+    )
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingState.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingState.kt
@@ -1,0 +1,24 @@
+package org.cescfe.numpairs.data.onboarding
+
+const val REQUIRED_ONBOARDING_VERSION = 1
+
+data class OnboardingState(
+    val isInitialized: Boolean = false,
+    val completedVersion: Int = 0,
+    val lastCompletedStage: OnboardingStageCheckpoint = OnboardingStageCheckpoint.NONE
+) {
+    fun isRequiredVersionComplete(): Boolean = completedVersion >= REQUIRED_ONBOARDING_VERSION
+}
+
+enum class OnboardingStageCheckpoint(internal val persistedValue: Int) {
+    NONE(0),
+    STAGE_ONE(1),
+    STAGE_TWO(2),
+    STAGE_THREE(3);
+
+    internal companion object {
+        fun fromPersistedValue(value: Int): OnboardingStageCheckpoint = entries
+            .firstOrNull { checkpoint -> checkpoint.persistedValue == value }
+            ?: NONE
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/PreV6UpgradeReceiver.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/PreV6UpgradeReceiver.kt
@@ -1,0 +1,34 @@
+package org.cescfe.numpairs.data.onboarding
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+
+class PreV6UpgradeReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (
+            intent.action == Intent.ACTION_MY_PACKAGE_REPLACED &&
+            context.currentVersionCode() == V6_APPLICATION_VERSION_CODE
+        ) {
+            context.preV6UpgradeMarker().mark()
+        }
+    }
+}
+
+internal fun Context.preV6UpgradeMarker(): PreV6UpgradeMarker = FilePreV6UpgradeMarker(
+    markerFile = noBackupFilesDir.resolve(PRE_V6_UPGRADE_MARKER_FILE_NAME)
+)
+
+@Suppress("DEPRECATION")
+private fun Context.currentVersionCode(): Long {
+    val packageInfo = packageManager.getPackageInfo(packageName, 0)
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        packageInfo.longVersionCode
+    } else {
+        packageInfo.versionCode.toLong()
+    }
+}
+
+private const val V6_APPLICATION_VERSION_CODE = 2L
+private const val PRE_V6_UPGRADE_MARKER_FILE_NAME = "pre_v6_upgrade"

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -6,6 +6,9 @@
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
+    <exclude
+        domain="file"
+        path="datastore/onboarding.preferences_pb" />
     <!--
    <include domain="sharedpref" path="."/>
    <exclude domain="sharedpref" path="device.xml"/>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,15 +5,17 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
+        <exclude
+            domain="file"
+            path="datastore/onboarding.preferences_pb" />
         <!-- TODO: Use <include> and <exclude> to control what is backed up.
         <include .../>
         <exclude .../>
         -->
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude
+            domain="file"
+            path="datastore/onboarding.preferences_pb" />
     </device-transfer>
-    -->
 </data-extraction-rules>

--- a/app/src/test/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepositoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepositoryTest.kt
@@ -1,0 +1,149 @@
+package org.cescfe.numpairs.data.onboarding
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import java.io.File
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DataStoreOnboardingRepositoryTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val dataStoreJobs = mutableListOf<Job>()
+
+    @After
+    fun tearDown() {
+        dataStoreJobs.forEach(Job::cancel)
+    }
+
+    @Test
+    fun `state is uninitialized before installation policy is applied`() = runBlocking {
+        val fixture = createRepository()
+
+        assertEquals(OnboardingState(), fixture.repository.onboardingState.first())
+    }
+
+    @Test
+    fun `fresh installation starts required version incomplete`() = runBlocking {
+        val fixture = createRepository()
+
+        fixture.repository.initialize(OnboardingInstallationKind.FRESH_INSTALL)
+
+        val state = fixture.repository.onboardingState.first()
+        assertTrue(state.isInitialized)
+        assertFalse(state.isRequiredVersionComplete())
+        assertEquals(OnboardingStageCheckpoint.NONE, state.lastCompletedStage)
+    }
+
+    @Test
+    fun `pre-v6 upgrade starts required version complete`() = runBlocking {
+        val fixture = createRepository()
+
+        fixture.repository.initialize(OnboardingInstallationKind.PRE_V6_UPGRADE)
+
+        val state = fixture.repository.onboardingState.first()
+        assertTrue(state.isInitialized)
+        assertTrue(state.isRequiredVersionComplete())
+        assertEquals(REQUIRED_ONBOARDING_VERSION, state.completedVersion)
+    }
+
+    @Test
+    fun `initialization never overwrites existing progress`() = runBlocking {
+        val fixture = createRepository()
+        fixture.repository.initialize(OnboardingInstallationKind.FRESH_INSTALL)
+        fixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_TWO)
+
+        fixture.repository.initialize(OnboardingInstallationKind.PRE_V6_UPGRADE)
+
+        val state = fixture.repository.onboardingState.first()
+        assertFalse(state.isRequiredVersionComplete())
+        assertEquals(OnboardingStageCheckpoint.STAGE_TWO, state.lastCompletedStage)
+    }
+
+    @Test
+    fun `stage checkpoints only move forward`() = runBlocking {
+        val fixture = createRepository()
+        fixture.repository.initialize(OnboardingInstallationKind.FRESH_INSTALL)
+
+        fixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_TWO)
+        fixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_ONE)
+
+        assertEquals(
+            OnboardingStageCheckpoint.STAGE_TWO,
+            fixture.repository.onboardingState.first().lastCompletedStage
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `none cannot be recorded as a completed stage`() = runBlocking {
+        createRepository().repository.recordStageCompleted(OnboardingStageCheckpoint.NONE)
+    }
+
+    @Test
+    fun `final completion is versioned and independent from stage checkpoint`() = runBlocking {
+        val fixture = createRepository()
+        fixture.repository.initialize(OnboardingInstallationKind.FRESH_INSTALL)
+        fixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_TWO)
+
+        fixture.repository.markRequiredVersionCompleted()
+
+        val state = fixture.repository.onboardingState.first()
+        assertTrue(state.isRequiredVersionComplete())
+        assertEquals(REQUIRED_ONBOARDING_VERSION, state.completedVersion)
+        assertEquals(OnboardingStageCheckpoint.STAGE_TWO, state.lastCompletedStage)
+    }
+
+    @Test
+    fun `state persists across repository instances`() = runBlocking {
+        val dataStoreFile = createDataStoreFile()
+        val firstFixture = createRepository(dataStoreFile)
+        firstFixture.repository.initialize(OnboardingInstallationKind.FRESH_INSTALL)
+        firstFixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_THREE)
+        firstFixture.close()
+
+        val secondFixture = createRepository(dataStoreFile)
+
+        assertEquals(
+            OnboardingStageCheckpoint.STAGE_THREE,
+            secondFixture.repository.onboardingState.first().lastCompletedStage
+        )
+    }
+
+    private fun createRepository(dataStoreFile: File = createDataStoreFile()): RepositoryFixture {
+        val job = SupervisorJob()
+        dataStoreJobs += job
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(job + Dispatchers.IO),
+            produceFile = { dataStoreFile }
+        )
+
+        return RepositoryFixture(
+            repository = DataStoreOnboardingRepository(dataStore),
+            job = job
+        )
+    }
+
+    private fun createDataStoreFile(): File = File(
+        temporaryFolder.root,
+        "${UUID.randomUUID()}.preferences_pb"
+    )
+
+    private data class RepositoryFixture(val repository: OnboardingRepository, private val job: Job) {
+        suspend fun close() {
+            job.cancelAndJoin()
+        }
+    }
+}

--- a/app/src/test/java/org/cescfe/numpairs/data/onboarding/FilePreV6UpgradeMarkerTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/onboarding/FilePreV6UpgradeMarkerTest.kt
@@ -1,0 +1,23 @@
+package org.cescfe.numpairs.data.onboarding
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class FilePreV6UpgradeMarkerTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `marker can be written and consumed locally`() {
+        val marker = FilePreV6UpgradeMarker(temporaryFolder.root.resolve("no_backup/pre_v6_upgrade"))
+
+        assertFalse(marker.isMarked())
+        marker.mark()
+        assertTrue(marker.isMarked())
+        marker.clear()
+        assertFalse(marker.isMarked())
+    }
+}

--- a/app/src/test/java/org/cescfe/numpairs/data/onboarding/OnboardingInitializerTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/onboarding/OnboardingInitializerTest.kt
@@ -1,0 +1,86 @@
+package org.cescfe.numpairs.data.onboarding
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OnboardingInitializerTest {
+    @Test
+    fun `missing upgrade marker initializes a fresh first run`() = runBlocking {
+        val repository = FakeOnboardingRepository()
+        val marker = FakePreV6UpgradeMarker(isMarked = false)
+
+        OnboardingInitializer(repository, marker).initialize()
+
+        assertEquals(OnboardingInstallationKind.FRESH_INSTALL, repository.initializationKind)
+        assertFalse(repository.onboardingState.first().isRequiredVersionComplete())
+        assertFalse(marker.wasCleared)
+    }
+
+    @Test
+    fun `upgrade marker initializes completion and is consumed after persistence`() = runBlocking {
+        val repository = FakeOnboardingRepository()
+        val marker = FakePreV6UpgradeMarker(isMarked = true)
+
+        OnboardingInitializer(repository, marker).initialize()
+
+        assertEquals(OnboardingInstallationKind.PRE_V6_UPGRADE, repository.initializationKind)
+        assertTrue(repository.onboardingState.first().isRequiredVersionComplete())
+        assertTrue(marker.wasCleared)
+    }
+
+    @Test
+    fun `missing local state after data clearing initializes a new first run`() = runBlocking {
+        val marker = FakePreV6UpgradeMarker(isMarked = true)
+        OnboardingInitializer(FakeOnboardingRepository(), marker).initialize()
+        val repositoryAfterDataClear = FakeOnboardingRepository()
+
+        OnboardingInitializer(repositoryAfterDataClear, marker).initialize()
+
+        assertEquals(OnboardingInstallationKind.FRESH_INSTALL, repositoryAfterDataClear.initializationKind)
+        assertFalse(repositoryAfterDataClear.onboardingState.first().isRequiredVersionComplete())
+    }
+
+    private class FakeOnboardingRepository : OnboardingRepository {
+        override val onboardingState = MutableStateFlow(OnboardingState())
+        var initializationKind: OnboardingInstallationKind? = null
+            private set
+
+        override suspend fun initialize(installationKind: OnboardingInstallationKind) {
+            initializationKind = installationKind
+            onboardingState.value = OnboardingState(
+                isInitialized = true,
+                completedVersion = if (installationKind == OnboardingInstallationKind.PRE_V6_UPGRADE) {
+                    REQUIRED_ONBOARDING_VERSION
+                } else {
+                    0
+                }
+            )
+        }
+
+        override suspend fun recordStageCompleted(stage: OnboardingStageCheckpoint) = Unit
+
+        override suspend fun markRequiredVersionCompleted() = Unit
+    }
+
+    private class FakePreV6UpgradeMarker(isMarked: Boolean) : PreV6UpgradeMarker {
+        private var marked = isMarked
+        var wasCleared = false
+            private set
+
+        override fun isMarked(): Boolean = marked
+
+        override fun mark() {
+            marked = true
+        }
+
+        override fun clear() {
+            marked = false
+            wasCleared = true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a dedicated Preferences DataStore for versioned onboarding completion and monotonic stage checkpoints
- initialize fresh installs as incomplete and consume an explicit pre-v6 package-upgrade marker as completed
- exclude onboarding state from backup/transfer restoration and increase the v6 version boundary to versionCode 2

## Verification

- `./gradlew spotlessApply testDebugUnitTest spotlessCheck compileDebugAndroidTestKotlin`
- Instrumented tests were compiled only; no emulator was started.

Closes #422