### PR TITLE
[202] Gate first run with mandatory onboarding

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.test.espresso.Espresso.pressBackUnconditionally
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
 import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
@@ -79,6 +80,7 @@ class AppNavigationLearningFlowTest {
         composeTestRule.setContent {
             NumPairsTheme {
                 AppNavigation(
+                    onboardingRepository = FakeOnboardingRepository(),
                     topAppBarActionDiscoveryRepository = actionDiscoveryRepository,
                     generatedModeRegistry = GeneratedModes.registry,
                     generatedPuzzleGenerationUseCaseFactory = fourPairsProviderFactory(puzzleProvider = puzzleProvider)

--- a/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
@@ -1,0 +1,135 @@
+package org.cescfe.numpairs
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.Espresso.pressBackUnconditionally
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
+import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
+import org.cescfe.numpairs.data.onboarding.OnboardingState
+import org.cescfe.numpairs.data.onboarding.completedOnboardingState
+import org.cescfe.numpairs.data.onboarding.incompleteOnboardingState
+import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
+import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
+import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationResult
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCase
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
+import org.cescfe.numpairs.feature.menu.ui.MenuScreenTestTags
+import org.cescfe.numpairs.feature.onboarding.ONBOARDING_LOADING_SCREEN_TEST_TAG
+import org.cescfe.numpairs.feature.tutorial.ui.TutorialScreenTestTags
+import org.cescfe.numpairs.ui.navigation.AppNavigation
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RequiredOnboardingNavigationTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun uninitializedStateWaitsBeforeRoutingAndFreshStateStartsStageOne() {
+        val repository = FakeOnboardingRepository(initialState = OnboardingState())
+        setContent(repository)
+
+        composeTestRule
+            .onNodeWithTag(ONBOARDING_LOADING_SCREEN_TEST_TAG)
+            .assertIsDisplayed()
+
+        repository.onboardingState.value = incompleteOnboardingState()
+
+        composeTestRule
+            .onNodeWithText(string(R.string.tutorial_stage_one_place_number_copy))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun completedStateStartsAtTheUnlockedMenu() {
+        setContent(FakeOnboardingRepository(completedOnboardingState()))
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun completedCheckpointsResumeAtTheNextRequiredStageOrValidation() {
+        val repository = FakeOnboardingRepository(
+            incompleteOnboardingState(OnboardingStageCheckpoint.STAGE_ONE)
+        )
+        setContent(repository)
+        composeTestRule
+            .onNodeWithText(string(R.string.tutorial_stage_two_complete_sum_copy))
+            .assertIsDisplayed()
+
+        repository.onboardingState.value = incompleteOnboardingState(OnboardingStageCheckpoint.STAGE_TWO)
+        composeTestRule
+            .onNodeWithText(string(R.string.tutorial_stage_three_hidden_strip_value_copy))
+            .assertIsDisplayed()
+
+        repository.onboardingState.value = incompleteOnboardingState(OnboardingStageCheckpoint.STAGE_THREE)
+        composeTestRule
+            .onNodeWithText(string(R.string.final_validation_screen_title))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun systemBackCannotExposeTheMenuWhileOnboardingIsIncomplete() {
+        setContent(FakeOnboardingRepository(incompleteOnboardingState()))
+
+        pressBackUnconditionally()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.BACK_BUTTON)
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.INSTRUCTION_SURFACE)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SCREEN)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun persistedValidationCompletionUnlocksTheMenu() {
+        val repository = FakeOnboardingRepository(
+            incompleteOnboardingState(OnboardingStageCheckpoint.STAGE_THREE)
+        )
+        setContent(repository)
+
+        repository.onboardingState.value = completedOnboardingState()
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+    }
+
+    private fun setContent(repository: FakeOnboardingRepository) {
+        composeTestRule.setContent {
+            NumPairsTheme {
+                AppNavigation(
+                    onboardingRepository = repository,
+                    topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
+                    generatedModeRegistry = GeneratedModes.registry,
+                    generatedPuzzleGenerationUseCaseFactory = generatedPuzzleFactory()
+                )
+            }
+        }
+    }
+
+    private fun generatedPuzzleFactory(): GeneratedPuzzleGenerationUseCaseFactory =
+        GeneratedPuzzleGenerationUseCaseFactory {
+            GeneratedPuzzleGenerationUseCase { request ->
+                GeneratedPuzzleGenerationResult.Generated(request, samplePuzzle)
+            }
+        }
+
+    private fun string(stringResId: Int): String = composeTestRule.activity.getString(stringResId)
+}

--- a/app/src/androidTest/java/org/cescfe/numpairs/data/onboarding/FakeOnboardingRepository.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/data/onboarding/FakeOnboardingRepository.kt
@@ -1,0 +1,42 @@
+package org.cescfe.numpairs.data.onboarding
+
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeOnboardingRepository(initialState: OnboardingState = completedOnboardingState()) : OnboardingRepository {
+    override val onboardingState = MutableStateFlow(initialState)
+
+    override suspend fun initialize(installationKind: OnboardingInstallationKind) {
+        if (onboardingState.value.isInitialized) {
+            return
+        }
+
+        onboardingState.value = OnboardingState(
+            isInitialized = true,
+            completedVersion = if (installationKind == OnboardingInstallationKind.PRE_V6_UPGRADE) {
+                REQUIRED_ONBOARDING_VERSION
+            } else {
+                0
+            }
+        )
+    }
+
+    override suspend fun recordStageCompleted(stage: OnboardingStageCheckpoint) {
+        onboardingState.value = onboardingState.value.copy(lastCompletedStage = stage)
+    }
+
+    override suspend fun markRequiredVersionCompleted() {
+        onboardingState.value = onboardingState.value.copy(completedVersion = REQUIRED_ONBOARDING_VERSION)
+    }
+}
+
+fun completedOnboardingState(): OnboardingState = OnboardingState(
+    isInitialized = true,
+    completedVersion = REQUIRED_ONBOARDING_VERSION
+)
+
+fun incompleteOnboardingState(
+    lastCompletedStage: OnboardingStageCheckpoint = OnboardingStageCheckpoint.NONE
+): OnboardingState = OnboardingState(
+    isInitialized = true,
+    lastCompletedStage = lastCompletedStage
+)

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/eightpairs/EightPairsModeTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/eightpairs/EightPairsModeTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso.pressBackUnconditionally
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
 import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.domain.puzzle.model.Board
 import org.cescfe.numpairs.domain.puzzle.model.Expression
@@ -110,6 +111,7 @@ class EightPairsModeTest {
         composeTestRule.setContent {
             NumPairsTheme {
                 AppNavigation(
+                    onboardingRepository = FakeOnboardingRepository(),
                     topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
                     generatedModeRegistry = GeneratedModes.registry,
                     generatedPuzzleGenerationUseCaseFactory = eightPairsProviderFactory(puzzleProvider = puzzleProvider)

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/fourpairs/FourPairsCompletionActionsTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/fourpairs/FourPairsCompletionActionsTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.test.espresso.Espresso.pressBackUnconditionally
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
 import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerator
@@ -167,6 +168,7 @@ class FourPairsCompletionActionsTest {
         composeTestRule.setContent {
             NumPairsTheme {
                 AppNavigation(
+                    onboardingRepository = FakeOnboardingRepository(),
                     topAppBarActionDiscoveryRepository = actionDiscoveryRepository,
                     generatedModeRegistry = GeneratedModes.registry,
                     generatedPuzzleGenerationUseCaseFactory = fourPairsProviderFactory(puzzleProvider = puzzleProvider)

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -232,7 +232,7 @@ class TutorialRouteTest {
         val completedStages = mutableListOf<GuidedOnboardingStage>()
         setGuidedIntroductionContent(
             startStage = GuidedOnboardingStage.COMPLEMENTARY_PAIR,
-            onStageCompleted = completedStages::add
+            onStageCompleted = { stage -> completedStages += stage }
         )
 
         assertComplementaryPairScenarioDisplayed()
@@ -307,7 +307,7 @@ class TutorialRouteTest {
 
     private fun setGuidedIntroductionContent(
         startStage: GuidedOnboardingStage = GuidedOnboardingStage.NUMBER_PLACEMENT,
-        onStageCompleted: (GuidedOnboardingStage) -> Unit = {},
+        onStageCompleted: suspend (GuidedOnboardingStage) -> Unit = {},
         onIntroductionCompleted: () -> Unit = {}
     ) {
         composeTestRule.setContent {

--- a/app/src/main/java/org/cescfe/numpairs/MainActivity.kt
+++ b/app/src/main/java/org/cescfe/numpairs/MainActivity.kt
@@ -5,6 +5,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+import org.cescfe.numpairs.data.onboarding.createOnboardingRuntime
 import org.cescfe.numpairs.data.preferences.createTopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.feature.generated.ConfiguredGeneratedPuzzleGenerationUseCaseFactory
 import org.cescfe.numpairs.feature.generated.GeneratedModes
@@ -16,15 +19,20 @@ class MainActivity : ComponentActivity() {
         installSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        val onboardingRuntime = createOnboardingRuntime(applicationContext)
         val topAppBarActionDiscoveryRepository = createTopAppBarActionDiscoveryRepository(applicationContext)
         val generatedModeRegistry = GeneratedModes.registry
         val generatedPuzzleGenerationUseCaseFactory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
             modeRegistry = generatedModeRegistry
         )
+        lifecycleScope.launch {
+            onboardingRuntime.initializer.initialize()
+        }
 
         setContent {
             NumPairsTheme {
                 AppNavigation(
+                    onboardingRepository = onboardingRuntime.repository,
                     topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
                     generatedModeRegistry = generatedModeRegistry,
                     generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory

--- a/app/src/main/java/org/cescfe/numpairs/feature/onboarding/OnboardingLoadingScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/onboarding/OnboardingLoadingScreen.kt
@@ -1,0 +1,26 @@
+package org.cescfe.numpairs.feature.onboarding
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+
+@Composable
+fun OnboardingLoadingScreen(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .testTag(ONBOARDING_LOADING_SCREEN_TEST_TAG),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+const val ONBOARDING_LOADING_SCREEN_TEST_TAG = "onboarding_loading_screen"

--- a/app/src/main/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRoute.kt
@@ -1,0 +1,65 @@
+package org.cescfe.numpairs.feature.onboarding
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import kotlinx.coroutines.launch
+import org.cescfe.numpairs.data.onboarding.OnboardingRepository
+import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
+import org.cescfe.numpairs.data.onboarding.OnboardingState
+import org.cescfe.numpairs.feature.tutorial.FinalValidationRoute
+import org.cescfe.numpairs.feature.tutorial.GuidedIntroductionRoute
+import org.cescfe.numpairs.feature.tutorial.GuidedOnboardingStage
+
+@Composable
+fun RequiredOnboardingRoute(
+    onboardingState: OnboardingState,
+    onboardingRepository: OnboardingRepository,
+    modifier: Modifier = Modifier
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val nextGuidedStage = onboardingState.lastCompletedStage.nextRequiredGuidedStage()
+
+    BackHandler(enabled = true, onBack = {})
+
+    if (nextGuidedStage != null) {
+        GuidedIntroductionRoute(
+            modifier = modifier,
+            startStage = nextGuidedStage,
+            saveProgressAcrossRecreation = false,
+            onStageCompleted = { stage ->
+                onboardingRepository.recordStageCompleted(stage.toCheckpoint())
+            },
+            onIntroductionCompleted = {
+                coroutineScope.launch {
+                    onboardingRepository.markRequiredVersionCompleted()
+                }
+            }
+        )
+    } else {
+        FinalValidationRoute(
+            modifier = modifier,
+            onValidationSolved = {
+                coroutineScope.launch {
+                    onboardingRepository.markRequiredVersionCompleted()
+                }
+            },
+            onNavigateBack = {},
+            onReturnToMenuRequested = {}
+        )
+    }
+}
+
+internal fun OnboardingStageCheckpoint.nextRequiredGuidedStage(): GuidedOnboardingStage? = when (this) {
+    OnboardingStageCheckpoint.NONE -> GuidedOnboardingStage.NUMBER_PLACEMENT
+    OnboardingStageCheckpoint.STAGE_ONE -> GuidedOnboardingStage.COMPLEMENTARY_PAIR
+    OnboardingStageCheckpoint.STAGE_TWO -> GuidedOnboardingStage.HIDDEN_STRIP_VALUE
+    OnboardingStageCheckpoint.STAGE_THREE -> null
+}
+
+private fun GuidedOnboardingStage.toCheckpoint(): OnboardingStageCheckpoint = when (this) {
+    GuidedOnboardingStage.NUMBER_PLACEMENT -> OnboardingStageCheckpoint.STAGE_ONE
+    GuidedOnboardingStage.COMPLEMENTARY_PAIR -> OnboardingStageCheckpoint.STAGE_TWO
+    GuidedOnboardingStage.HIDDEN_STRIP_VALUE -> OnboardingStageCheckpoint.STAGE_THREE
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/GuidedIntroductionRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/GuidedIntroductionRoute.kt
@@ -3,32 +3,50 @@ package org.cescfe.numpairs.feature.tutorial
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import kotlinx.coroutines.launch
 
 @Composable
 fun GuidedIntroductionRoute(
     modifier: Modifier = Modifier,
     startStage: GuidedOnboardingStage = GuidedOnboardingStage.NUMBER_PLACEMENT,
-    onStageCompleted: (GuidedOnboardingStage) -> Unit = {},
+    saveProgressAcrossRecreation: Boolean = true,
+    onStageCompleted: suspend (GuidedOnboardingStage) -> Unit = {},
     onIntroductionCompleted: () -> Unit = {},
     onNavigateBack: () -> Unit = {}
 ) {
-    var phase by rememberSaveable(startStage) { mutableStateOf(GuidedIntroductionPhase.from(startStage)) }
+    val phaseState = if (saveProgressAcrossRecreation) {
+        rememberSaveable(startStage) { mutableStateOf(GuidedIntroductionPhase.from(startStage)) }
+    } else {
+        remember(startStage) { mutableStateOf(GuidedIntroductionPhase.from(startStage)) }
+    }
+    var phase by phaseState
     val currentOnStageCompleted by rememberUpdatedState(onStageCompleted)
     val currentOnIntroductionCompleted by rememberUpdatedState(onIntroductionCompleted)
+    val coroutineScope = rememberCoroutineScope()
 
     phase.guidedStage?.let { stage ->
+        var isStageCompletionInProgress by remember(stage) { mutableStateOf(false) }
+
         TutorialRoute(
             modifier = modifier,
             mode = TutorialMode.LEARN_BASICS,
             guidedStage = stage,
+            saveProgressAcrossRecreation = saveProgressAcrossRecreation,
             onTutorialCompleted = {
-                currentOnStageCompleted(stage)
-                phase = stage.nextOrNull()?.let(GuidedIntroductionPhase::from)
-                    ?: GuidedIntroductionPhase.FINAL_VALIDATION
+                if (!isStageCompletionInProgress) {
+                    isStageCompletionInProgress = true
+                    coroutineScope.launch {
+                        currentOnStageCompleted(stage)
+                        phase = stage.nextOrNull()?.let(GuidedIntroductionPhase::from)
+                            ?: GuidedIntroductionPhase.FINAL_VALIDATION
+                    }
+                }
             },
             onNavigateBack = onNavigateBack
         )

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -40,6 +40,7 @@ fun TutorialRoute(
     modifier: Modifier = Modifier,
     mode: TutorialMode = TutorialMode.LEARN_BASICS,
     guidedStage: GuidedOnboardingStage? = null,
+    saveProgressAcrossRecreation: Boolean = true,
     onTutorialCompleted: (() -> Unit)? = null,
     onNavigateBack: () -> Unit = {}
 ) {
@@ -48,8 +49,18 @@ fun TutorialRoute(
     }
     val playbackKey = guidedStage ?: mode
     val steps = guidedStage?.let(TutorialContent::stepsFor) ?: TutorialContent.stepsFor(mode)
-    var currentStepIndex by rememberSaveable(playbackKey) { mutableIntStateOf(0) }
-    var hasReportedCompletion by rememberSaveable(playbackKey) { mutableStateOf(false) }
+    val currentStepIndexState = if (saveProgressAcrossRecreation) {
+        rememberSaveable(playbackKey) { mutableIntStateOf(0) }
+    } else {
+        remember(playbackKey) { mutableIntStateOf(0) }
+    }
+    val completionReportedState = if (saveProgressAcrossRecreation) {
+        rememberSaveable(playbackKey) { mutableStateOf(false) }
+    } else {
+        remember(playbackKey) { mutableStateOf(false) }
+    }
+    var currentStepIndex by currentStepIndexState
+    var hasReportedCompletion by completionReportedState
     var latestGameUiState by remember(playbackKey) { mutableStateOf<GameUiState?>(null) }
     val currentOnTutorialCompleted by rememberUpdatedState(onTutorialCompleted)
     val currentStep = steps[currentStepIndex]

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -2,12 +2,15 @@ package org.cescfe.numpairs.ui.navigation
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import org.cescfe.numpairs.data.onboarding.OnboardingRepository
+import org.cescfe.numpairs.data.onboarding.OnboardingState
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.feature.fourpairs.FourPairsRoute
 import org.cescfe.numpairs.feature.generated.GeneratedModeId
@@ -16,6 +19,8 @@ import org.cescfe.numpairs.feature.generated.GeneratedModeRoute
 import org.cescfe.numpairs.feature.generated.GeneratedModes
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
 import org.cescfe.numpairs.feature.menu.MenuRoute
+import org.cescfe.numpairs.feature.onboarding.OnboardingLoadingScreen
+import org.cescfe.numpairs.feature.onboarding.RequiredOnboardingRoute
 import org.cescfe.numpairs.feature.tutorial.GuidedIntroductionRoute
 
 sealed interface AppDestination {
@@ -26,11 +31,39 @@ sealed interface AppDestination {
 
 @Composable
 fun AppNavigation(
+    onboardingRepository: OnboardingRepository,
     topAppBarActionDiscoveryRepository: TopAppBarActionDiscoveryRepository,
     generatedModeRegistry: GeneratedModeRegistry,
     generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory,
     modifier: Modifier = Modifier,
     startDestination: AppDestination = AppDestination.Menu
+) {
+    val onboardingState by onboardingRepository.onboardingState.collectAsState(initial = OnboardingState())
+
+    when {
+        !onboardingState.isInitialized -> OnboardingLoadingScreen(modifier = modifier)
+        !onboardingState.isRequiredVersionComplete() -> RequiredOnboardingRoute(
+            onboardingState = onboardingState,
+            onboardingRepository = onboardingRepository,
+            modifier = modifier
+        )
+        else -> UnlockedAppNavigation(
+            topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
+            generatedModeRegistry = generatedModeRegistry,
+            generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory,
+            modifier = modifier,
+            startDestination = startDestination
+        )
+    }
+}
+
+@Composable
+private fun UnlockedAppNavigation(
+    topAppBarActionDiscoveryRepository: TopAppBarActionDiscoveryRepository,
+    generatedModeRegistry: GeneratedModeRegistry,
+    generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory,
+    modifier: Modifier,
+    startDestination: AppDestination
 ) {
     var currentDestination by remember(startDestination) {
         mutableStateOf(startDestination)

--- a/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
@@ -1,0 +1,26 @@
+package org.cescfe.numpairs.feature.onboarding
+
+import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
+import org.cescfe.numpairs.feature.tutorial.GuidedOnboardingStage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RequiredOnboardingRouteTest {
+    @Test
+    fun `checkpoint resumes at the next required guided stage`() {
+        assertEquals(
+            GuidedOnboardingStage.NUMBER_PLACEMENT,
+            OnboardingStageCheckpoint.NONE.nextRequiredGuidedStage()
+        )
+        assertEquals(
+            GuidedOnboardingStage.COMPLEMENTARY_PAIR,
+            OnboardingStageCheckpoint.STAGE_ONE.nextRequiredGuidedStage()
+        )
+        assertEquals(
+            GuidedOnboardingStage.HIDDEN_STRIP_VALUE,
+            OnboardingStageCheckpoint.STAGE_TWO.nextRequiredGuidedStage()
+        )
+        assertNull(OnboardingStageCheckpoint.STAGE_THREE.nextRequiredGuidedStage())
+    }
+}


### PR DESCRIPTION
## Summary

- initialize onboarding at app startup and gate unlocked navigation on versioned completion
- persist stage checkpoints before advancing and resume the next authored stage or final validation
- consume back navigation while onboarding is incomplete and unlock the menu only after solved validation is persisted

## Verification

- `./gradlew spotlessApply testDebugUnitTest spotlessCheck compileDebugAndroidTestKotlin`
- Instrumented tests were compiled only; no emulator was started.

Closes #424