### PR TITLE
[205] Document the repository delivery workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,7 @@
 ## Related Issue
 
-Closes #
+Resolves #
 
 ## Summary
 
 - Describe the outcome of this Pull Request.
-___

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,36 @@
-Resolves #
+## Related Issue
+
+Closes #
+
+## Summary
+
+- Describe the outcome of this Pull Request.
+
+## Verification
+
+- [ ] `git diff --check`
+- [ ] Relevant automated checks have been run
+- [ ] Instrumented tests were compiled only, or are not applicable
+
+Commands and results:
+
+```text
+Add the verification commands and results here.
+```
+
+## Delivery Metadata
+
+- Work reference:
+- Branch:
+- Primary label:
+- Intended squash title: `[{reference}] {Relevant sentence-case message}`
+
+## Review Readiness
+
+- [ ] The change is limited to the related issue.
+- [ ] The issue acceptance criteria are satisfied.
+- [ ] User-facing copy is localized where required.
+- [ ] Documentation and relative links are updated where required.
+- [ ] No emulator or connected-device test was started.
+- [ ] The Pull Request is assigned and labeled correctly.
+- [ ] Required GitHub checks must pass before merge.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,17 +18,23 @@ Commands and results:
 Add the verification commands and results here.
 ```
 
+## Acceptance Criteria
+
+- [ ] Every acceptance criterion in the linked issue has been reviewed against the implementation.
+- [ ] Every fulfilled acceptance-criteria checkbox has been marked complete in the linked issue.
+- [ ] No required acceptance criterion remains unmet before merge.
+
 ## Delivery Metadata
 
 - Work reference:
 - Branch:
 - Primary label:
+- Project status: `In Progress`
 - Intended squash title: `[{reference}] {Relevant sentence-case message}`
 
 ## Review Readiness
 
 - [ ] The change is limited to the related issue.
-- [ ] The issue acceptance criteria are satisfied.
 - [ ] User-facing copy is localized where required.
 - [ ] Documentation and relative links are updated where required.
 - [ ] No emulator or connected-device test was started.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,38 +5,4 @@ Closes #
 ## Summary
 
 - Describe the outcome of this Pull Request.
-
-## Verification
-
-- [ ] `git diff --check`
-- [ ] Relevant automated checks have been run
-- [ ] Instrumented tests were compiled only, or are not applicable
-
-Commands and results:
-
-```text
-Add the verification commands and results here.
-```
-
-## Acceptance Criteria
-
-- [ ] Every acceptance criterion in the linked issue has been reviewed against the implementation.
-- [ ] Every fulfilled acceptance-criteria checkbox has been marked complete in the linked issue.
-- [ ] No required acceptance criterion remains unmet before merge.
-
-## Delivery Metadata
-
-- Work reference:
-- Branch:
-- Primary label:
-- Project status: `In Progress`
-- Intended squash title: `[{reference}] {Relevant sentence-case message}`
-
-## Review Readiness
-
-- [ ] The change is limited to the related issue.
-- [ ] User-facing copy is localized where required.
-- [ ] Documentation and relative links are updated where required.
-- [ ] No emulator or connected-device test was started.
-- [ ] The Pull Request is assigned and labeled correctly.
-- [ ] Required GitHub checks must pass before merge.
+___

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,190 +1,31 @@
 # Repository Agent Instructions
 
-These instructions apply to the complete NumPairs repository. User instructions for a specific task take precedence over the defaults below.
+These instructions apply to the complete NumPairs repository. User instructions for a specific task take precedence over repository defaults.
 
-## Sources Of Truth
+## Required Reading
+
+- Read [the delivery workflow](docs/technical/delivery-workflow.md) completely before planning issues, changing repository files, validating work, opening a Pull Request, or merging.
+- Read [the code quality guidelines](docs/technical/code-quality.md) completely before changing production or test code.
+- For game-rule or domain-model changes, also read [the ubiquitous language](docs/ubiquitous-language.md) and [the game rules](docs/game-rules.md).
+- Review the relevant [Architectural Decision Records](docs/technical/adr/) before changing an established architectural boundary or decision.
+
+Use the linked documents as the canonical sources rather than copying their complete rules into this file.
+
+## Repository Templates
 
 - Use [the feature issue template](.github/ISSUE_TEMPLATE/feature.md) for feature and task issues.
 - Use [the bug issue template](.github/ISSUE_TEMPLATE/bug.md) for defects.
 - Use [the user-story template](.github/ISSUE_TEMPLATE/user-story.md) when the requested unit of work is a user story.
 - Use [the Pull Request template](.github/pull_request_template.md) for every Pull Request.
 
-Do not duplicate complete templates in issues or documentation. Follow the repository template and replace its prompts with task-specific content.
+Follow the selected template and replace its prompts with task-specific content.
 
-## Delivery Context
+## Non-Negotiable Safeguards
 
-Treat these values as delivery-specific inputs:
-
-- milestone URL or number
-- GitHub Project URL
-- Project iteration
-- starting work reference
-- labels or other metadata that differ from the defaults
-
-Obtain them from the user or the current task. Do not carry a milestone, iteration, or starting reference from a previous delivery batch without verification.
-
-Unless the task specifies otherwise, use:
-
-- assignee: `FrancescFe`
-- label for feature work: `feat`
-- issue type: `Task`
-- issue field `Priority`: `Medium`
-- issue field `Effort`: `Low`
-- GitHub Project: `https://github.com/orgs/CescFe/projects/11`
-- Project field `Size`: `xs`
-
-Use the iteration and milestone specified for the current delivery batch. Do not attach new work to a closed milestone unless the user explicitly requests it.
-
-Project `Priority` is contextual and ranges from `P0` to `P3`. Unless the user specifies a value, inspect the most recently worked issue and reuse its Project `Priority`. Do not treat `P2` or any other priority as a permanent default. If there is no previous issue from which to inherit priority, ask for it.
-
-Set Project `Status` according to how the issue enters the workflow:
-
-- `Backlog` when a user is requesting future work and is not starting implementation.
-- `Ready For Dev` when an authorized planning task creates an atomic, refined issue that is ready to be implemented.
-- `In Progress` immediately before implementation begins on an existing issue.
-
-Resolve GitHub node IDs, field IDs, option IDs, and iteration IDs through the GitHub API. Treat these identifiers as opaque and do not store previously observed values as permanent repository configuration.
-
-## Atomic Issue Planning
-
-For milestone delivery:
-
-1. Read the relevant PRD or product reference completely.
-2. Inspect the implemented baseline before proposing work.
-3. Divide the remaining scope into independently reviewable, dependency-ordered issues.
-4. Give each issue one observable outcome and one Pull Request.
-5. Write each issue in English using the selected issue template.
-6. Apply the required assignee, label, type, issue fields, Project fields, iteration, and milestone.
-7. Set Project `Status` to `Ready For Dev` for each planned issue.
-
-Do not combine unrelated product behavior, refactors, or documentation in one issue merely to reduce the number of Pull Requests.
-
-## Work References And Branches
-
-Work references are sequential numbers independent from GitHub issue numbers.
-
-Use the starting reference provided by the user. If none is provided, inspect recent merged squash commits and remote branches, then use the next available reference. If the sequence is ambiguous, ask before creating a branch.
-
-Create every implementation branch from an up-to-date `main`.
-
-Branch format:
-
-```text
-{reference}_{descriptive_snake_case_name}
-```
-
-Example:
-
-```text
-205_document_repository_delivery_workflow
-```
-
-Never implement multiple atomic issues in the same branch.
-
-## Commit Conventions
-
-Commit format:
-
-```text
-{type}({reference}): {lowercase message}
-```
-
-Allowed types:
-
-- `feat`
-- `test`
-- `doc`
-- `ci`
-- `refactor`
-- `chore`
-
-Examples:
-
-```text
-feat(205): persist onboarding progress
-doc(206): document the release workflow
-```
-
-Keep the branch focused and prefer one meaningful implementation commit when that accurately represents the work.
-
-## Pull Request Conventions
-
-Pull Requests must:
-
-- target `main`
-- be ready for review rather than draft unless the user requests a draft
-- use the repository Pull Request template
-- link the issue with `Resolves #{issue_number}`
-- be assigned to `FrancescFe` unless specified otherwise
-- use the issue's primary label, normally `feat` for feature work
-- contain only the associated issue's scope
-
-Pull Request title format:
-
-```text
-[{reference}] {Relevant sentence-case message}
-```
-
-When a merge is authorized, use squash and merge with this squash commit title:
-
-```text
-[{reference}] {Relevant sentence-case message}
-```
-
-Do not merge while a required check is pending, unexpectedly skipped, cancelled, or failing. Merge only when the user requested an end-to-end merge cycle. If the user asks to review the Pull Request first or explicitly says not to merge, stop after creating and reporting the Pull Request.
-
-Before any authorized merge:
-
-1. Re-read the associated issue's acceptance criteria.
-2. Verify every criterion against the implemented change and available validation evidence.
-3. Mark each fulfilled acceptance-criteria checkbox as complete in the issue.
-4. Leave unmet criteria unchecked and do not merge while a required criterion remains unmet.
-
-Do not mark criteria complete merely because implementation has ended or checks are green.
-
-## Implementation Cycle
-
-For each authorized issue:
-
-1. Set the issue's Project `Status` to `In Progress`.
-2. Update local `main` from `origin/main`.
-3. Create the issue branch using the assigned work reference.
-4. Implement only the issue acceptance criteria.
-5. Validate in proportion to the change.
-6. Review `git diff` and `git diff --check`.
-7. Commit using the required convention.
-8. Push the branch.
-9. Open and configure the Pull Request.
-10. Wait for required GitHub checks when a merge is part of the requested cycle.
-11. Review the associated issue's acceptance criteria and mark only fulfilled criteria complete.
-12. If checks pass, every required criterion is fulfilled, and merge is authorized, squash and merge with the required title.
-13. Update local `main` before starting the next issue.
-
-Do not start dependent implementation from an unmerged branch when the requested workflow requires sequential integration into `main`.
-
-## Android Validation
-
-For application changes, run the relevant tasks sequentially:
-
-```text
-./gradlew spotlessApply testDebugUnitTest spotlessCheck compileDebugAndroidTestKotlin
-```
-
-Run `lintDebug` when completing a stage or milestone and for changes with broader Android risk.
-
-Instrumented tests must only be compiled. Do not start an emulator or run connected-device tasks because doing so can make the development machine unusable.
-
-For documentation-only changes, validate Markdown structure, relative links, consistency, and `git diff --check`. Android build tasks are not required unless the documentation change affects build configuration or executable examples.
-
-## Milestone Completion
-
-Before closing a milestone:
-
-- confirm every planned issue is closed or deliberately marked `not planned`
-- confirm every associated Pull Request is merged
-- confirm the milestone has zero open issues
-- update local `main` from `origin/main`
-- run final formatting, unit-test, lint, and instrumented-test compilation checks
-- confirm the worktree is clean and synchronized with `origin/main`
-
-Close the milestone only when the user authorized completion and all required verification has passed.
+- Keep each implementation limited to one atomic issue, one branch, and one Pull Request.
+- Preserve unrelated and user-authored work already present in the worktree.
+- Verify the associated issue's acceptance criteria and mark only fulfilled criteria complete before merge.
+- Do not merge without explicit authorization or while a required check is not successful.
+- Compile instrumented tests when required, but do not start an emulator or run connected-device tasks.
+- Resolve current GitHub Project field and option identifiers dynamically; do not treat opaque IDs as permanent configuration.
+- Do not introduce an architectural pattern, dependency, or refactor solely to satisfy a generic best practice.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,6 @@ These instructions apply to the complete NumPairs repository. User instructions 
 - Use [the bug issue template](.github/ISSUE_TEMPLATE/bug.md) for defects.
 - Use [the user-story template](.github/ISSUE_TEMPLATE/user-story.md) when the requested unit of work is a user story.
 - Use [the Pull Request template](.github/pull_request_template.md) for every Pull Request.
-- Use [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor-facing explanation of this workflow.
 
 Do not duplicate complete templates in issues or documentation. Follow the repository template and replace its prompts with task-specific content.
 
@@ -32,10 +31,17 @@ Unless the task specifies otherwise, use:
 - issue field `Priority`: `Medium`
 - issue field `Effort`: `Low`
 - GitHub Project: `https://github.com/orgs/CescFe/projects/11`
-- Project field `Priority`: `P2`
 - Project field `Size`: `xs`
 
 Use the iteration and milestone specified for the current delivery batch. Do not attach new work to a closed milestone unless the user explicitly requests it.
+
+Project `Priority` is contextual and ranges from `P0` to `P3`. Unless the user specifies a value, inspect the most recently worked issue and reuse its Project `Priority`. Do not treat `P2` or any other priority as a permanent default. If there is no previous issue from which to inherit priority, ask for it.
+
+Set Project `Status` according to how the issue enters the workflow:
+
+- `Backlog` when a user is requesting future work and is not starting implementation.
+- `Ready For Dev` when an authorized planning task creates an atomic, refined issue that is ready to be implemented.
+- `In Progress` immediately before implementation begins on an existing issue.
 
 Resolve GitHub node IDs, field IDs, option IDs, and iteration IDs through the GitHub API. Treat these identifiers as opaque and do not store previously observed values as permanent repository configuration.
 
@@ -49,6 +55,7 @@ For milestone delivery:
 4. Give each issue one observable outcome and one Pull Request.
 5. Write each issue in English using the selected issue template.
 6. Apply the required assignee, label, type, issue fields, Project fields, iteration, and milestone.
+7. Set Project `Status` to `Ready For Dev` for each planned issue.
 
 Do not combine unrelated product behavior, refactors, or documentation in one issue merely to reduce the number of Pull Requests.
 
@@ -127,21 +134,32 @@ When a merge is authorized, use squash and merge with this squash commit title:
 
 Do not merge while a required check is pending, unexpectedly skipped, cancelled, or failing. Merge only when the user requested an end-to-end merge cycle. If the user asks to review the Pull Request first or explicitly says not to merge, stop after creating and reporting the Pull Request.
 
+Before any authorized merge:
+
+1. Re-read the associated issue's acceptance criteria.
+2. Verify every criterion against the implemented change and available validation evidence.
+3. Mark each fulfilled acceptance-criteria checkbox as complete in the issue.
+4. Leave unmet criteria unchecked and do not merge while a required criterion remains unmet.
+
+Do not mark criteria complete merely because implementation has ended or checks are green.
+
 ## Implementation Cycle
 
 For each authorized issue:
 
-1. Update local `main` from `origin/main`.
-2. Create the issue branch using the assigned work reference.
-3. Implement only the issue acceptance criteria.
-4. Validate in proportion to the change.
-5. Review `git diff` and `git diff --check`.
-6. Commit using the required convention.
-7. Push the branch.
-8. Open and configure the Pull Request.
-9. Wait for required GitHub checks when a merge is part of the requested cycle.
-10. If checks pass and merge is authorized, squash and merge with the required title.
-11. Update local `main` before starting the next issue.
+1. Set the issue's Project `Status` to `In Progress`.
+2. Update local `main` from `origin/main`.
+3. Create the issue branch using the assigned work reference.
+4. Implement only the issue acceptance criteria.
+5. Validate in proportion to the change.
+6. Review `git diff` and `git diff --check`.
+7. Commit using the required convention.
+8. Push the branch.
+9. Open and configure the Pull Request.
+10. Wait for required GitHub checks when a merge is part of the requested cycle.
+11. Review the associated issue's acceptance criteria and mark only fulfilled criteria complete.
+12. If checks pass, every required criterion is fulfilled, and merge is authorized, squash and merge with the required title.
+13. Update local `main` before starting the next issue.
 
 Do not start dependent implementation from an unmerged branch when the requested workflow requires sequential integration into `main`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,173 @@
+# Repository Agent Instructions
+
+These instructions apply to the complete NumPairs repository. User instructions for a specific task take precedence over the defaults below.
+
+## Sources Of Truth
+
+- Use [the feature issue template](.github/ISSUE_TEMPLATE/feature.md) for feature and task issues.
+- Use [the bug issue template](.github/ISSUE_TEMPLATE/bug.md) for defects.
+- Use [the user-story template](.github/ISSUE_TEMPLATE/user-story.md) when the requested unit of work is a user story.
+- Use [the Pull Request template](.github/pull_request_template.md) for every Pull Request.
+- Use [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor-facing explanation of this workflow.
+
+Do not duplicate complete templates in issues or documentation. Follow the repository template and replace its prompts with task-specific content.
+
+## Delivery Context
+
+Treat these values as delivery-specific inputs:
+
+- milestone URL or number
+- GitHub Project URL
+- Project iteration
+- starting work reference
+- labels or other metadata that differ from the defaults
+
+Obtain them from the user or the current task. Do not carry a milestone, iteration, or starting reference from a previous delivery batch without verification.
+
+Unless the task specifies otherwise, use:
+
+- assignee: `FrancescFe`
+- label for feature work: `feat`
+- issue type: `Task`
+- issue field `Priority`: `Medium`
+- issue field `Effort`: `Low`
+- GitHub Project: `https://github.com/orgs/CescFe/projects/11`
+- Project field `Priority`: `P2`
+- Project field `Size`: `xs`
+
+Use the iteration and milestone specified for the current delivery batch. Do not attach new work to a closed milestone unless the user explicitly requests it.
+
+Resolve GitHub node IDs, field IDs, option IDs, and iteration IDs through the GitHub API. Treat these identifiers as opaque and do not store previously observed values as permanent repository configuration.
+
+## Atomic Issue Planning
+
+For milestone delivery:
+
+1. Read the relevant PRD or product reference completely.
+2. Inspect the implemented baseline before proposing work.
+3. Divide the remaining scope into independently reviewable, dependency-ordered issues.
+4. Give each issue one observable outcome and one Pull Request.
+5. Write each issue in English using the selected issue template.
+6. Apply the required assignee, label, type, issue fields, Project fields, iteration, and milestone.
+
+Do not combine unrelated product behavior, refactors, or documentation in one issue merely to reduce the number of Pull Requests.
+
+## Work References And Branches
+
+Work references are sequential numbers independent from GitHub issue numbers.
+
+Use the starting reference provided by the user. If none is provided, inspect recent merged squash commits and remote branches, then use the next available reference. If the sequence is ambiguous, ask before creating a branch.
+
+Create every implementation branch from an up-to-date `main`.
+
+Branch format:
+
+```text
+{reference}_{descriptive_snake_case_name}
+```
+
+Example:
+
+```text
+205_document_repository_delivery_workflow
+```
+
+Never implement multiple atomic issues in the same branch.
+
+## Commit Conventions
+
+Commit format:
+
+```text
+{type}({reference}): {lowercase message}
+```
+
+Allowed types:
+
+- `feat`
+- `test`
+- `doc`
+- `ci`
+- `refactor`
+- `chore`
+
+Examples:
+
+```text
+feat(205): persist onboarding progress
+doc(206): document the release workflow
+```
+
+Keep the branch focused and prefer one meaningful implementation commit when that accurately represents the work.
+
+## Pull Request Conventions
+
+Pull Requests must:
+
+- target `main`
+- be ready for review rather than draft unless the user requests a draft
+- use the repository Pull Request template
+- link the issue with `Closes #{issue_number}`
+- be assigned to `FrancescFe` unless specified otherwise
+- use the issue's primary label, normally `feat` for feature work
+- state the work reference and verification performed
+- contain only the associated issue's scope
+
+Pull Request title format:
+
+```text
+[{reference}] {Relevant sentence-case message}
+```
+
+When a merge is authorized, use squash and merge with this squash commit title:
+
+```text
+[{reference}] {Relevant sentence-case message}
+```
+
+Do not merge while a required check is pending, unexpectedly skipped, cancelled, or failing. Merge only when the user requested an end-to-end merge cycle. If the user asks to review the Pull Request first or explicitly says not to merge, stop after creating and reporting the Pull Request.
+
+## Implementation Cycle
+
+For each authorized issue:
+
+1. Update local `main` from `origin/main`.
+2. Create the issue branch using the assigned work reference.
+3. Implement only the issue acceptance criteria.
+4. Validate in proportion to the change.
+5. Review `git diff` and `git diff --check`.
+6. Commit using the required convention.
+7. Push the branch.
+8. Open and configure the Pull Request.
+9. Wait for required GitHub checks when a merge is part of the requested cycle.
+10. If checks pass and merge is authorized, squash and merge with the required title.
+11. Update local `main` before starting the next issue.
+
+Do not start dependent implementation from an unmerged branch when the requested workflow requires sequential integration into `main`.
+
+## Android Validation
+
+For application changes, run the relevant tasks sequentially:
+
+```text
+./gradlew spotlessApply testDebugUnitTest spotlessCheck compileDebugAndroidTestKotlin
+```
+
+Run `lintDebug` when completing a stage or milestone and for changes with broader Android risk.
+
+Instrumented tests must only be compiled. Do not start an emulator or run connected-device tasks because doing so can make the development machine unusable.
+
+For documentation-only changes, validate Markdown structure, relative links, consistency, and `git diff --check`. Android build tasks are not required unless the documentation change affects build configuration or executable examples.
+
+## Milestone Completion
+
+Before closing a milestone:
+
+- confirm every planned issue is closed or deliberately marked `not planned`
+- confirm every associated Pull Request is merged
+- confirm the milestone has zero open issues
+- update local `main` from `origin/main`
+- run final formatting, unit-test, lint, and instrumented-test compilation checks
+- confirm the worktree is clean and synchronized with `origin/main`
+
+Close the milestone only when the user authorized completion and all required verification has passed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,6 @@ Pull Requests must:
 - link the issue with `Closes #{issue_number}`
 - be assigned to `FrancescFe` unless specified otherwise
 - use the issue's primary label, normally `feat` for feature work
-- state the work reference and verification performed
 - contain only the associated issue's scope
 
 Pull Request title format:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ Pull Requests must:
 - target `main`
 - be ready for review rather than draft unless the user requests a draft
 - use the repository Pull Request template
-- link the issue with `Closes #{issue_number}`
+- link the issue with `Resolves #{issue_number}`
 - be assigned to `FrancescFe` unless specified otherwise
 - use the issue's primary label, normally `feat` for feature work
 - contain only the associated issue's scope

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,13 @@
 
 Thank you for contributing to NumPairs. The project uses small, issue-driven changes so that product decisions, implementation, and review remain easy to trace.
 
-Repository automation instructions live in [AGENTS.md](AGENTS.md). This guide presents the same workflow for human contributors.
+The canonical repository guidance is:
+
+- [AGENTS.md](AGENTS.md) for agent routing and non-negotiable safeguards
+- [the delivery workflow](docs/technical/delivery-workflow.md) for issue, branch, commit, validation, Pull Request, and merge conventions
+- [the code quality guidelines](docs/technical/code-quality.md) for architecture, domain modeling, implementation, and testing expectations
+
+This guide distinguishes requesting future work from implementing an existing issue. It does not replace the canonical workflow and quality documents.
 
 ## Requesting An Issue
 
@@ -12,124 +18,26 @@ Use an issue to request a focused change for a future contributor. Select the ap
 - [Bug report](.github/ISSUE_TEMPLATE/bug.md)
 - [User story](.github/ISSUE_TEMPLATE/user-story.md)
 
-Describe the context, requested outcome, and verifiable acceptance criteria without assuming that implementation has started. Add the issue to Project 11 with Project `Status: Backlog`, not `Ready For Dev` or `In Progress`.
+Describe the context, requested outcome, and verifiable acceptance criteria without assuming that implementation has started.
 
-`Ready For Dev` is reserved for refined, atomic work that maintainers or an authorized planning workflow have prepared for implementation.
+Add requested future work to Project 11 with Project `Status: Backlog`. Do not place it in `Ready For Dev` or `In Progress`.
+
+`Ready For Dev` is reserved for refined, atomic issues that maintainers or an authorized planning workflow have prepared for implementation.
 
 ## Implementing An Existing Issue
 
-Contributors implement an existing issue rather than creating a duplicate. Before editing code:
+Implement an existing pending issue rather than creating a duplicate. Before editing repository files:
 
 1. Read the complete issue and its acceptance criteria.
 2. Confirm that the work is not already assigned or in progress.
-3. Confirm the current milestone, Project iteration, and work reference.
-4. Change the issue's Project `Status` to `In Progress`.
-5. Create a focused branch from an up-to-date `main`.
+3. Read [the delivery workflow](docs/technical/delivery-workflow.md).
+4. Read [the code quality guidelines](docs/technical/code-quality.md) before changing production or test code.
+5. Confirm the current milestone, Project iteration, and work reference.
+6. Change the issue's Project `Status` to `In Progress`.
+7. Create a focused branch from an up-to-date `main`.
 
-An issue selected from `Backlog` can move directly to `In Progress` when a contributor begins implementation. A planned issue may already be in `Ready For Dev`; it must still move to `In Progress` before work starts.
+An issue selected from `Backlog` can move directly to `In Progress` when implementation begins. A planned issue may already be in `Ready For Dev`; it must still move to `In Progress` before work starts.
 
-Milestone, iteration, and starting work reference are delivery-specific values and should not be copied from an earlier delivery batch.
+Keep the implementation limited to the issue and validate it according to the delivery workflow. Before merge, verify every acceptance criterion, mark only fulfilled criteria complete, and leave the Pull Request open while a required criterion or check remains unmet.
 
-Unless a delivery batch specifies otherwise, feature tasks use:
-
-- assignee `FrancescFe`
-- label `feat`
-- type `Task`
-- issue fields `Priority: Medium` and `Effort: Low`
-- [NumPairs Project 11](https://github.com/orgs/CescFe/projects/11)
-- Project field `Size: xs`
-- the iteration and milestone selected for the current delivery batch
-
-Project `Priority` can be `P0`, `P1`, `P2`, or `P3`. Unless the delivery batch specifies a priority, use the same Project `Priority` as the most recently worked issue. Ask when there is no previous issue from which to inherit it.
-
-Issues should be atomic: one independently reviewable outcome, one branch, and one Pull Request.
-
-## Branches And Work References
-
-Work references are sequential delivery numbers and are not GitHub issue numbers. Use the reference assigned to the task.
-
-Start from an up-to-date `main`:
-
-```bash
-git switch main
-git pull --ff-only
-git switch -c 205_document_repository_delivery_workflow
-```
-
-Branch names use:
-
-```text
-{reference}_{descriptive_snake_case_name}
-```
-
-## Commits
-
-Commit messages use:
-
-```text
-{type}({reference}): {lowercase message}
-```
-
-Allowed types are `feat`, `test`, `doc`, `ci`, `refactor`, and `chore`.
-
-Examples:
-
-```text
-feat(205): add a replay entry point
-doc(206): document the delivery workflow
-```
-
-Keep commits and branches limited to the associated issue.
-
-## Local Verification
-
-For application changes, run the relevant Android validation sequentially:
-
-```bash
-./gradlew spotlessApply testDebugUnitTest spotlessCheck compileDebugAndroidTestKotlin
-```
-
-Use `./gradlew lintDebug` for stage, milestone, and broader Android validation.
-
-Instrumented tests are compiled only. Do not start an emulator or run connected-device tasks on the development machine.
-
-For documentation-only work, check Markdown structure and links, review the diff, and run:
-
-```bash
-git diff --check
-```
-
-## Pull Requests
-
-Push the issue branch and open a ready-for-review Pull Request against `main`. Complete [the Pull Request template](.github/pull_request_template.md), including:
-
-- the closing issue reference
-- a concise outcome-oriented summary
-
-Assign the Pull Request to `FrancescFe` and apply the issue's primary label unless the delivery batch specifies different metadata.
-
-Pull Request and squash commit titles use:
-
-```text
-[{reference}] {Relevant sentence-case message}
-```
-
-Example:
-
-```text
-[205] Document the repository delivery workflow
-```
-
-The project uses squash and merge. Required checks must pass before merging. A Pull Request must remain unmerged when the requester asks to review it first.
-
-Before merging, re-read every acceptance criterion in the associated issue. Check the box for each criterion that the implementation and validation evidence satisfy. Leave unmet criteria unchecked, and do not merge while a required criterion remains unmet.
-
-## Completing A Milestone
-
-A milestone can be closed after:
-
-- every planned issue is closed or deliberately marked `not planned`
-- every associated Pull Request is merged
-- the milestone has no open issues
-- final formatting, unit-test, lint, and instrumented-test compilation checks pass on `main`
-- the local worktree is clean and synchronized with `origin/main`
+Instrumented tests are compiled only on the development machine. Do not start an emulator or run connected-device tasks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,15 +4,31 @@ Thank you for contributing to NumPairs. The project uses small, issue-driven cha
 
 Repository automation instructions live in [AGENTS.md](AGENTS.md). This guide presents the same workflow for human contributors.
 
-## Before Starting
+## Requesting An Issue
 
-Every change should have a focused GitHub issue. Select the appropriate template:
+Use an issue to request a focused change for a future contributor. Select the appropriate template:
 
 - [Feature request](.github/ISSUE_TEMPLATE/feature.md)
 - [Bug report](.github/ISSUE_TEMPLATE/bug.md)
 - [User story](.github/ISSUE_TEMPLATE/user-story.md)
 
-For milestone work, confirm the current milestone, Project iteration, and starting work reference before creating a branch. These are delivery-specific values and should not be copied from an earlier milestone.
+Describe the context, requested outcome, and verifiable acceptance criteria without assuming that implementation has started. Add the issue to Project 11 with Project `Status: Backlog`, not `Ready For Dev` or `In Progress`.
+
+`Ready For Dev` is reserved for refined, atomic work that maintainers or an authorized planning workflow have prepared for implementation.
+
+## Implementing An Existing Issue
+
+Contributors implement an existing issue rather than creating a duplicate. Before editing code:
+
+1. Read the complete issue and its acceptance criteria.
+2. Confirm that the work is not already assigned or in progress.
+3. Confirm the current milestone, Project iteration, and work reference.
+4. Change the issue's Project `Status` to `In Progress`.
+5. Create a focused branch from an up-to-date `main`.
+
+An issue selected from `Backlog` can move directly to `In Progress` when a contributor begins implementation. A planned issue may already be in `Ready For Dev`; it must still move to `In Progress` before work starts.
+
+Milestone, iteration, and starting work reference are delivery-specific values and should not be copied from an earlier delivery batch.
 
 Unless a delivery batch specifies otherwise, feature tasks use:
 
@@ -21,8 +37,10 @@ Unless a delivery batch specifies otherwise, feature tasks use:
 - type `Task`
 - issue fields `Priority: Medium` and `Effort: Low`
 - [NumPairs Project 11](https://github.com/orgs/CescFe/projects/11)
-- Project fields `Priority: P2` and `Size: xs`
+- Project field `Size: xs`
 - the iteration and milestone selected for the current delivery batch
+
+Project `Priority` can be `P0`, `P1`, `P2`, or `P3`. Unless the delivery batch specifies a priority, use the same Project `Priority` as the most recently worked issue. Ask when there is no previous issue from which to inherit it.
 
 Issues should be atomic: one independently reviewable outcome, one branch, and one Pull Request.
 
@@ -106,6 +124,8 @@ Example:
 ```
 
 The project uses squash and merge. Required checks must pass before merging. A Pull Request must remain unmerged when the requester asks to review it first.
+
+Before merging, re-read every acceptance criterion in the associated issue. Check the box for each criterion that the implementation and validation evidence satisfy. Leave unmet criteria unchecked, and do not merge while a required criterion remains unmet.
 
 ## Completing A Milestone
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,9 +105,6 @@ Push the issue branch and open a ready-for-review Pull Request against `main`. C
 
 - the closing issue reference
 - a concise outcome-oriented summary
-- the commands or checks used for verification
-- the work reference
-- the intended squash title
 
 Assign the Pull Request to `FrancescFe` and apply the issue's primary label unless the delivery batch specifies different metadata.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,118 @@
+# Contributing To NumPairs
+
+Thank you for contributing to NumPairs. The project uses small, issue-driven changes so that product decisions, implementation, and review remain easy to trace.
+
+Repository automation instructions live in [AGENTS.md](AGENTS.md). This guide presents the same workflow for human contributors.
+
+## Before Starting
+
+Every change should have a focused GitHub issue. Select the appropriate template:
+
+- [Feature request](.github/ISSUE_TEMPLATE/feature.md)
+- [Bug report](.github/ISSUE_TEMPLATE/bug.md)
+- [User story](.github/ISSUE_TEMPLATE/user-story.md)
+
+For milestone work, confirm the current milestone, Project iteration, and starting work reference before creating a branch. These are delivery-specific values and should not be copied from an earlier milestone.
+
+Unless a delivery batch specifies otherwise, feature tasks use:
+
+- assignee `FrancescFe`
+- label `feat`
+- type `Task`
+- issue fields `Priority: Medium` and `Effort: Low`
+- [NumPairs Project 11](https://github.com/orgs/CescFe/projects/11)
+- Project fields `Priority: P2` and `Size: xs`
+- the iteration and milestone selected for the current delivery batch
+
+Issues should be atomic: one independently reviewable outcome, one branch, and one Pull Request.
+
+## Branches And Work References
+
+Work references are sequential delivery numbers and are not GitHub issue numbers. Use the reference assigned to the task.
+
+Start from an up-to-date `main`:
+
+```bash
+git switch main
+git pull --ff-only
+git switch -c 205_document_repository_delivery_workflow
+```
+
+Branch names use:
+
+```text
+{reference}_{descriptive_snake_case_name}
+```
+
+## Commits
+
+Commit messages use:
+
+```text
+{type}({reference}): {lowercase message}
+```
+
+Allowed types are `feat`, `test`, `doc`, `ci`, `refactor`, and `chore`.
+
+Examples:
+
+```text
+feat(205): add a replay entry point
+doc(206): document the delivery workflow
+```
+
+Keep commits and branches limited to the associated issue.
+
+## Local Verification
+
+For application changes, run the relevant Android validation sequentially:
+
+```bash
+./gradlew spotlessApply testDebugUnitTest spotlessCheck compileDebugAndroidTestKotlin
+```
+
+Use `./gradlew lintDebug` for stage, milestone, and broader Android validation.
+
+Instrumented tests are compiled only. Do not start an emulator or run connected-device tasks on the development machine.
+
+For documentation-only work, check Markdown structure and links, review the diff, and run:
+
+```bash
+git diff --check
+```
+
+## Pull Requests
+
+Push the issue branch and open a ready-for-review Pull Request against `main`. Complete [the Pull Request template](.github/pull_request_template.md), including:
+
+- the closing issue reference
+- a concise outcome-oriented summary
+- the commands or checks used for verification
+- the work reference
+- the intended squash title
+
+Assign the Pull Request to `FrancescFe` and apply the issue's primary label unless the delivery batch specifies different metadata.
+
+Pull Request and squash commit titles use:
+
+```text
+[{reference}] {Relevant sentence-case message}
+```
+
+Example:
+
+```text
+[205] Document the repository delivery workflow
+```
+
+The project uses squash and merge. Required checks must pass before merging. A Pull Request must remain unmerged when the requester asks to review it first.
+
+## Completing A Milestone
+
+A milestone can be closed after:
+
+- every planned issue is closed or deliberately marked `not planned`
+- every associated Pull Request is merged
+- the milestone has no open issues
+- final formatting, unit-test, lint, and instrumented-test compilation checks pass on `main`
+- the local worktree is clean and synchronized with `origin/main`

--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ app/
 │   └── ui/
 docs/
 ├── product/
-├── technical/adr/
+├── technical/
+│   ├── adr/
+│   ├── code-quality.md
+│   └── delivery-workflow.md
 ├── game-rules.md
 └── ubiquitous-language.md
 ```
@@ -85,6 +88,8 @@ Core responsibilities:
 - Puzzle generation: [puzzle-generation.md](./docs/product/puzzle-generation.md)
 - UX decisions: `docs/product/ux-decisions.md`
 - Architectural Decision Records: `docs/technical/adr/`
+- Delivery workflow: [delivery-workflow.md](./docs/technical/delivery-workflow.md)
+- Code quality guidelines: [code-quality.md](./docs/technical/code-quality.md)
 - Game rules: `docs/game-rules.md`
 - Ubiquitous Language: `docs/ubiquitous-language.md`
 

--- a/docs/technical/code-quality.md
+++ b/docs/technical/code-quality.md
@@ -1,0 +1,106 @@
+# Code Quality Guidelines
+
+This document is the canonical technical quality guidance for NumPairs production and test code. Apply it in proportion to the change and prefer concrete improvements to ceremonial compliance.
+
+## Engineering Approach
+
+NumPairs uses DDD-inspired domain modeling, not strict Domain-Driven Design or a prescribed Clean Architecture implementation.
+
+The goal is to express game concepts, rules, identities, and state transitions clearly. Patterns such as repositories, factories, use cases, services, entities, or value objects are tools to introduce when they solve a demonstrated problem, not mandatory layers for every feature.
+
+Prioritize:
+
+1. correct game behavior and preserved invariants
+2. clear domain language and ownership
+3. simple, testable state transitions
+4. consistency with the existing codebase
+5. abstraction only when its benefit is concrete
+
+## Domain Modeling
+
+- Use the terminology defined in [the ubiquitous language](../ubiquitous-language.md) in production code, tests, issues, and technical documentation.
+- Treat [the game rules](../game-rules.md) as the behavioral source of truth. Resolve ambiguity before encoding a new rule.
+- Keep game rules and invariants in `domain` rather than duplicating them in ViewModels, routes, or Composables.
+- Keep the domain model independent from Android, Compose, persistence frameworks, `data`, `feature`, and `ui`.
+- Model identity explicitly when behavior depends on which game element was selected. Preserve the stable strip-entry identity established by [ADR-003](adr/adr-003-use-stable-strip-entry-identity.md).
+- Prefer typed states, outcomes, and violations when callers must distinguish business cases. Do not replace meaningful domain distinctions with loosely related booleans, nullable values, or display strings.
+- Use a domain service when behavior spans concepts and does not naturally belong to one model. Do not create service or use-case wrappers that only forward a call.
+- Keep invariants in one authoritative location and test them there.
+
+## Architectural Boundaries
+
+Respect the responsibilities already established in the repository:
+
+- `domain`: puzzle models, rules, assignments, validation, profiles, and generation logic
+- `data`: persistence, platform-backed state, and seed data
+- `feature`: feature coordination, presentation state, routes, and feature-specific UI
+- `ui/theme`: shared visual tokens and reusable design-system components
+- `ui/navigation`: application composition and navigation between features
+
+Dependencies should preserve these boundaries:
+
+- `domain` must remain platform-independent.
+- `data` must not depend on feature or UI code.
+- Features may coordinate domain, data, and shared UI concerns, but business rules must remain in the domain.
+- Composables must not become an alternative domain or persistence layer.
+- Platform and persistence types should be translated at their boundary instead of leaking into domain APIs.
+
+Do not reorganize packages merely to make the project resemble a generic architecture diagram. When a cross-cutting change revises an established boundary or introduces a durable architectural decision, add or update an ADR.
+
+## Clean Code
+
+- Name code after its domain responsibility rather than its implementation mechanism.
+- Keep functions, classes, and files cohesive and focused on one reason to change.
+- Prefer straightforward control flow, guard clauses, and explicit state transitions over deeply nested or implicit behavior.
+- Prefer immutable models and copy-based state changes unless mutation has a measured and documented benefit.
+- Keep public APIs as small as the supported behavior allows.
+- Extract shared code only when the abstraction has a stable meaning. Similar-looking code is not automatically the same concept.
+- Explain surprising constraints and tradeoffs in comments; do not narrate code that is already clear.
+- Remove obsolete code introduced by the current change, but avoid unrelated cleanup or speculative refactors.
+- Follow the existing formatting and naming conventions enforced by the repository tooling.
+
+## Design Patterns And Abstractions
+
+- Prefer an existing project pattern when it already fits the problem.
+- Introduce a new pattern only when it improves at least one concrete concern: domain expression, dependency ownership, variation handling, state management, or testability.
+- Use the smallest pattern that solves the problem. Avoid additional interfaces, factories, repositories, strategies, or use cases with only one trivial implementation and no boundary to protect.
+- Do not hide simple domain behavior behind generic infrastructure terminology.
+- Make a non-obvious local pattern understandable through names and focused documentation.
+- Record cross-cutting or long-lived architectural patterns in an ADR, including the alternatives and consequences.
+
+Design-pattern usage is not a quality target by itself. A simpler implementation is preferable when it remains cohesive, correctly located, and easy to test.
+
+## Kotlin And Compose
+
+- Represent closed state families with sealed types or enums when exhaustive handling prevents invalid behavior.
+- Use value types or validated construction when raw primitives cannot express an important domain constraint.
+- Keep mapping between domain and presentation state explicit and testable.
+- Let routes and ViewModels coordinate dependencies and durable state. Prefer content Composables that receive state and emit events.
+- Keep transient UI state local only when it has no domain or navigation significance.
+- Keep side effects explicit and lifecycle-aware; do not trigger durable work directly from composition.
+- Use shared theme tokens and components before adding feature-local visual constants.
+- Put user-facing text in Android resources and preserve accessibility semantics for interactive behavior.
+
+## Testing
+
+- Add or update unit tests for new domain rules, invariants, and state transitions.
+- Add a regression test for a defect when a stable automated reproduction is feasible.
+- Test presentation transformations and ViewModel behavior without requiring Android UI when possible.
+- Use Compose or navigation tests for behavior that depends on rendering, semantics, focus, or application routing.
+- Test observable behavior and domain outcomes rather than private implementation details.
+- Keep tests deterministic. Control randomness, time, persistence, and external state through explicit inputs or suitable fakes.
+- Reuse focused builders, mothers, fixtures, and robots when they make intent clearer; do not create a test abstraction that obscures the scenario.
+- Compile instrumented tests as required by [the delivery workflow](delivery-workflow.md), but do not start an emulator or connected-device task on the development machine.
+
+## Change Review
+
+Before considering a code change complete, confirm:
+
+- behavior matches the issue and product sources of truth
+- domain terminology and invariants remain consistent
+- dependencies respect the repository boundaries
+- new abstractions and patterns have a concrete justification
+- tests cover the changed behavior at the lowest useful level
+- user-facing behavior includes localization and accessibility where applicable
+- architectural decisions and affected documentation are updated
+- unrelated refactors are excluded from the change

--- a/docs/technical/code-quality.md
+++ b/docs/technical/code-quality.md
@@ -55,7 +55,7 @@ Do not reorganize packages merely to make the project resemble a generic archite
 - Prefer immutable models and copy-based state changes unless mutation has a measured and documented benefit.
 - Keep public APIs as small as the supported behavior allows.
 - Extract shared code only when the abstraction has a stable meaning. Similar-looking code is not automatically the same concept.
-- Explain surprising constraints and tradeoffs in comments; do not narrate code that is already clear.
+- Comments are strongly discouraged. If you need a comment, you probably need a refactor. Explain surprising constraints or tradeoffs in comments.
 - Remove obsolete code introduced by the current change, but avoid unrelated cleanup or speculative refactors.
 - Follow the existing formatting and naming conventions enforced by the repository tooling.
 
@@ -90,17 +90,3 @@ Design-pattern usage is not a quality target by itself. A simpler implementation
 - Test observable behavior and domain outcomes rather than private implementation details.
 - Keep tests deterministic. Control randomness, time, persistence, and external state through explicit inputs or suitable fakes.
 - Reuse focused builders, mothers, fixtures, and robots when they make intent clearer; do not create a test abstraction that obscures the scenario.
-- Compile instrumented tests as required by [the delivery workflow](delivery-workflow.md), but do not start an emulator or connected-device task on the development machine.
-
-## Change Review
-
-Before considering a code change complete, confirm:
-
-- behavior matches the issue and product sources of truth
-- domain terminology and invariants remain consistent
-- dependencies respect the repository boundaries
-- new abstractions and patterns have a concrete justification
-- tests cover the changed behavior at the lowest useful level
-- user-facing behavior includes localization and accessibility where applicable
-- architectural decisions and affected documentation are updated
-- unrelated refactors are excluded from the change

--- a/docs/technical/delivery-workflow.md
+++ b/docs/technical/delivery-workflow.md
@@ -1,0 +1,190 @@
+# Repository Delivery Workflow
+
+This is the canonical workflow for planning, implementing, validating, and delivering changes to NumPairs. User instructions for a specific task take precedence over the defaults below.
+
+## Sources Of Truth
+
+- Use [the feature issue template](../../.github/ISSUE_TEMPLATE/feature.md) for feature and task issues.
+- Use [the bug issue template](../../.github/ISSUE_TEMPLATE/bug.md) for defects.
+- Use [the user-story template](../../.github/ISSUE_TEMPLATE/user-story.md) when the requested unit of work is a user story.
+- Use [the Pull Request template](../../.github/pull_request_template.md) for every Pull Request.
+
+Do not duplicate complete templates in issues or documentation. Follow the repository template and replace its prompts with task-specific content.
+
+## Delivery Context
+
+Treat these values as delivery-specific inputs:
+
+- milestone URL or number
+- GitHub Project URL
+- Project iteration
+- starting work reference
+- labels or other metadata that differ from the defaults
+
+Obtain them from the user or the current task. Do not carry a milestone, iteration, or starting reference from a previous delivery batch without verification.
+
+Unless the task specifies otherwise, use:
+
+- assignee: `FrancescFe`
+- label for feature work: `feat`
+- issue type: `Task`
+- issue field `Priority`: `Medium`
+- issue field `Effort`: `Low`
+- GitHub Project: `https://github.com/orgs/CescFe/projects/11`
+- Project field `Size`: `xs`
+
+Use the iteration and milestone specified for the current delivery batch. Do not attach new work to a closed milestone unless the user explicitly requests it.
+
+Project `Priority` is contextual and ranges from `P0` to `P3`. Unless the user specifies a value, inspect the most recently worked issue and reuse its Project `Priority`. Do not treat `P2` or any other priority as a permanent default. If there is no previous issue from which to inherit priority, ask for it.
+
+Set Project `Status` according to how the issue enters the workflow:
+
+- `Backlog` when a user is requesting future work and is not starting implementation.
+- `Ready For Dev` when an authorized planning task creates an atomic, refined issue that is ready to be implemented.
+- `In Progress` immediately before implementation begins on an existing issue.
+
+Resolve GitHub node IDs, field IDs, option IDs, and iteration IDs through the GitHub API. Treat these identifiers as opaque and do not store previously observed values as permanent repository configuration.
+
+## Atomic Issue Planning
+
+For milestone delivery:
+
+1. Read the relevant PRD or product reference completely.
+2. Inspect the implemented baseline before proposing work.
+3. Divide the remaining scope into independently reviewable, dependency-ordered issues.
+4. Give each issue one observable outcome and one Pull Request.
+5. Write each issue in English using the selected issue template.
+6. Apply the required assignee, label, type, issue fields, Project fields, iteration, and milestone.
+7. Set Project `Status` to `Ready For Dev` for each planned issue.
+
+Do not combine unrelated product behavior, refactors, or documentation in one issue merely to reduce the number of Pull Requests.
+
+## Work References And Branches
+
+Work references are sequential numbers independent from GitHub issue numbers.
+
+Use the starting reference provided by the user. If none is provided, inspect recent merged squash commits and remote branches, then use the next available reference. If the sequence is ambiguous, ask before creating a branch.
+
+Create every implementation branch from an up-to-date `main`.
+
+Branch format:
+
+```text
+{reference}_{descriptive_snake_case_name}
+```
+
+Example:
+
+```text
+205_document_repository_delivery_workflow
+```
+
+Never implement multiple atomic issues in the same branch.
+
+## Commit Conventions
+
+Commit format:
+
+```text
+{type}({reference}): {lowercase message}
+```
+
+Allowed types:
+
+- `feat`
+- `test`
+- `doc`
+- `ci`
+- `refactor`
+- `chore`
+
+Examples:
+
+```text
+feat(205): persist onboarding progress
+doc(206): document the release workflow
+```
+
+Keep the branch focused and prefer one meaningful implementation commit when that accurately represents the work.
+
+## Pull Request Conventions
+
+Pull Requests must:
+
+- target `main`
+- be ready for review rather than draft unless the user requests a draft
+- use the repository Pull Request template
+- link the issue with `Resolves #{issue_number}`
+- be assigned to `FrancescFe` unless specified otherwise
+- use the issue's primary label, normally `feat` for feature work
+- contain only the associated issue's scope
+
+Pull Request title format:
+
+```text
+[{reference}] {Relevant sentence-case message}
+```
+
+When a merge is authorized, use squash and merge with this squash commit title:
+
+```text
+[{reference}] {Relevant sentence-case message}
+```
+
+Do not merge while a required check is pending, unexpectedly skipped, cancelled, or failing. Merge only when the user requested an end-to-end merge cycle. If the user asks to review the Pull Request first or explicitly says not to merge, stop after creating and reporting the Pull Request.
+
+Before any authorized merge:
+
+1. Re-read the associated issue's acceptance criteria.
+2. Verify every criterion against the implemented change and available validation evidence.
+3. Mark each fulfilled acceptance-criteria checkbox as complete in the issue.
+4. Leave unmet criteria unchecked and do not merge while a required criterion remains unmet.
+
+Do not mark criteria complete merely because implementation has ended or checks are green.
+
+## Implementation Cycle
+
+For each authorized issue:
+
+1. Set the issue's Project `Status` to `In Progress`.
+2. Update local `main` from `origin/main`.
+3. Create the issue branch using the assigned work reference.
+4. Implement only the issue acceptance criteria.
+5. Validate in proportion to the change.
+6. Review `git diff` and `git diff --check`.
+7. Commit using the required convention.
+8. Push the branch.
+9. Open and configure the Pull Request.
+10. Wait for required GitHub checks when a merge is part of the requested cycle.
+11. Review the associated issue's acceptance criteria and mark only fulfilled criteria complete.
+12. If checks pass, every required criterion is fulfilled, and merge is authorized, squash and merge with the required title.
+13. Update local `main` before starting the next issue.
+
+Do not start dependent implementation from an unmerged branch when the requested workflow requires sequential integration into `main`.
+
+## Android Validation
+
+For application changes, run the relevant tasks sequentially:
+
+```text
+./gradlew spotlessApply testDebugUnitTest spotlessCheck compileDebugAndroidTestKotlin
+```
+
+Run `lintDebug` when completing a stage or milestone and for changes with broader Android risk.
+
+Instrumented tests must only be compiled. Do not start an emulator or run connected-device tasks because doing so can make the development machine unusable.
+
+For documentation-only changes, validate Markdown structure, relative links, consistency, and `git diff --check`. Android build tasks are not required unless the documentation change affects build configuration or executable examples.
+
+## Milestone Completion
+
+Before closing a milestone:
+
+- confirm every planned issue is closed or deliberately marked `not planned`
+- confirm every associated Pull Request is merged
+- confirm the milestone has zero open issues
+- update local `main` from `origin/main`
+- run final formatting, unit-test, lint, and instrumented-test compilation checks
+- confirm the worktree is clean and synchronized with `origin/main`
+
+Close the milestone only when the user authorized completion and all required verification has passed.


### PR DESCRIPTION
## Related Issue

Resolves #432

## Summary

- Keep `AGENTS.md` concise by routing agents to canonical delivery and code-quality guidance.
- Move the complete issue-to-merge workflow to `docs/technical/delivery-workflow.md`.
- Add project-specific DDD-inspired domain modeling, architectural, Clean Code, design-pattern, Kotlin, Compose, and testing guidance.
- Keep contributor documentation, README discovery, and the minimal Pull Request template consistent with the canonical guidance.
