### PR TITLE
[204] Expose safe How to play replay

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performScrollTo
@@ -14,6 +15,10 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.espresso.Espresso.pressBackUnconditionally
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
+import org.cescfe.numpairs.data.onboarding.OnboardingPostCorePath
+import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
+import org.cescfe.numpairs.data.onboarding.OnboardingState
+import org.cescfe.numpairs.data.onboarding.REQUIRED_ONBOARDING_VERSION
 import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
@@ -39,20 +44,39 @@ class AppNavigationLearningFlowTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun menuTutorialLaunchesTheCombinedIntroductionAndBackReturnsToMenu() {
-        setContent(puzzleProvider = QueueGeneratedPuzzleProvider(samplePuzzle))
+    fun howToPlayReplaysFromStageOneAndBackPreservesCompletedOnboarding() {
+        val completedState = OnboardingState(
+            isInitialized = true,
+            completedVersion = REQUIRED_ONBOARDING_VERSION,
+            lastCompletedStage = OnboardingStageCheckpoint.STAGE_THREE,
+            postCorePath = OnboardingPostCorePath.CONTINUE_GUIDED
+        )
+        val onboardingRepository = FakeOnboardingRepository(initialState = completedState)
+        setContent(
+            puzzleProvider = QueueGeneratedPuzzleProvider(samplePuzzle),
+            onboardingRepository = onboardingRepository
+        )
 
         composeTestRule
             .onNodeWithTag(MenuScreenTestTags.TUTORIAL_BUTTON)
+            .assert(hasText(string(R.string.menu_tutorial_button)))
             .performClick()
         composeTestRule
-            .onNodeWithTag(TutorialScreenTestTags.INSTRUCTION_SURFACE)
+            .onNodeWithText(string(R.string.tutorial_stage_one_place_number_copy))
             .assertIsDisplayed()
 
         pressBackUnconditionally()
 
         composeTestRule
             .onNodeWithTag(MenuScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        assertEquals(completedState, onboardingRepository.onboardingState.value)
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.TUTORIAL_BUTTON)
+            .performClick()
+        composeTestRule
+            .onNodeWithText(string(R.string.tutorial_stage_one_place_number_copy))
             .assertIsDisplayed()
     }
 
@@ -74,13 +98,16 @@ class AppNavigationLearningFlowTest {
         assertEquals(1, puzzleProvider.requestCount)
     }
 
-    private fun setContent(puzzleProvider: QueueGeneratedPuzzleProvider) {
+    private fun setContent(
+        puzzleProvider: QueueGeneratedPuzzleProvider,
+        onboardingRepository: FakeOnboardingRepository = FakeOnboardingRepository()
+    ) {
         val actionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository()
 
         composeTestRule.setContent {
             NumPairsTheme {
                 AppNavigation(
-                    onboardingRepository = FakeOnboardingRepository(),
+                    onboardingRepository = onboardingRepository,
                     topAppBarActionDiscoveryRepository = actionDiscoveryRepository,
                     generatedModeRegistry = GeneratedModes.registry,
                     generatedPuzzleGenerationUseCaseFactory = fourPairsProviderFactory(puzzleProvider = puzzleProvider)

--- a/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
@@ -17,9 +17,12 @@ class LocalizationResourceTest {
 
         assertEquals("Jugar 4 pares", resources.getString(R.string.menu_four_pairs_button))
         assertEquals("Jugar 8 pares", resources.getString(R.string.menu_eight_pairs_button))
+        assertEquals("Cómo jugar", resources.getString(R.string.menu_tutorial_button))
         assertEquals("8 pares", resources.getString(R.string.eight_pairs_screen_title))
         assertEquals("Serie", resources.getString(R.string.strip_content_description))
         assertEquals("Paso 1 de 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
+        assertEquals("Ya sé jugar", resources.getString(R.string.onboarding_early_validation_button))
+        assertEquals("Comprobación final", resources.getString(R.string.final_validation_screen_title))
     }
 
     @Test
@@ -28,9 +31,12 @@ class LocalizationResourceTest {
 
         assertEquals("Juga a 4 parelles", resources.getString(R.string.menu_four_pairs_button))
         assertEquals("Juga a 8 parelles", resources.getString(R.string.menu_eight_pairs_button))
+        assertEquals("Com jugar", resources.getString(R.string.menu_tutorial_button))
         assertEquals("8 parelles", resources.getString(R.string.eight_pairs_screen_title))
         assertEquals("Sèrie", resources.getString(R.string.strip_content_description))
         assertEquals("Pas 1 de 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
+        assertEquals("Ja sé jugar", resources.getString(R.string.onboarding_early_validation_button))
+        assertEquals("Comprovació final", resources.getString(R.string.final_validation_screen_title))
     }
 
     @Test
@@ -39,9 +45,12 @@ class LocalizationResourceTest {
 
         assertEquals("Play 4 pairs", resources.getString(R.string.menu_four_pairs_button))
         assertEquals("Play 8 pairs", resources.getString(R.string.menu_eight_pairs_button))
+        assertEquals("How to play", resources.getString(R.string.menu_tutorial_button))
         assertEquals("8 pairs", resources.getString(R.string.eight_pairs_screen_title))
         assertEquals("Strip", resources.getString(R.string.strip_content_description))
         assertEquals("Step 1 of 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
+        assertEquals("I know how to play", resources.getString(R.string.onboarding_early_validation_button))
+        assertEquals("Final check", resources.getString(R.string.final_validation_screen_title))
     }
 
     private fun resourcesFor(languageTag: String): Resources {

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/eightpairs/EightPairsModeTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/eightpairs/EightPairsModeTest.kt
@@ -37,7 +37,7 @@ class EightPairsModeTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun menuShowsTutorialFourPairsAndEightPairs() {
+    fun menuShowsHowToPlayFourPairsAndEightPairs() {
         setContent()
 
         composeTestRule

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -4,7 +4,7 @@
     <string name="back_button_content_description">Arrere</string>
 
     <!-- Menu screen -->
-    <string name="menu_tutorial_button">Tutorial</string>
+    <string name="menu_tutorial_button">Com jugar</string>
     <string name="menu_four_pairs_button">Juga a 4 parelles</string>
     <string name="menu_eight_pairs_button">Juga a 8 parelles</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4,7 +4,7 @@
     <string name="back_button_content_description">Atrás</string>
 
     <!-- Menu screen -->
-    <string name="menu_tutorial_button">Tutorial</string>
+    <string name="menu_tutorial_button">Cómo jugar</string>
     <string name="menu_four_pairs_button">Jugar 4 pares</string>
     <string name="menu_eight_pairs_button">Jugar 8 pares</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="back_button_content_description">Back</string>
 
     <!-- Menu screen -->
-    <string name="menu_tutorial_button">Tutorial</string>
+    <string name="menu_tutorial_button">How to play</string>
     <string name="menu_four_pairs_button">Play 4 pairs</string>
     <string name="menu_eight_pairs_button">Play 8 pairs</string>
 


### PR DESCRIPTION
## Summary

- rename the unlocked menu learning entry to How to play in English, Spanish, and Catalan
- verify voluntary replay always starts from Stage 1 and can return to the unlocked menu
- prove replay leaves versioned completion, checkpoints, and path selection unchanged while optional learning surfaces remain separate

## Verification

- `./gradlew spotlessApply testDebugUnitTest spotlessCheck compileDebugAndroidTestKotlin`
- Instrumented tests were compiled only; no emulator was started.

Closes #426