### PR TITLE
[207] Define generated session snapshots

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/data/generated/session/GeneratedSessionSnapshot.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/generated/session/GeneratedSessionSnapshot.kt
@@ -1,0 +1,70 @@
+package org.cescfe.numpairs.data.generated.session
+
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+
+const val GENERATED_SESSION_SCHEMA_VERSION: Int = 1
+
+@JvmInline
+value class GeneratedSessionId(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "Generated session id must not be blank."
+        }
+    }
+}
+
+data class GeneratedSessionSnapshot(
+    val schemaVersion: Int = GENERATED_SESSION_SCHEMA_VERSION,
+    val sessionId: GeneratedSessionId,
+    val modeId: String,
+    val profileId: String,
+    val seed: Int,
+    val initialPuzzle: Puzzle,
+    val currentPuzzle: Puzzle
+) {
+    init {
+        require(schemaVersion == GENERATED_SESSION_SCHEMA_VERSION) {
+            "Generated session snapshot schema version is unsupported."
+        }
+        require(modeId.isNotBlank()) {
+            "Generated session mode id must not be blank."
+        }
+        require(profileId.isNotBlank()) {
+            "Generated session profile id must not be blank."
+        }
+        require(
+            initialPuzzle.board.tiles.map { tile -> tile.result } ==
+                currentPuzzle.board.tiles.map { tile -> tile.result }
+        ) {
+            "Generated session puzzle results must remain unchanged."
+        }
+        require(
+            initialPuzzle.strip.entries.map { entry -> entry.id }.toSet() ==
+                currentPuzzle.strip.entries.map { entry -> entry.id }.toSet()
+        ) {
+            "Generated session strip entry identities must remain unchanged."
+        }
+
+        val currentItemsByEntryId = currentPuzzle.strip.entries.associate { entry ->
+            entry.id to entry.item
+        }
+        initialPuzzle.strip.entries.forEach { initialEntry ->
+            val initialItem = initialEntry.item
+            val currentItem = currentItemsByEntryId.getValue(initialEntry.id)
+            when (initialItem) {
+                StripItem.Hidden -> require(currentItem !is StripItem.Known) {
+                    "Hidden generated session strip entries cannot become known entries."
+                }
+
+                is StripItem.Known -> require(currentItem == initialItem) {
+                    "Known generated session strip entries must remain unchanged."
+                }
+
+                is StripItem.PlayerEntered -> error(
+                    "Initial generated session strip entries cannot be player-entered."
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/generated/session/GeneratedSessionSnapshotCodec.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/generated/session/GeneratedSessionSnapshotCodec.kt
@@ -1,0 +1,220 @@
+package org.cescfe.numpairs.data.generated.session
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.IOException
+import org.cescfe.numpairs.domain.puzzle.model.Board
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.Strip
+import org.cescfe.numpairs.domain.puzzle.model.StripEntry
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.cescfe.numpairs.domain.puzzle.model.Tile
+
+sealed interface GeneratedSessionSnapshotDecodingResult {
+    data class Decoded(val snapshot: GeneratedSessionSnapshot) : GeneratedSessionSnapshotDecodingResult
+
+    data class UnsupportedVersion(val schemaVersion: Int) : GeneratedSessionSnapshotDecodingResult
+
+    data object InvalidData : GeneratedSessionSnapshotDecodingResult
+}
+
+class GeneratedSessionSnapshotCodec {
+    fun encode(snapshot: GeneratedSessionSnapshot): ByteArray {
+        require(snapshot.schemaVersion == GENERATED_SESSION_SCHEMA_VERSION) {
+            "Only the current generated session schema can be encoded."
+        }
+
+        return ByteArrayOutputStream().use { bytes ->
+            DataOutputStream(bytes).use { output ->
+                output.writeInt(FILE_MAGIC)
+                output.writeInt(snapshot.schemaVersion)
+                output.writeUTF(snapshot.sessionId.value)
+                output.writeUTF(snapshot.modeId)
+                output.writeUTF(snapshot.profileId)
+                output.writeInt(snapshot.seed)
+                output.writePuzzle(snapshot.initialPuzzle)
+                output.writePuzzle(snapshot.currentPuzzle)
+            }
+            bytes.toByteArray()
+        }
+    }
+
+    fun decode(bytes: ByteArray): GeneratedSessionSnapshotDecodingResult = try {
+        DataInputStream(ByteArrayInputStream(bytes)).use { input ->
+            if (input.readInt() != FILE_MAGIC) {
+                return GeneratedSessionSnapshotDecodingResult.InvalidData
+            }
+
+            val schemaVersion = input.readInt()
+            if (schemaVersion != GENERATED_SESSION_SCHEMA_VERSION) {
+                return GeneratedSessionSnapshotDecodingResult.UnsupportedVersion(schemaVersion)
+            }
+
+            val snapshot = GeneratedSessionSnapshot(
+                schemaVersion = schemaVersion,
+                sessionId = GeneratedSessionId(input.readUTF()),
+                modeId = input.readUTF(),
+                profileId = input.readUTF(),
+                seed = input.readInt(),
+                initialPuzzle = input.readPuzzle(),
+                currentPuzzle = input.readPuzzle()
+            )
+
+            if (input.available() != 0) {
+                GeneratedSessionSnapshotDecodingResult.InvalidData
+            } else {
+                GeneratedSessionSnapshotDecodingResult.Decoded(snapshot)
+            }
+        }
+    } catch (_: IOException) {
+        GeneratedSessionSnapshotDecodingResult.InvalidData
+    } catch (_: IllegalArgumentException) {
+        GeneratedSessionSnapshotDecodingResult.InvalidData
+    } catch (_: IllegalStateException) {
+        GeneratedSessionSnapshotDecodingResult.InvalidData
+    }
+}
+
+private fun DataOutputStream.writePuzzle(puzzle: Puzzle) {
+    writeInt(puzzle.board.tiles.size)
+    puzzle.board.tiles.forEach(::writeTile)
+    writeInt(puzzle.strip.entries.size)
+    puzzle.strip.entries.forEach(::writeStripEntry)
+}
+
+private fun DataOutputStream.writeTile(tile: Tile) {
+    writeOperand(tile.expression.leftOperand)
+    writeOperator(tile.expression.operator)
+    writeOperand(tile.expression.rightOperand)
+    writeInt(tile.result)
+}
+
+private fun DataOutputStream.writeOperand(operand: Expression.Operand) {
+    when (operand) {
+        Expression.Operand.Hidden -> writeByte(OPERAND_HIDDEN)
+        is Expression.Operand.Known -> {
+            writeByte(OPERAND_KNOWN)
+            writeInt(operand.value)
+            writeBoolean(operand.stripEntryId != null)
+            operand.stripEntryId?.let(::writeInt)
+        }
+    }
+}
+
+private fun DataOutputStream.writeOperator(operator: Operator) {
+    val encodedOperator = when (operator) {
+        Operator.Hidden -> OPERATOR_HIDDEN
+        Operator.Addition -> OPERATOR_ADDITION
+        Operator.Multiplication -> OPERATOR_MULTIPLICATION
+    }
+    writeByte(encodedOperator)
+}
+
+private fun DataOutputStream.writeStripEntry(entry: StripEntry) {
+    writeInt(entry.id)
+    when (val item = entry.item) {
+        StripItem.Hidden -> writeByte(STRIP_ITEM_HIDDEN)
+        is StripItem.Known -> {
+            writeByte(STRIP_ITEM_KNOWN)
+            writeInt(item.value)
+        }
+
+        is StripItem.PlayerEntered -> {
+            writeByte(STRIP_ITEM_PLAYER_ENTERED)
+            writeInt(item.value)
+        }
+    }
+}
+
+private fun DataInputStream.readPuzzle(): Puzzle {
+    val tileCount = readPuzzleElementCount()
+    val board = Board(
+        tiles = List(tileCount) {
+            readTile()
+        }
+    )
+    val stripEntryCount = readPuzzleElementCount()
+    val strip = Strip.fromEntries(
+        entries = List(stripEntryCount) {
+            readStripEntry()
+        }
+    )
+
+    return Puzzle(
+        board = board,
+        strip = strip
+    )
+}
+
+private fun DataInputStream.readTile(): Tile = Tile(
+    expression = Expression(
+        leftOperand = readOperand(),
+        operator = readOperator(),
+        rightOperand = readOperand()
+    ),
+    result = readInt()
+)
+
+private fun DataInputStream.readOperand(): Expression.Operand = when (readUnsignedByte()) {
+    OPERAND_HIDDEN -> Expression.Operand.Hidden
+    OPERAND_KNOWN -> {
+        val value = readInt()
+        val stripEntryId = if (readBoolean()) {
+            readInt()
+        } else {
+            null
+        }
+        Expression.Operand.Known(
+            value = value,
+            stripEntryId = stripEntryId
+        )
+    }
+
+    else -> throw InvalidGeneratedSessionData()
+}
+
+private fun DataInputStream.readOperator(): Operator = when (readUnsignedByte()) {
+    OPERATOR_HIDDEN -> Operator.Hidden
+    OPERATOR_ADDITION -> Operator.ADDITION
+    OPERATOR_MULTIPLICATION -> Operator.MULTIPLICATION
+    else -> throw InvalidGeneratedSessionData()
+}
+
+private fun DataInputStream.readStripEntry(): StripEntry {
+    val id = readInt()
+    val item = when (readUnsignedByte()) {
+        STRIP_ITEM_HIDDEN -> StripItem.Hidden
+        STRIP_ITEM_KNOWN -> StripItem.Known(readInt())
+        STRIP_ITEM_PLAYER_ENTERED -> StripItem.PlayerEntered(readInt())
+        else -> throw InvalidGeneratedSessionData()
+    }
+
+    return StripEntry(
+        id = id,
+        item = item
+    )
+}
+
+private fun DataInputStream.readPuzzleElementCount(): Int = readInt().also { count ->
+    if (count !in MIN_PUZZLE_ELEMENT_COUNT..MAX_PUZZLE_ELEMENT_COUNT || count % 2 != 0) {
+        throw InvalidGeneratedSessionData()
+    }
+}
+
+private class InvalidGeneratedSessionData : IllegalArgumentException()
+
+private const val FILE_MAGIC = 0x4E505331
+private const val MIN_PUZZLE_ELEMENT_COUNT = 2
+private const val MAX_PUZZLE_ELEMENT_COUNT = 128
+private const val OPERAND_HIDDEN = 0
+private const val OPERAND_KNOWN = 1
+private const val OPERATOR_HIDDEN = 0
+private const val OPERATOR_ADDITION = 1
+private const val OPERATOR_MULTIPLICATION = 2
+private const val STRIP_ITEM_HIDDEN = 0
+private const val STRIP_ITEM_KNOWN = 1
+private const val STRIP_ITEM_PLAYER_ENTERED = 2

--- a/app/src/test/java/org/cescfe/numpairs/data/generated/session/GeneratedSessionSnapshotCodecTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/generated/session/GeneratedSessionSnapshotCodecTest.kt
@@ -1,0 +1,196 @@
+package org.cescfe.numpairs.data.generated.session
+
+import java.nio.ByteBuffer
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerator
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPuzzleGenerationRequest
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfiles
+import org.cescfe.numpairs.domain.puzzle.model.Board
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.Strip
+import org.cescfe.numpairs.domain.puzzle.model.StripEntry
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.cescfe.numpairs.domain.puzzle.model.Tile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GeneratedSessionSnapshotCodecTest {
+    private val codec = GeneratedSessionSnapshotCodec()
+
+    @Test
+    fun `round trips representative four pairs session`() {
+        val puzzle = generatedInitialPuzzle(
+            profile = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW,
+            seed = 207
+        )
+        val snapshot = snapshot(
+            modeId = "four-pairs",
+            profileId = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW.id.value,
+            seed = 207,
+            initialPuzzle = puzzle,
+            currentPuzzle = puzzle
+        )
+
+        assertEquals(
+            GeneratedSessionSnapshotDecodingResult.Decoded(snapshot),
+            codec.decode(codec.encode(snapshot))
+        )
+    }
+
+    @Test
+    fun `round trips representative eight pairs session`() {
+        val puzzle = generatedInitialPuzzle(
+            profile = GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM,
+            seed = 208
+        )
+        val snapshot = snapshot(
+            modeId = "eight-pairs",
+            profileId = GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM.id.value,
+            seed = 208,
+            initialPuzzle = puzzle,
+            currentPuzzle = puzzle
+        )
+
+        assertEquals(
+            GeneratedSessionSnapshotDecodingResult.Decoded(snapshot),
+            codec.decode(codec.encode(snapshot))
+        )
+    }
+
+    @Test
+    fun `preserves repeated values item origins and stable operand identities`() {
+        val initialPuzzle = repeatedValuePuzzle(
+            strip = Strip.fromEntries(
+                entries = listOf(
+                    StripEntry(id = 0, item = StripItem.Known(2)),
+                    StripEntry(id = 1, item = StripItem.Hidden),
+                    StripEntry(id = 2, item = StripItem.Known(3)),
+                    StripEntry(id = 3, item = StripItem.Hidden)
+                )
+            ),
+            firstExpression = hiddenExpression()
+        )
+        val currentPuzzle = repeatedValuePuzzle(
+            strip = Strip.fromEntries(
+                entries = listOf(
+                    StripEntry(id = 0, item = StripItem.Known(2)),
+                    StripEntry(id = 1, item = StripItem.PlayerEntered(2)),
+                    StripEntry(id = 2, item = StripItem.Known(3)),
+                    StripEntry(id = 3, item = StripItem.PlayerEntered(4))
+                )
+            ),
+            firstExpression = Expression(
+                leftOperand = Expression.Operand.Known(value = 2, stripEntryId = 0),
+                operator = Operator.ADDITION,
+                rightOperand = Expression.Operand.Known(value = 2, stripEntryId = 1)
+            )
+        )
+        val snapshot = snapshot(
+            initialPuzzle = initialPuzzle,
+            currentPuzzle = currentPuzzle
+        )
+
+        val decoded = codec.decode(codec.encode(snapshot))
+
+        assertEquals(GeneratedSessionSnapshotDecodingResult.Decoded(snapshot), decoded)
+    }
+
+    @Test
+    fun `reports unsupported schema version`() {
+        val encoded = codec.encode(snapshot())
+        ByteBuffer.wrap(encoded).putInt(Int.SIZE_BYTES, GENERATED_SESSION_SCHEMA_VERSION + 1)
+
+        assertEquals(
+            GeneratedSessionSnapshotDecodingResult.UnsupportedVersion(
+                GENERATED_SESSION_SCHEMA_VERSION + 1
+            ),
+            codec.decode(encoded)
+        )
+    }
+
+    @Test
+    fun `reports malformed and invariant breaking data`() {
+        assertEquals(
+            GeneratedSessionSnapshotDecodingResult.InvalidData,
+            codec.decode(byteArrayOf(1, 2, 3))
+        )
+
+        val encoded = codec.encode(snapshot())
+        val truncated = encoded.copyOf(encoded.size - 1)
+        assertEquals(
+            GeneratedSessionSnapshotDecodingResult.InvalidData,
+            codec.decode(truncated)
+        )
+
+        val trailingData = encoded + 1
+        assertEquals(
+            GeneratedSessionSnapshotDecodingResult.InvalidData,
+            codec.decode(trailingData)
+        )
+    }
+
+    @Test
+    fun `encoding is deterministic`() {
+        val snapshot = snapshot()
+
+        assertTrue(codec.encode(snapshot).contentEquals(codec.encode(snapshot)))
+    }
+
+    private fun snapshot(
+        modeId: String = "four-pairs",
+        profileId: String = "4-pairs-low",
+        seed: Int = 207,
+        initialPuzzle: Puzzle = repeatedValuePuzzle(),
+        currentPuzzle: Puzzle = initialPuzzle
+    ): GeneratedSessionSnapshot = GeneratedSessionSnapshot(
+        sessionId = GeneratedSessionId("session-207"),
+        modeId = modeId,
+        profileId = profileId,
+        seed = seed,
+        initialPuzzle = initialPuzzle,
+        currentPuzzle = currentPuzzle
+    )
+
+    private fun generatedInitialPuzzle(profile: GeneratedPuzzleProfile, seed: Int): Puzzle {
+        val outcome = GeneratedPairsPuzzleGenerator(profile = profile).generate(
+            request = GeneratedPuzzleGenerationRequest(
+                profile = profile,
+                seed = seed
+            )
+        )
+
+        return (outcome as GeneratedPairsPuzzleGenerationOutcome.Generated).puzzle.initialPuzzle
+    }
+
+    private fun repeatedValuePuzzle(
+        strip: Strip = Strip.fromEntries(
+            entries = listOf(
+                StripEntry(id = 0, item = StripItem.Known(2)),
+                StripEntry(id = 1, item = StripItem.Hidden),
+                StripEntry(id = 2, item = StripItem.Known(3)),
+                StripEntry(id = 3, item = StripItem.Hidden)
+            )
+        ),
+        firstExpression: Expression = hiddenExpression()
+    ): Puzzle = Puzzle(
+        board = Board(
+            tiles = listOf(
+                Tile(expression = firstExpression, result = 4),
+                Tile(expression = hiddenExpression(), result = 4),
+                Tile(expression = hiddenExpression(), result = 5),
+                Tile(expression = hiddenExpression(), result = 6)
+            )
+        ),
+        strip = strip
+    )
+
+    private fun hiddenExpression(): Expression = Expression(
+        leftOperand = Expression.Operand.Hidden,
+        operator = Operator.Hidden,
+        rightOperand = Expression.Operand.Hidden
+    )
+}


### PR DESCRIPTION
## Related Issue

Resolves #436

## Summary

- Add a versioned single-session snapshot with stable session, mode, profile, seed, initial-puzzle, and current-puzzle state.
- Add deterministic binary encoding with typed unsupported-version and invalid-data outcomes.
- Cover 4 Pairs, 8 Pairs, repeated values, stable operand identities, malformed data, and deterministic output.
