### PR TITLE
[209] Expose committed puzzle state

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/game/GameRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/game/GameRouteTest.kt
@@ -123,6 +123,42 @@ class GameRouteTest {
     }
 
     @Test
+    fun exposes_initial_and_committed_puzzle_changes_to_the_caller() {
+        val observedPuzzle = AtomicReference<Puzzle?>()
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                GameRoute(
+                    title = "4 pairs",
+                    initialPuzzle = samplePuzzle,
+                    gameSessionKey = "observed-puzzle",
+                    onPuzzleChanged = observedPuzzle::set
+                )
+            }
+        }
+
+        composeTestRule.waitUntil {
+            observedPuzzle.get() == samplePuzzle
+        }
+
+        GameScreenRobot(
+            activity = composeTestRule.activity,
+            interactions = composeTestRule
+        ).tapStripItem(index = 0)
+            .enterStripValue("1")
+            .submitStripEntryInput()
+
+        composeTestRule.waitUntil {
+            observedPuzzle.get()?.strip?.items?.get(0) == StripItem.PlayerEntered(1)
+        }
+
+        assertEquals(
+            StripItem.PlayerEntered(1),
+            observedPuzzle.get()?.strip?.items?.get(0)
+        )
+    }
+
+    @Test
     fun solved_puzzle_shows_the_success_overlay_by_default() {
         composeTestRule.setContent {
             NumPairsTheme {

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/GameRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/GameRoute.kt
@@ -38,6 +38,7 @@ fun GameRoute(
     topBarActions: @Composable RowScope.() -> Unit = {},
     contentBeforePuzzle: @Composable ColumnScope.() -> Unit = {},
     onGameUiStateChanged: (GameUiState) -> Unit = {},
+    onPuzzleChanged: (Puzzle) -> Unit = {},
     onNavigateBack: () -> Unit = {}
 ) {
     val gameViewModel = rememberGameViewModel(
@@ -46,9 +47,13 @@ fun GameRoute(
     )
     val uiState by gameViewModel.uiState.collectAsState()
     val currentOnGameUiStateChanged by rememberUpdatedState(onGameUiStateChanged)
+    val currentOnPuzzleChanged by rememberUpdatedState(onPuzzleChanged)
 
     LaunchedEffect(gameViewModel, puzzleResetKey) {
         gameViewModel.reset(initialPuzzle = initialPuzzle)
+        gameViewModel.currentPuzzle.collect { puzzle ->
+            currentOnPuzzleChanged(puzzle)
+        }
     }
 
     LaunchedEffect(uiState) {

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/presentation/GameViewModel.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/presentation/GameViewModel.kt
@@ -17,6 +17,9 @@ class GameViewModel(initialPuzzle: Puzzle = samplePuzzle) : ViewModel() {
     private var puzzle: Puzzle = initialPuzzle
     private var presentationState = GamePresentationState()
 
+    private val _currentPuzzle = MutableStateFlow(puzzle)
+    val currentPuzzle: StateFlow<Puzzle> = _currentPuzzle.asStateFlow()
+
     private val _uiState = MutableStateFlow(
         GameUiState.from(puzzle = puzzle, presentationState = presentationState)
     )
@@ -25,6 +28,7 @@ class GameViewModel(initialPuzzle: Puzzle = samplePuzzle) : ViewModel() {
     fun reset(initialPuzzle: Puzzle) {
         puzzle = initialPuzzle
         presentationState = GamePresentationState()
+        _currentPuzzle.value = puzzle
         publishUiState()
     }
 
@@ -242,12 +246,16 @@ class GameViewModel(initialPuzzle: Puzzle = samplePuzzle) : ViewModel() {
         val nextPresentationState = presentationState
             .updatePresentation()
             .onPuzzleChanged(isPuzzleSolved = updatedPuzzle.isSolved)
-        val hasStateChanged = updatedPuzzle != puzzle || nextPresentationState != presentationState
+        val hasPuzzleChanged = updatedPuzzle != puzzle
+        val hasStateChanged = hasPuzzleChanged || nextPresentationState != presentationState
 
         puzzle = updatedPuzzle
         presentationState = nextPresentationState
 
         if (hasStateChanged) {
+            if (hasPuzzleChanged) {
+                _currentPuzzle.value = puzzle
+            }
             publishUiState()
         }
     }

--- a/app/src/test/java/org/cescfe/numpairs/feature/game/presentation/GameViewModelPuzzleStateTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/game/presentation/GameViewModelPuzzleStateTest.kt
@@ -1,0 +1,83 @@
+package org.cescfe.numpairs.feature.game.presentation
+
+import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class GameViewModelPuzzleStateTest {
+    @Test
+    fun `starts with the exact initial puzzle`() {
+        val viewModel = GameViewModel(initialPuzzle = samplePuzzle)
+
+        assertSame(samplePuzzle, viewModel.currentPuzzle.value)
+    }
+
+    @Test
+    fun `transient strip drafts and selectors do not change the current puzzle`() {
+        val viewModel = GameViewModel(initialPuzzle = samplePuzzle)
+
+        viewModel.onStripItemTapped(index = 0)
+        viewModel.onStripItemEntryInputChanged(draftText = "1")
+        assertSame(samplePuzzle, viewModel.currentPuzzle.value)
+
+        viewModel.onStripItemEntryInputCancelled()
+        viewModel.onTileLeftOperandTapped(index = 0)
+        assertSame(samplePuzzle, viewModel.currentPuzzle.value)
+
+        viewModel.onTileOperandSelectionDismissed()
+        viewModel.onTileOperatorTapped(index = 0)
+        assertSame(samplePuzzle, viewModel.currentPuzzle.value)
+    }
+
+    @Test
+    fun `confirmed strip operand and operator changes update the current puzzle`() {
+        val viewModel = GameViewModel(initialPuzzle = samplePuzzle)
+
+        viewModel.onStripItemTapped(index = 0)
+        viewModel.onStripItemEntryInputChanged(draftText = "1")
+        viewModel.onStripItemEntryInputConfirmed()
+        assertEquals(StripItem.PlayerEntered(1), viewModel.currentPuzzle.value.strip.items[0])
+
+        viewModel.onTileLeftOperandTapped(index = 0)
+        viewModel.onTileOperandSelectionConfirmed(stripEntryId = 0)
+        assertEquals(
+            Expression.Operand.Known(value = 1, stripEntryId = 0),
+            viewModel.currentPuzzle.value.board.tiles[0].expression.leftOperand
+        )
+
+        viewModel.onTileOperatorTapped(index = 0)
+        viewModel.onTileOperatorSelectionConfirmed(operator = Operator.ADDITION)
+        assertEquals(
+            Operator.ADDITION,
+            viewModel.currentPuzzle.value.board.tiles[0].expression.operator
+        )
+    }
+
+    @Test
+    fun `tile and full puzzle reset update the current puzzle`() {
+        val viewModel = GameViewModel(initialPuzzle = samplePuzzle)
+        viewModel.onTileLeftOperandTapped(index = 0)
+        viewModel.onTileOperandSelectionConfirmed(stripEntryId = 2)
+
+        viewModel.onTileResetTapped(index = 0)
+
+        assertEquals(
+            Expression.Operand.Hidden,
+            viewModel.currentPuzzle.value.board.tiles[0].expression.leftOperand
+        )
+
+        val replacement = samplePuzzle.copy(
+            strip = samplePuzzle.strip.withUpdatedEntry(
+                index = 1,
+                value = 1
+            )
+        )
+        viewModel.reset(initialPuzzle = replacement)
+
+        assertSame(replacement, viewModel.currentPuzzle.value)
+    }
+}


### PR DESCRIPTION
## Related Issue

Resolves #438

## Summary

- Expose the exact current domain puzzle as read-only GameViewModel state.
- Report initial, reset, and committed puzzle changes through a focused GameRoute callback.
- Keep transient drafts and modal-only presentation changes outside the puzzle stream with unit and compiled route coverage.
