### PR TITLE
[203] Add the validated early-exit path

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso.pressBackUnconditionally
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
+import org.cescfe.numpairs.data.onboarding.OnboardingPostCorePath
 import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
 import org.cescfe.numpairs.data.onboarding.OnboardingState
 import org.cescfe.numpairs.data.onboarding.completedOnboardingState
@@ -22,9 +23,12 @@ import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCase
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
 import org.cescfe.numpairs.feature.menu.ui.MenuScreenTestTags
 import org.cescfe.numpairs.feature.onboarding.ONBOARDING_LOADING_SCREEN_TEST_TAG
+import org.cescfe.numpairs.feature.tutorial.PostCoreChoiceTestTags
 import org.cescfe.numpairs.feature.tutorial.ui.TutorialScreenTestTags
 import org.cescfe.numpairs.ui.navigation.AppNavigation
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -60,7 +64,7 @@ class RequiredOnboardingNavigationTest {
     }
 
     @Test
-    fun completedCheckpointsResumeAtTheNextRequiredStageOrValidation() {
+    fun completedCheckpointsResumeAtTheRequiredChoiceStageOrValidation() {
         val repository = FakeOnboardingRepository(
             incompleteOnboardingState(OnboardingStageCheckpoint.STAGE_ONE)
         )
@@ -71,13 +75,52 @@ class RequiredOnboardingNavigationTest {
 
         repository.onboardingState.value = incompleteOnboardingState(OnboardingStageCheckpoint.STAGE_TWO)
         composeTestRule
+            .onNodeWithTag(PostCoreChoiceTestTags.SCREEN)
+            .assertIsDisplayed()
+
+        repository.onboardingState.value = incompleteOnboardingState(
+            lastCompletedStage = OnboardingStageCheckpoint.STAGE_TWO,
+            postCorePath = OnboardingPostCorePath.CONTINUE_GUIDED
+        )
+        composeTestRule
             .onNodeWithText(string(R.string.tutorial_stage_three_hidden_strip_value_copy))
+            .assertIsDisplayed()
+
+        repository.onboardingState.value = incompleteOnboardingState(
+            lastCompletedStage = OnboardingStageCheckpoint.STAGE_TWO,
+            postCorePath = OnboardingPostCorePath.EARLY_VALIDATION
+        )
+        composeTestRule
+            .onNodeWithText(string(R.string.final_validation_screen_title))
             .assertIsDisplayed()
 
         repository.onboardingState.value = incompleteOnboardingState(OnboardingStageCheckpoint.STAGE_THREE)
         composeTestRule
             .onNodeWithText(string(R.string.final_validation_screen_title))
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun earlyExitIsUnavailableBeforeStageTwoAndSelectionDoesNotCompleteOnboarding() {
+        val repository = FakeOnboardingRepository(
+            incompleteOnboardingState(OnboardingStageCheckpoint.STAGE_ONE)
+        )
+        setContent(repository)
+        composeTestRule
+            .onNodeWithTag(PostCoreChoiceTestTags.EARLY_VALIDATION_BUTTON)
+            .assertDoesNotExist()
+
+        repository.onboardingState.value = incompleteOnboardingState(OnboardingStageCheckpoint.STAGE_TWO)
+        composeTestRule
+            .onNodeWithTag(PostCoreChoiceTestTags.EARLY_VALIDATION_BUTTON)
+            .assertIsDisplayed()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText(string(R.string.final_validation_screen_title))
+            .assertIsDisplayed()
+        assertEquals(OnboardingPostCorePath.EARLY_VALIDATION, repository.onboardingState.value.postCorePath)
+        assertFalse(repository.onboardingState.value.isRequiredVersionComplete())
     }
 
     @Test

--- a/app/src/androidTest/java/org/cescfe/numpairs/data/onboarding/FakeOnboardingRepository.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/data/onboarding/FakeOnboardingRepository.kt
@@ -24,6 +24,10 @@ class FakeOnboardingRepository(initialState: OnboardingState = completedOnboardi
         onboardingState.value = onboardingState.value.copy(lastCompletedStage = stage)
     }
 
+    override suspend fun selectPostCorePath(path: OnboardingPostCorePath) {
+        onboardingState.value = onboardingState.value.copy(postCorePath = path)
+    }
+
     override suspend fun markRequiredVersionCompleted() {
         onboardingState.value = onboardingState.value.copy(completedVersion = REQUIRED_ONBOARDING_VERSION)
     }
@@ -35,8 +39,10 @@ fun completedOnboardingState(): OnboardingState = OnboardingState(
 )
 
 fun incompleteOnboardingState(
-    lastCompletedStage: OnboardingStageCheckpoint = OnboardingStageCheckpoint.NONE
+    lastCompletedStage: OnboardingStageCheckpoint = OnboardingStageCheckpoint.NONE,
+    postCorePath: OnboardingPostCorePath = OnboardingPostCorePath.UNDECIDED
 ): OnboardingState = OnboardingState(
     isInitialized = true,
-    lastCompletedStage = lastCompletedStage
+    lastCompletedStage = lastCompletedStage,
+    postCorePath = postCorePath
 )

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performScrollTo
@@ -203,7 +204,15 @@ class TutorialRouteTest {
         val completionCount = AtomicInteger(0)
         setGuidedIntroductionContent(onIntroductionCompleted = { completionCount.incrementAndGet() })
 
-        completeStageTwo()
+        completeStageTwo(waitForStageThree = false)
+        composeTestRule
+            .onNodeWithTag(PostCoreChoiceTestTags.SCREEN)
+            .assertIsDisplayed()
+        assertEquals(0, completionCount.get())
+        composeTestRule
+            .onNodeWithTag(PostCoreChoiceTestTags.CONTINUE_BUTTON)
+            .performClick()
+        waitForStep(stepIndex = 3)
         enterStripValue(index = 1, value = "3")
 
         composeTestRule.waitUntil(timeoutMillis = TUTORIAL_STEP_WAIT_TIMEOUT_MS) {
@@ -244,10 +253,37 @@ class TutorialRouteTest {
         waitForStep(stepIndex = 2)
         assertEquals(emptyList<GuidedOnboardingStage>(), completedStages)
         completeTile(tileIndex = 1, leftStripEntryId = 0, operator = Operator.MULTIPLICATION, rightStripEntryId = 1)
-        waitForStep(stepIndex = 3)
+        composeTestRule
+            .onNodeWithTag(PostCoreChoiceTestTags.SCREEN)
+            .assertIsDisplayed()
 
         assertEquals(listOf(GuidedOnboardingStage.COMPLEMENTARY_PAIR), completedStages)
+        composeTestRule
+            .onNodeWithTag(PostCoreChoiceTestTags.CONTINUE_BUTTON)
+            .performClick()
+        waitForStep(stepIndex = 3)
         assertHiddenStripValueScenarioDisplayed()
+    }
+
+    @Test
+    fun guidedIntroductionEarlyExitStillRequiresFinalValidation() {
+        val completionCount = AtomicInteger(0)
+        setGuidedIntroductionContent(
+            startStage = GuidedOnboardingStage.COMPLEMENTARY_PAIR,
+            onIntroductionCompleted = { completionCount.incrementAndGet() }
+        )
+
+        completeTile(tileIndex = 0, leftStripEntryId = 0, operator = Operator.ADDITION, rightStripEntryId = 1)
+        waitForStep(stepIndex = 2)
+        completeTile(tileIndex = 1, leftStripEntryId = 0, operator = Operator.MULTIPLICATION, rightStripEntryId = 1)
+        composeTestRule
+            .onNodeWithTag(PostCoreChoiceTestTags.EARLY_VALIDATION_BUTTON)
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText(string(R.string.final_validation_screen_title))
+            .assertIsDisplayed()
+        assertEquals(0, completionCount.get())
     }
 
     @Test
@@ -349,12 +385,14 @@ class TutorialRouteTest {
         waitForStep(stepIndex = 1)
     }
 
-    private fun completeStageTwo() {
+    private fun completeStageTwo(waitForStageThree: Boolean = true) {
         completeStageOne()
         completeTile(tileIndex = 0, leftStripEntryId = 0, operator = Operator.ADDITION, rightStripEntryId = 1)
         waitForStep(stepIndex = 2)
         completeTile(tileIndex = 1, leftStripEntryId = 0, operator = Operator.MULTIPLICATION, rightStripEntryId = 1)
-        waitForStep(stepIndex = 3)
+        if (waitForStageThree) {
+            waitForStep(stepIndex = 3)
+        }
     }
 
     private fun enterStripValue(index: Int, value: String) {

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepository.kt
@@ -26,6 +26,9 @@ class DataStoreOnboardingRepository(private val dataStore: DataStore<Preferences
                 completedVersion = preferences[PreferenceKeys.COMPLETED_VERSION] ?: 0,
                 lastCompletedStage = OnboardingStageCheckpoint.fromPersistedValue(
                     preferences[PreferenceKeys.LAST_COMPLETED_STAGE] ?: 0
+                ),
+                postCorePath = OnboardingPostCorePath.fromPersistedValue(
+                    preferences[PreferenceKeys.POST_CORE_PATH] ?: 0
                 )
             )
         }
@@ -42,6 +45,22 @@ class DataStoreOnboardingRepository(private val dataStore: DataStore<Preferences
                 OnboardingInstallationKind.PRE_V6_UPGRADE -> REQUIRED_ONBOARDING_VERSION
             }
             preferences[PreferenceKeys.LAST_COMPLETED_STAGE] = OnboardingStageCheckpoint.NONE.persistedValue
+            preferences[PreferenceKeys.POST_CORE_PATH] = OnboardingPostCorePath.UNDECIDED.persistedValue
+        }
+    }
+
+    override suspend fun selectPostCorePath(path: OnboardingPostCorePath) {
+        require(path != OnboardingPostCorePath.UNDECIDED) {
+            "The selected post-core onboarding path cannot be UNDECIDED."
+        }
+
+        dataStore.edit { preferences ->
+            val currentPath = OnboardingPostCorePath.fromPersistedValue(
+                preferences[PreferenceKeys.POST_CORE_PATH] ?: 0
+            )
+            if (currentPath == OnboardingPostCorePath.UNDECIDED) {
+                preferences[PreferenceKeys.POST_CORE_PATH] = path.persistedValue
+            }
         }
     }
 
@@ -67,5 +86,6 @@ class DataStoreOnboardingRepository(private val dataStore: DataStore<Preferences
         val IS_INITIALIZED = booleanPreferencesKey("onboarding_is_initialized")
         val COMPLETED_VERSION = intPreferencesKey("onboarding_completed_version")
         val LAST_COMPLETED_STAGE = intPreferencesKey("onboarding_last_completed_stage")
+        val POST_CORE_PATH = intPreferencesKey("onboarding_post_core_path")
     }
 }

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingRepository.kt
@@ -9,6 +9,8 @@ interface OnboardingRepository {
 
     suspend fun recordStageCompleted(stage: OnboardingStageCheckpoint)
 
+    suspend fun selectPostCorePath(path: OnboardingPostCorePath)
+
     suspend fun markRequiredVersionCompleted()
 }
 

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingState.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingState.kt
@@ -5,9 +5,22 @@ const val REQUIRED_ONBOARDING_VERSION = 1
 data class OnboardingState(
     val isInitialized: Boolean = false,
     val completedVersion: Int = 0,
-    val lastCompletedStage: OnboardingStageCheckpoint = OnboardingStageCheckpoint.NONE
+    val lastCompletedStage: OnboardingStageCheckpoint = OnboardingStageCheckpoint.NONE,
+    val postCorePath: OnboardingPostCorePath = OnboardingPostCorePath.UNDECIDED
 ) {
     fun isRequiredVersionComplete(): Boolean = completedVersion >= REQUIRED_ONBOARDING_VERSION
+}
+
+enum class OnboardingPostCorePath(internal val persistedValue: Int) {
+    UNDECIDED(0),
+    CONTINUE_GUIDED(1),
+    EARLY_VALIDATION(2);
+
+    internal companion object {
+        fun fromPersistedValue(value: Int): OnboardingPostCorePath = entries
+            .firstOrNull { path -> path.persistedValue == value }
+            ?: UNDECIDED
+    }
 }
 
 enum class OnboardingStageCheckpoint(internal val persistedValue: Int) {

--- a/app/src/main/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRoute.kt
@@ -5,12 +5,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import kotlinx.coroutines.launch
+import org.cescfe.numpairs.data.onboarding.OnboardingPostCorePath
 import org.cescfe.numpairs.data.onboarding.OnboardingRepository
 import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
 import org.cescfe.numpairs.data.onboarding.OnboardingState
 import org.cescfe.numpairs.feature.tutorial.FinalValidationRoute
 import org.cescfe.numpairs.feature.tutorial.GuidedIntroductionRoute
 import org.cescfe.numpairs.feature.tutorial.GuidedOnboardingStage
+import org.cescfe.numpairs.feature.tutorial.PostCoreChoiceScreen
 
 @Composable
 fun RequiredOnboardingRoute(
@@ -19,15 +21,16 @@ fun RequiredOnboardingRoute(
     modifier: Modifier = Modifier
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val nextGuidedStage = onboardingState.lastCompletedStage.nextRequiredGuidedStage()
+    val requiredStep = onboardingState.nextRequiredStep()
 
     BackHandler(enabled = true, onBack = {})
 
-    if (nextGuidedStage != null) {
-        GuidedIntroductionRoute(
+    when (requiredStep) {
+        is RequiredOnboardingStep.GuidedStage -> GuidedIntroductionRoute(
             modifier = modifier,
-            startStage = nextGuidedStage,
+            startStage = requiredStep.stage,
             saveProgressAcrossRecreation = false,
+            showPostCoreChoice = false,
             onStageCompleted = { stage ->
                 onboardingRepository.recordStageCompleted(stage.toCheckpoint())
             },
@@ -37,8 +40,20 @@ fun RequiredOnboardingRoute(
                 }
             }
         )
-    } else {
-        FinalValidationRoute(
+        RequiredOnboardingStep.PostCoreChoice -> PostCoreChoiceScreen(
+            modifier = modifier,
+            onContinueGuided = {
+                coroutineScope.launch {
+                    onboardingRepository.selectPostCorePath(OnboardingPostCorePath.CONTINUE_GUIDED)
+                }
+            },
+            onStartValidation = {
+                coroutineScope.launch {
+                    onboardingRepository.selectPostCorePath(OnboardingPostCorePath.EARLY_VALIDATION)
+                }
+            }
+        )
+        RequiredOnboardingStep.FinalValidation -> FinalValidationRoute(
             modifier = modifier,
             onValidationSolved = {
                 coroutineScope.launch {
@@ -51,11 +66,25 @@ fun RequiredOnboardingRoute(
     }
 }
 
-internal fun OnboardingStageCheckpoint.nextRequiredGuidedStage(): GuidedOnboardingStage? = when (this) {
-    OnboardingStageCheckpoint.NONE -> GuidedOnboardingStage.NUMBER_PLACEMENT
-    OnboardingStageCheckpoint.STAGE_ONE -> GuidedOnboardingStage.COMPLEMENTARY_PAIR
-    OnboardingStageCheckpoint.STAGE_TWO -> GuidedOnboardingStage.HIDDEN_STRIP_VALUE
-    OnboardingStageCheckpoint.STAGE_THREE -> null
+internal fun OnboardingState.nextRequiredStep(): RequiredOnboardingStep = when (lastCompletedStage) {
+    OnboardingStageCheckpoint.NONE -> RequiredOnboardingStep.GuidedStage(GuidedOnboardingStage.NUMBER_PLACEMENT)
+    OnboardingStageCheckpoint.STAGE_ONE ->
+        RequiredOnboardingStep.GuidedStage(GuidedOnboardingStage.COMPLEMENTARY_PAIR)
+    OnboardingStageCheckpoint.STAGE_TWO -> when (postCorePath) {
+        OnboardingPostCorePath.UNDECIDED -> RequiredOnboardingStep.PostCoreChoice
+        OnboardingPostCorePath.CONTINUE_GUIDED ->
+            RequiredOnboardingStep.GuidedStage(GuidedOnboardingStage.HIDDEN_STRIP_VALUE)
+        OnboardingPostCorePath.EARLY_VALIDATION -> RequiredOnboardingStep.FinalValidation
+    }
+    OnboardingStageCheckpoint.STAGE_THREE -> RequiredOnboardingStep.FinalValidation
+}
+
+internal sealed interface RequiredOnboardingStep {
+    data class GuidedStage(val stage: GuidedOnboardingStage) : RequiredOnboardingStep
+
+    data object PostCoreChoice : RequiredOnboardingStep
+
+    data object FinalValidation : RequiredOnboardingStep
 }
 
 private fun GuidedOnboardingStage.toCheckpoint(): OnboardingStageCheckpoint = when (this) {

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/GuidedIntroductionRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/GuidedIntroductionRoute.kt
@@ -16,6 +16,7 @@ fun GuidedIntroductionRoute(
     modifier: Modifier = Modifier,
     startStage: GuidedOnboardingStage = GuidedOnboardingStage.NUMBER_PLACEMENT,
     saveProgressAcrossRecreation: Boolean = true,
+    showPostCoreChoice: Boolean = true,
     onStageCompleted: suspend (GuidedOnboardingStage) -> Unit = {},
     onIntroductionCompleted: () -> Unit = {},
     onNavigateBack: () -> Unit = {}
@@ -30,37 +31,58 @@ fun GuidedIntroductionRoute(
     val currentOnIntroductionCompleted by rememberUpdatedState(onIntroductionCompleted)
     val coroutineScope = rememberCoroutineScope()
 
-    phase.guidedStage?.let { stage ->
-        var isStageCompletionInProgress by remember(stage) { mutableStateOf(false) }
-
-        TutorialRoute(
+    when (phase) {
+        GuidedIntroductionPhase.POST_CORE_CHOICE -> PostCoreChoiceScreen(
             modifier = modifier,
-            mode = TutorialMode.LEARN_BASICS,
-            guidedStage = stage,
-            saveProgressAcrossRecreation = saveProgressAcrossRecreation,
-            onTutorialCompleted = {
-                if (!isStageCompletionInProgress) {
-                    isStageCompletionInProgress = true
-                    coroutineScope.launch {
-                        currentOnStageCompleted(stage)
-                        phase = stage.nextOrNull()?.let(GuidedIntroductionPhase::from)
-                            ?: GuidedIntroductionPhase.FINAL_VALIDATION
-                    }
-                }
+            onContinueGuided = {
+                phase = GuidedIntroductionPhase.HIDDEN_STRIP_VALUE
+            },
+            onStartValidation = {
+                phase = GuidedIntroductionPhase.FINAL_VALIDATION
             },
             onNavigateBack = onNavigateBack
         )
-    } ?: FinalValidationRoute(
-        modifier = modifier,
-        onValidationSolved = currentOnIntroductionCompleted,
-        onNavigateBack = onNavigateBack,
-        onReturnToMenuRequested = onNavigateBack
-    )
+        GuidedIntroductionPhase.FINAL_VALIDATION -> FinalValidationRoute(
+            modifier = modifier,
+            onValidationSolved = currentOnIntroductionCompleted,
+            onNavigateBack = onNavigateBack,
+            onReturnToMenuRequested = onNavigateBack
+        )
+        else -> phase.guidedStage?.let { stage ->
+            var isStageCompletionInProgress by remember(stage) { mutableStateOf(false) }
+
+            TutorialRoute(
+                modifier = modifier,
+                mode = TutorialMode.LEARN_BASICS,
+                guidedStage = stage,
+                saveProgressAcrossRecreation = saveProgressAcrossRecreation,
+                onTutorialCompleted = {
+                    if (!isStageCompletionInProgress) {
+                        isStageCompletionInProgress = true
+                        coroutineScope.launch {
+                            currentOnStageCompleted(stage)
+                            phase = if (
+                                stage == GuidedOnboardingStage.COMPLEMENTARY_PAIR &&
+                                showPostCoreChoice
+                            ) {
+                                GuidedIntroductionPhase.POST_CORE_CHOICE
+                            } else {
+                                stage.nextOrNull()?.let(GuidedIntroductionPhase::from)
+                                    ?: GuidedIntroductionPhase.FINAL_VALIDATION
+                            }
+                        }
+                    }
+                },
+                onNavigateBack = onNavigateBack
+            )
+        }
+    }
 }
 
 private enum class GuidedIntroductionPhase(val guidedStage: GuidedOnboardingStage?) {
     NUMBER_PLACEMENT(GuidedOnboardingStage.NUMBER_PLACEMENT),
     COMPLEMENTARY_PAIR(GuidedOnboardingStage.COMPLEMENTARY_PAIR),
+    POST_CORE_CHOICE(null),
     HIDDEN_STRIP_VALUE(GuidedOnboardingStage.HIDDEN_STRIP_VALUE),
     FINAL_VALIDATION(null);
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/PostCoreChoiceScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/PostCoreChoiceScreen.kt
@@ -1,0 +1,111 @@
+package org.cescfe.numpairs.feature.tutorial
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.ui.theme.NumPairsComponents
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PostCoreChoiceScreen(
+    onContinueGuided: () -> Unit,
+    onStartValidation: () -> Unit,
+    modifier: Modifier = Modifier,
+    onNavigateBack: () -> Unit = {}
+) {
+    Scaffold(
+        modifier = modifier
+            .fillMaxSize()
+            .testTag(PostCoreChoiceTestTags.SCREEN),
+        topBar = {
+            TopAppBar(
+                colors = NumPairsComponents.topAppBarColors(),
+                navigationIcon = {
+                    IconButton(
+                        onClick = onNavigateBack,
+                        modifier = Modifier.testTag(PostCoreChoiceTestTags.BACK_BUTTON)
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_chevron_left),
+                            contentDescription = stringResource(R.string.back_button_content_description)
+                        )
+                    }
+                },
+                title = {
+                    Text(text = stringResource(R.string.tutorial_screen_title))
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 24.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Column(
+                modifier = Modifier.widthIn(max = 420.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.onboarding_post_core_title),
+                    style = androidx.compose.material3.MaterialTheme.typography.headlineSmall,
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    text = stringResource(R.string.onboarding_post_core_message),
+                    style = androidx.compose.material3.MaterialTheme.typography.bodyLarge,
+                    textAlign = TextAlign.Center
+                )
+                NumPairsComponents.PrimaryCtaButton(
+                    onClick = onContinueGuided,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(PostCoreChoiceTestTags.CONTINUE_BUTTON)
+                ) {
+                    Text(text = stringResource(R.string.onboarding_continue_guided_button))
+                }
+                Button(
+                    onClick = onStartValidation,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(PostCoreChoiceTestTags.EARLY_VALIDATION_BUTTON),
+                    shape = NumPairsComponents.MediumShape,
+                    colors = NumPairsComponents.secondaryButtonColors(),
+                    border = NumPairsComponents.secondaryButtonBorder()
+                ) {
+                    Text(text = stringResource(R.string.onboarding_early_validation_button))
+                }
+            }
+        }
+    }
+}
+
+object PostCoreChoiceTestTags {
+    const val SCREEN = "post_core_choice_screen"
+    const val BACK_BUTTON = "post_core_choice_back_button"
+    const val CONTINUE_BUTTON = "post_core_choice_continue_button"
+    const val EARLY_VALIDATION_BUTTON = "post_core_choice_early_validation_button"
+}

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -37,6 +37,10 @@
     <string name="tutorial_previous_step_button">Arrere</string>
     <string name="tutorial_next_step_button">Següent</string>
     <string name="final_validation_screen_title">Comprovació final</string>
+    <string name="onboarding_post_core_title">Lliçó essencial completada</string>
+    <string name="onboarding_post_core_message">Has completat una suma i un producte amb la mateixa parella. Continua amb una lliçó guiada més o demostra el que saps a la comprovació final.</string>
+    <string name="onboarding_continue_guided_button">Continuar aprenent</string>
+    <string name="onboarding_early_validation_button">Ja sé jugar</string>
 
     <!-- Game screen: board and strip -->
     <string name="board_content_description">Tauler</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -37,6 +37,10 @@
     <string name="tutorial_previous_step_button">Atrás</string>
     <string name="tutorial_next_step_button">Siguiente</string>
     <string name="final_validation_screen_title">Comprobación final</string>
+    <string name="onboarding_post_core_title">Lección esencial completada</string>
+    <string name="onboarding_post_core_message">Has completado una suma y un producto con la misma pareja. Continúa con una lección guiada más o demuestra lo que sabes en la comprobación final.</string>
+    <string name="onboarding_continue_guided_button">Seguir aprendiendo</string>
+    <string name="onboarding_early_validation_button">Ya sé jugar</string>
 
     <!-- Game screen: board and strip -->
     <string name="board_content_description">Tablero</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,10 @@
     <string name="tutorial_previous_step_button">Back</string>
     <string name="tutorial_next_step_button">Next</string>
     <string name="final_validation_screen_title">Final check</string>
+    <string name="onboarding_post_core_title">Core lesson complete</string>
+    <string name="onboarding_post_core_message">You completed a sum and product with the same pair. Continue with one more guided lesson, or demonstrate what you know in the final check.</string>
+    <string name="onboarding_continue_guided_button">Keep learning</string>
+    <string name="onboarding_early_validation_button">I know how to play</string>
 
     <!-- Game screen: board and strip -->
     <string name="board_content_description">Board</string>

--- a/app/src/test/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepositoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepositoryTest.kt
@@ -107,6 +107,25 @@ class DataStoreOnboardingRepositoryTest {
     }
 
     @Test
+    fun `post-core path is persisted once without completing onboarding`() = runBlocking {
+        val fixture = createRepository()
+        fixture.repository.initialize(OnboardingInstallationKind.FRESH_INSTALL)
+        fixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_TWO)
+
+        fixture.repository.selectPostCorePath(OnboardingPostCorePath.EARLY_VALIDATION)
+        fixture.repository.selectPostCorePath(OnboardingPostCorePath.CONTINUE_GUIDED)
+
+        val state = fixture.repository.onboardingState.first()
+        assertEquals(OnboardingPostCorePath.EARLY_VALIDATION, state.postCorePath)
+        assertFalse(state.isRequiredVersionComplete())
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `undecided cannot be selected as a post-core path`() = runBlocking {
+        createRepository().repository.selectPostCorePath(OnboardingPostCorePath.UNDECIDED)
+    }
+
+    @Test
     fun `state persists across repository instances`() = runBlocking {
         val dataStoreFile = createDataStoreFile()
         val firstFixture = createRepository(dataStoreFile)

--- a/app/src/test/java/org/cescfe/numpairs/data/onboarding/OnboardingInitializerTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/onboarding/OnboardingInitializerTest.kt
@@ -64,6 +64,8 @@ class OnboardingInitializerTest {
 
         override suspend fun recordStageCompleted(stage: OnboardingStageCheckpoint) = Unit
 
+        override suspend fun selectPostCorePath(path: OnboardingPostCorePath) = Unit
+
         override suspend fun markRequiredVersionCompleted() = Unit
     }
 

--- a/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
@@ -1,26 +1,61 @@
 package org.cescfe.numpairs.feature.onboarding
 
+import org.cescfe.numpairs.data.onboarding.OnboardingPostCorePath
 import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
+import org.cescfe.numpairs.data.onboarding.OnboardingState
 import org.cescfe.numpairs.feature.tutorial.GuidedOnboardingStage
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 class RequiredOnboardingRouteTest {
     @Test
-    fun `checkpoint resumes at the next required guided stage`() {
+    fun `early checkpoints resume at the next required guided stage`() {
         assertEquals(
-            GuidedOnboardingStage.NUMBER_PLACEMENT,
-            OnboardingStageCheckpoint.NONE.nextRequiredGuidedStage()
+            RequiredOnboardingStep.GuidedStage(GuidedOnboardingStage.NUMBER_PLACEMENT),
+            state(OnboardingStageCheckpoint.NONE).nextRequiredStep()
         )
         assertEquals(
-            GuidedOnboardingStage.COMPLEMENTARY_PAIR,
-            OnboardingStageCheckpoint.STAGE_ONE.nextRequiredGuidedStage()
+            RequiredOnboardingStep.GuidedStage(GuidedOnboardingStage.COMPLEMENTARY_PAIR),
+            state(OnboardingStageCheckpoint.STAGE_ONE).nextRequiredStep()
         )
-        assertEquals(
-            GuidedOnboardingStage.HIDDEN_STRIP_VALUE,
-            OnboardingStageCheckpoint.STAGE_TWO.nextRequiredGuidedStage()
-        )
-        assertNull(OnboardingStageCheckpoint.STAGE_THREE.nextRequiredGuidedStage())
     }
+
+    @Test
+    fun `stage two requires a path choice and resumes the selected path`() {
+        assertEquals(
+            RequiredOnboardingStep.PostCoreChoice,
+            state(OnboardingStageCheckpoint.STAGE_TWO).nextRequiredStep()
+        )
+        assertEquals(
+            RequiredOnboardingStep.GuidedStage(GuidedOnboardingStage.HIDDEN_STRIP_VALUE),
+            state(
+                checkpoint = OnboardingStageCheckpoint.STAGE_TWO,
+                path = OnboardingPostCorePath.CONTINUE_GUIDED
+            ).nextRequiredStep()
+        )
+        assertEquals(
+            RequiredOnboardingStep.FinalValidation,
+            state(
+                checkpoint = OnboardingStageCheckpoint.STAGE_TWO,
+                path = OnboardingPostCorePath.EARLY_VALIDATION
+            ).nextRequiredStep()
+        )
+    }
+
+    @Test
+    fun `stage three resumes final validation`() {
+        assertEquals(
+            RequiredOnboardingStep.FinalValidation,
+            state(OnboardingStageCheckpoint.STAGE_THREE).nextRequiredStep()
+        )
+    }
+
+    private fun state(
+        checkpoint: OnboardingStageCheckpoint,
+        path: OnboardingPostCorePath = OnboardingPostCorePath.UNDECIDED
+    ): OnboardingState = OnboardingState(
+        isInitialized = true,
+        lastCompletedStage = checkpoint,
+        postCorePath = path
+    )
 }


### PR DESCRIPTION
## Summary

- present a localized post-core choice only after the complete Stage 2 sum/product pair
- persist full-guided versus early-validation routing independently from onboarding completion
- converge required and voluntary paths on the same authored final validation without unlocking the menu early

## Verification

- `./gradlew spotlessApply testDebugUnitTest spotlessCheck compileDebugAndroidTestKotlin`
- Instrumented tests were compiled only; no emulator was started.

Closes #425