### PR TITLE
[201] Support stage-bounded onboarding playback

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -228,6 +228,29 @@ class TutorialRouteTest {
     }
 
     @Test
+    fun guidedIntroductionCanStartAtStageTwoAndReportsItsFullBoundary() {
+        val completedStages = mutableListOf<GuidedOnboardingStage>()
+        setGuidedIntroductionContent(
+            startStage = GuidedOnboardingStage.COMPLEMENTARY_PAIR,
+            onStageCompleted = completedStages::add
+        )
+
+        assertComplementaryPairScenarioDisplayed()
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.STEP_COPY)
+            .assert(hasText(string(R.string.tutorial_stage_two_complete_sum_copy)))
+
+        completeTile(tileIndex = 0, leftStripEntryId = 0, operator = Operator.ADDITION, rightStripEntryId = 1)
+        waitForStep(stepIndex = 2)
+        assertEquals(emptyList<GuidedOnboardingStage>(), completedStages)
+        completeTile(tileIndex = 1, leftStripEntryId = 0, operator = Operator.MULTIPLICATION, rightStripEntryId = 1)
+        waitForStep(stepIndex = 3)
+
+        assertEquals(listOf(GuidedOnboardingStage.COMPLEMENTARY_PAIR), completedStages)
+        assertHiddenStripValueScenarioDisplayed()
+    }
+
+    @Test
     fun solvingTipsPracticeHighlightsExpectedActionsAndCompletesWithSuccessOverlay() {
         setSolvingTipsPracticeTutorialContent()
 
@@ -282,10 +305,18 @@ class TutorialRouteTest {
             .assertIsDisplayed()
     }
 
-    private fun setGuidedIntroductionContent(onIntroductionCompleted: () -> Unit) {
+    private fun setGuidedIntroductionContent(
+        startStage: GuidedOnboardingStage = GuidedOnboardingStage.NUMBER_PLACEMENT,
+        onStageCompleted: (GuidedOnboardingStage) -> Unit = {},
+        onIntroductionCompleted: () -> Unit = {}
+    ) {
         composeTestRule.setContent {
             NumPairsTheme {
-                GuidedIntroductionRoute(onIntroductionCompleted = onIntroductionCompleted)
+                GuidedIntroductionRoute(
+                    startStage = startStage,
+                    onStageCompleted = onStageCompleted,
+                    onIntroductionCompleted = onIntroductionCompleted
+                )
             }
         }
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/GuidedIntroductionRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/GuidedIntroductionRoute.kt
@@ -11,31 +11,43 @@ import androidx.compose.ui.Modifier
 @Composable
 fun GuidedIntroductionRoute(
     modifier: Modifier = Modifier,
+    startStage: GuidedOnboardingStage = GuidedOnboardingStage.NUMBER_PLACEMENT,
+    onStageCompleted: (GuidedOnboardingStage) -> Unit = {},
     onIntroductionCompleted: () -> Unit = {},
     onNavigateBack: () -> Unit = {}
 ) {
-    var phase by rememberSaveable { mutableStateOf(GuidedIntroductionPhase.GUIDED_STAGES) }
+    var phase by rememberSaveable(startStage) { mutableStateOf(GuidedIntroductionPhase.from(startStage)) }
+    val currentOnStageCompleted by rememberUpdatedState(onStageCompleted)
     val currentOnIntroductionCompleted by rememberUpdatedState(onIntroductionCompleted)
 
-    when (phase) {
-        GuidedIntroductionPhase.GUIDED_STAGES -> TutorialRoute(
+    phase.guidedStage?.let { stage ->
+        TutorialRoute(
             modifier = modifier,
             mode = TutorialMode.LEARN_BASICS,
+            guidedStage = stage,
             onTutorialCompleted = {
-                phase = GuidedIntroductionPhase.FINAL_VALIDATION
+                currentOnStageCompleted(stage)
+                phase = stage.nextOrNull()?.let(GuidedIntroductionPhase::from)
+                    ?: GuidedIntroductionPhase.FINAL_VALIDATION
             },
             onNavigateBack = onNavigateBack
         )
-        GuidedIntroductionPhase.FINAL_VALIDATION -> FinalValidationRoute(
-            modifier = modifier,
-            onValidationSolved = currentOnIntroductionCompleted,
-            onNavigateBack = onNavigateBack,
-            onReturnToMenuRequested = onNavigateBack
-        )
-    }
+    } ?: FinalValidationRoute(
+        modifier = modifier,
+        onValidationSolved = currentOnIntroductionCompleted,
+        onNavigateBack = onNavigateBack,
+        onReturnToMenuRequested = onNavigateBack
+    )
 }
 
-private enum class GuidedIntroductionPhase {
-    GUIDED_STAGES,
-    FINAL_VALIDATION
+private enum class GuidedIntroductionPhase(val guidedStage: GuidedOnboardingStage?) {
+    NUMBER_PLACEMENT(GuidedOnboardingStage.NUMBER_PLACEMENT),
+    COMPLEMENTARY_PAIR(GuidedOnboardingStage.COMPLEMENTARY_PAIR),
+    HIDDEN_STRIP_VALUE(GuidedOnboardingStage.HIDDEN_STRIP_VALUE),
+    FINAL_VALIDATION(null);
+
+    companion object {
+        fun from(stage: GuidedOnboardingStage): GuidedIntroductionPhase = entries
+            .first { phase -> phase.guidedStage == stage }
+    }
 }

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/GuidedOnboardingStage.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/GuidedOnboardingStage.kt
@@ -1,0 +1,9 @@
+package org.cescfe.numpairs.feature.tutorial
+
+enum class GuidedOnboardingStage {
+    NUMBER_PLACEMENT,
+    COMPLEMENTARY_PAIR,
+    HIDDEN_STRIP_VALUE;
+
+    internal fun nextOrNull(): GuidedOnboardingStage? = entries.getOrNull(ordinal + 1)
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContent.kt
@@ -21,5 +21,11 @@ object TutorialContent {
         TutorialMode.SOLVING_TIPS_PRACTICE -> solvingTipsPracticeSteps
     }
 
+    fun stepsFor(stage: GuidedOnboardingStage): List<TutorialStep> = when (stage) {
+        GuidedOnboardingStage.NUMBER_PLACEMENT -> listOf(StageOneNumberPlacementContent.step)
+        GuidedOnboardingStage.COMPLEMENTARY_PAIR -> StageTwoComplementaryPairContent.steps
+        GuidedOnboardingStage.HIDDEN_STRIP_VALUE -> listOf(StageThreeHiddenStripValueContent.step)
+    }
+
     fun scenario(id: TutorialScenarioId): TutorialScenario = scenarios.first { scenario -> scenario.id == id }
 }

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -39,13 +39,18 @@ import org.cescfe.numpairs.ui.theme.NumPairsComponents
 fun TutorialRoute(
     modifier: Modifier = Modifier,
     mode: TutorialMode = TutorialMode.LEARN_BASICS,
+    guidedStage: GuidedOnboardingStage? = null,
     onTutorialCompleted: (() -> Unit)? = null,
     onNavigateBack: () -> Unit = {}
 ) {
-    val steps = TutorialContent.stepsFor(mode)
-    var currentStepIndex by rememberSaveable(mode) { mutableIntStateOf(0) }
-    var hasReportedCompletion by rememberSaveable(mode) { mutableStateOf(false) }
-    var latestGameUiState by remember(mode) { mutableStateOf<GameUiState?>(null) }
+    require(guidedStage == null || mode == TutorialMode.LEARN_BASICS) {
+        "Guided onboarding stages are available only in Learn basics mode."
+    }
+    val playbackKey = guidedStage ?: mode
+    val steps = guidedStage?.let(TutorialContent::stepsFor) ?: TutorialContent.stepsFor(mode)
+    var currentStepIndex by rememberSaveable(playbackKey) { mutableIntStateOf(0) }
+    var hasReportedCompletion by rememberSaveable(playbackKey) { mutableStateOf(false) }
+    var latestGameUiState by remember(playbackKey) { mutableStateOf<GameUiState?>(null) }
     val currentOnTutorialCompleted by rememberUpdatedState(onTutorialCompleted)
     val currentStep = steps[currentStepIndex]
     val currentScenario = TutorialContent.scenario(currentStep.scenarioId)
@@ -71,8 +76,8 @@ fun TutorialRoute(
         title = stringResource(R.string.tutorial_screen_title),
         initialPuzzle = currentScenario.initialPuzzle,
         modifier = modifier,
-        gameSessionKey = "$TUTORIAL_GAME_SESSION_KEY:$mode:${currentScenario.id}",
-        puzzleResetKey = mode to currentScenario.id,
+        gameSessionKey = "$TUTORIAL_GAME_SESSION_KEY:$playbackKey:${currentScenario.id}",
+        puzzleResetKey = playbackKey to currentScenario.id,
         isSuccessOverlayEnabled = currentStepIndex == steps.lastIndex && onTutorialCompleted == null,
         interactionPolicy = currentStep.toInteractionPolicy(
             scenario = currentScenario,

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -16,6 +16,22 @@ import org.junit.Test
 
 class TutorialContentTest {
     @Test
+    fun `guided onboarding stages map to their authored steps`() {
+        assertEquals(
+            listOf(StageOneNumberPlacementContent.step),
+            TutorialContent.stepsFor(GuidedOnboardingStage.NUMBER_PLACEMENT)
+        )
+        assertEquals(
+            StageTwoComplementaryPairContent.steps,
+            TutorialContent.stepsFor(GuidedOnboardingStage.COMPLEMENTARY_PAIR)
+        )
+        assertEquals(
+            listOf(StageThreeHiddenStripValueContent.step),
+            TutorialContent.stepsFor(GuidedOnboardingStage.HIDDEN_STRIP_VALUE)
+        )
+    }
+
+    @Test
     fun exposes_authored_content_for_each_learning_flow() {
         assertEquals(
             listOf(


### PR DESCRIPTION
## Summary

- model the three guided onboarding stages and map each to its authored Tutorial steps
- let Tutorial playback start from a clean selected stage and report its exact completion boundary
- advance the guided introduction stage by stage into the existing unguided final validation

## Verification

- `./gradlew spotlessApply testDebugUnitTest spotlessCheck compileDebugAndroidTestKotlin`
- Instrumented tests were compiled only; no emulator was started.

Closes #423