### PR TITLE
[208] Persist one generated session

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/data/generated/session/DataStoreGeneratedSessionRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/generated/session/DataStoreGeneratedSessionRepository.kt
@@ -1,0 +1,81 @@
+package org.cescfe.numpairs.data.generated.session
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.byteArrayPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import java.io.IOException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+
+class DataStoreGeneratedSessionRepository(
+    private val dataStore: DataStore<Preferences>,
+    private val codec: GeneratedSessionSnapshotCodec = GeneratedSessionSnapshotCodec()
+) : GeneratedSessionRepository {
+    override val session: Flow<GeneratedSessionSnapshot?> = dataStore.data
+        .catch { throwable ->
+            if (throwable is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw throwable
+            }
+        }
+        .map { preferences ->
+            preferences[PreferenceKeys.SNAPSHOT]
+                ?.let(codec::decode)
+                ?.decodedSnapshotOrNull()
+        }
+
+    override suspend fun replace(snapshot: GeneratedSessionSnapshot) {
+        dataStore.edit { preferences ->
+            preferences[PreferenceKeys.SNAPSHOT] = codec.encode(snapshot)
+        }
+    }
+
+    override suspend fun updateCurrentPuzzle(expectedSessionId: GeneratedSessionId, puzzle: Puzzle): Boolean {
+        var wasUpdated = false
+        dataStore.edit { preferences ->
+            val snapshot = preferences.currentSnapshotOrNull()
+            if (snapshot?.sessionId == expectedSessionId) {
+                preferences[PreferenceKeys.SNAPSHOT] = codec.encode(
+                    snapshot.copy(currentPuzzle = puzzle)
+                )
+                wasUpdated = true
+            }
+        }
+
+        return wasUpdated
+    }
+
+    override suspend fun clear(expectedSessionId: GeneratedSessionId): Boolean {
+        var wasCleared = false
+        dataStore.edit { preferences ->
+            val snapshot = preferences.currentSnapshotOrNull()
+            if (snapshot?.sessionId == expectedSessionId) {
+                preferences.remove(PreferenceKeys.SNAPSHOT)
+                wasCleared = true
+            }
+        }
+
+        return wasCleared
+    }
+
+    private fun Preferences.currentSnapshotOrNull(): GeneratedSessionSnapshot? = this[PreferenceKeys.SNAPSHOT]
+        ?.let(codec::decode)
+        ?.decodedSnapshotOrNull()
+
+    private object PreferenceKeys {
+        val SNAPSHOT = byteArrayPreferencesKey(GENERATED_SESSION_SNAPSHOT_PREFERENCE_KEY_NAME)
+    }
+}
+
+private fun GeneratedSessionSnapshotDecodingResult.decodedSnapshotOrNull(): GeneratedSessionSnapshot? = when (this) {
+    is GeneratedSessionSnapshotDecodingResult.Decoded -> snapshot
+    is GeneratedSessionSnapshotDecodingResult.UnsupportedVersion,
+    GeneratedSessionSnapshotDecodingResult.InvalidData -> null
+}
+
+internal const val GENERATED_SESSION_SNAPSHOT_PREFERENCE_KEY_NAME = "generated_session_snapshot"

--- a/app/src/main/java/org/cescfe/numpairs/data/generated/session/GeneratedSessionRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/generated/session/GeneratedSessionRepository.kt
@@ -1,0 +1,14 @@
+package org.cescfe.numpairs.data.generated.session
+
+import kotlinx.coroutines.flow.Flow
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+
+interface GeneratedSessionRepository {
+    val session: Flow<GeneratedSessionSnapshot?>
+
+    suspend fun replace(snapshot: GeneratedSessionSnapshot)
+
+    suspend fun updateCurrentPuzzle(expectedSessionId: GeneratedSessionId, puzzle: Puzzle): Boolean
+
+    suspend fun clear(expectedSessionId: GeneratedSessionId): Boolean
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/generated/session/GeneratedSessionRepositoryFactory.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/generated/session/GeneratedSessionRepositoryFactory.kt
@@ -1,0 +1,21 @@
+package org.cescfe.numpairs.data.generated.session
+
+import android.content.Context
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStore
+
+fun createGeneratedSessionRepository(context: Context): GeneratedSessionRepository {
+    val applicationContext = context.applicationContext
+
+    return DataStoreGeneratedSessionRepository(applicationContext.generatedSessionDataStore)
+}
+
+private const val GENERATED_SESSION_DATA_STORE_NAME = "generated_session"
+
+private val Context.generatedSessionDataStore by preferencesDataStore(
+    name = GENERATED_SESSION_DATA_STORE_NAME,
+    corruptionHandler = ReplaceFileCorruptionHandler {
+        emptyPreferences()
+    }
+)

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -9,6 +9,9 @@
     <exclude
         domain="file"
         path="datastore/onboarding.preferences_pb" />
+    <exclude
+        domain="file"
+        path="datastore/generated_session.preferences_pb" />
     <!--
    <include domain="sharedpref" path="."/>
    <exclude domain="sharedpref" path="device.xml"/>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -8,6 +8,9 @@
         <exclude
             domain="file"
             path="datastore/onboarding.preferences_pb" />
+        <exclude
+            domain="file"
+            path="datastore/generated_session.preferences_pb" />
         <!-- TODO: Use <include> and <exclude> to control what is backed up.
         <include .../>
         <exclude .../>
@@ -17,5 +20,8 @@
         <exclude
             domain="file"
             path="datastore/onboarding.preferences_pb" />
+        <exclude
+            domain="file"
+            path="datastore/generated_session.preferences_pb" />
     </device-transfer>
 </data-extraction-rules>

--- a/app/src/test/java/org/cescfe/numpairs/data/generated/session/DataStoreGeneratedSessionRepositoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/generated/session/DataStoreGeneratedSessionRepositoryTest.kt
@@ -1,0 +1,188 @@
+package org.cescfe.numpairs.data.generated.session
+
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.byteArrayPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import java.io.File
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DataStoreGeneratedSessionRepositoryTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val dataStoreJobs = mutableListOf<Job>()
+
+    @After
+    fun tearDown() {
+        dataStoreJobs.forEach(Job::cancel)
+    }
+
+    @Test
+    fun `session is empty before a snapshot is stored`() = runBlocking {
+        val fixture = createRepository()
+
+        assertNull(fixture.repository.session.first())
+    }
+
+    @Test
+    fun `replaces the single session atomically`() = runBlocking {
+        val fixture = createRepository()
+        val firstSnapshot = snapshot(sessionId = "first")
+        val replacement = snapshot(sessionId = "replacement", modeId = "eight-pairs")
+
+        fixture.repository.replace(firstSnapshot)
+        fixture.repository.replace(replacement)
+
+        assertEquals(replacement, fixture.repository.session.first())
+    }
+
+    @Test
+    fun `updates the current puzzle for the owning session`() = runBlocking {
+        val fixture = createRepository()
+        val snapshot = snapshot()
+        val updatedPuzzle = updatedPuzzle()
+        fixture.repository.replace(snapshot)
+
+        val wasUpdated = fixture.repository.updateCurrentPuzzle(
+            expectedSessionId = snapshot.sessionId,
+            puzzle = updatedPuzzle
+        )
+
+        assertTrue(wasUpdated)
+        assertEquals(
+            snapshot.copy(currentPuzzle = updatedPuzzle),
+            fixture.repository.session.first()
+        )
+    }
+
+    @Test
+    fun `stale update cannot overwrite a replacement session`() = runBlocking {
+        val fixture = createRepository()
+        val staleSnapshot = snapshot(sessionId = "stale")
+        val replacement = snapshot(sessionId = "replacement")
+        fixture.repository.replace(staleSnapshot)
+        fixture.repository.replace(replacement)
+
+        val wasUpdated = fixture.repository.updateCurrentPuzzle(
+            expectedSessionId = staleSnapshot.sessionId,
+            puzzle = updatedPuzzle()
+        )
+
+        assertFalse(wasUpdated)
+        assertEquals(replacement, fixture.repository.session.first())
+    }
+
+    @Test
+    fun `clear only removes the owning session`() = runBlocking {
+        val fixture = createRepository()
+        val snapshot = snapshot()
+        fixture.repository.replace(snapshot)
+
+        assertFalse(fixture.repository.clear(GeneratedSessionId("stale")))
+        assertEquals(snapshot, fixture.repository.session.first())
+        assertTrue(fixture.repository.clear(snapshot.sessionId))
+        assertNull(fixture.repository.session.first())
+    }
+
+    @Test
+    fun `session persists across repository and data store recreation`() = runBlocking {
+        val dataStoreFile = createDataStoreFile()
+        val snapshot = snapshot()
+        val firstFixture = createRepository(dataStoreFile)
+        firstFixture.repository.replace(snapshot)
+        firstFixture.close()
+
+        val secondFixture = createRepository(dataStoreFile)
+
+        assertEquals(snapshot, secondFixture.repository.session.first())
+    }
+
+    @Test
+    fun `invalid encoded session recovers as empty`() = runBlocking {
+        val fixture = createRepository()
+        fixture.dataStore.edit { preferences ->
+            preferences[byteArrayPreferencesKey(GENERATED_SESSION_SNAPSHOT_PREFERENCE_KEY_NAME)] =
+                byteArrayOf(1, 2, 3)
+        }
+
+        assertNull(fixture.repository.session.first())
+
+        val replacement = snapshot()
+        fixture.repository.replace(replacement)
+        assertEquals(replacement, fixture.repository.session.first())
+    }
+
+    private fun createRepository(dataStoreFile: File = createDataStoreFile()): RepositoryFixture {
+        val job = SupervisorJob()
+        dataStoreJobs += job
+        val dataStore = PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler {
+                emptyPreferences()
+            },
+            scope = CoroutineScope(job + Dispatchers.IO),
+            produceFile = { dataStoreFile }
+        )
+
+        return RepositoryFixture(
+            repository = DataStoreGeneratedSessionRepository(dataStore),
+            dataStore = dataStore,
+            job = job
+        )
+    }
+
+    private fun createDataStoreFile(): File = File(
+        temporaryFolder.root,
+        "${UUID.randomUUID()}.preferences_pb"
+    )
+
+    private fun snapshot(sessionId: String = "session-208", modeId: String = "four-pairs"): GeneratedSessionSnapshot =
+        GeneratedSessionSnapshot(
+            sessionId = GeneratedSessionId(sessionId),
+            modeId = modeId,
+            profileId = if (modeId == "four-pairs") {
+                "4-pairs-low"
+            } else {
+                "8-pairs-medium"
+            },
+            seed = 208,
+            initialPuzzle = samplePuzzle,
+            currentPuzzle = samplePuzzle
+        )
+
+    private fun updatedPuzzle(): Puzzle = samplePuzzle.copy(
+        strip = samplePuzzle.strip.withUpdatedEntry(
+            index = 1,
+            value = 1
+        )
+    )
+
+    private data class RepositoryFixture(
+        val repository: GeneratedSessionRepository,
+        val dataStore: androidx.datastore.core.DataStore<Preferences>,
+        private val job: Job
+    ) {
+        suspend fun close() {
+            job.cancelAndJoin()
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue

Resolves #437

## Summary

- Add a dedicated one-slot generated-session repository with atomic replace and identity-guarded update/clear operations.
- Persist the versioned snapshot in an application-private DataStore record with safe invalid-data recovery.
- Add repository recreation and stale-writer tests, a shared factory, and backup/device-transfer exclusions.
