### PR TITLE
[210] Persist newly generated sessions

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.test.espresso.Espresso.pressBackUnconditionally
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
 import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
 import org.cescfe.numpairs.data.onboarding.OnboardingPostCorePath
 import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
@@ -108,6 +109,7 @@ class AppNavigationLearningFlowTest {
             NumPairsTheme {
                 AppNavigation(
                     onboardingRepository = onboardingRepository,
+                    generatedSessionRepository = FakeGeneratedSessionRepository(),
                     topAppBarActionDiscoveryRepository = actionDiscoveryRepository,
                     generatedModeRegistry = GeneratedModes.registry,
                     generatedPuzzleGenerationUseCaseFactory = fourPairsProviderFactory(puzzleProvider = puzzleProvider)

--- a/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso.pressBackUnconditionally
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
 import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
 import org.cescfe.numpairs.data.onboarding.OnboardingPostCorePath
 import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
@@ -159,6 +160,7 @@ class RequiredOnboardingNavigationTest {
             NumPairsTheme {
                 AppNavigation(
                     onboardingRepository = repository,
+                    generatedSessionRepository = FakeGeneratedSessionRepository(),
                     topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
                     generatedModeRegistry = GeneratedModes.registry,
                     generatedPuzzleGenerationUseCaseFactory = generatedPuzzleFactory()

--- a/app/src/androidTest/java/org/cescfe/numpairs/data/generated/session/FakeGeneratedSessionRepository.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/data/generated/session/FakeGeneratedSessionRepository.kt
@@ -1,0 +1,34 @@
+package org.cescfe.numpairs.data.generated.session
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+
+class FakeGeneratedSessionRepository(initialSession: GeneratedSessionSnapshot? = null) : GeneratedSessionRepository {
+    private val mutableSession = MutableStateFlow(initialSession)
+    override val session: StateFlow<GeneratedSessionSnapshot?> = mutableSession.asStateFlow()
+
+    override suspend fun replace(snapshot: GeneratedSessionSnapshot) {
+        mutableSession.value = snapshot
+    }
+
+    override suspend fun updateCurrentPuzzle(expectedSessionId: GeneratedSessionId, puzzle: Puzzle): Boolean {
+        val snapshot = mutableSession.value
+        if (snapshot?.sessionId != expectedSessionId) {
+            return false
+        }
+
+        mutableSession.value = snapshot.copy(currentPuzzle = puzzle)
+        return true
+    }
+
+    override suspend fun clear(expectedSessionId: GeneratedSessionId): Boolean {
+        if (mutableSession.value?.sessionId != expectedSessionId) {
+            return false
+        }
+
+        mutableSession.value = null
+        return true
+    }
+}

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/eightpairs/EightPairsModeTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/eightpairs/EightPairsModeTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso.pressBackUnconditionally
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
 import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
 import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.domain.puzzle.model.Board
@@ -112,6 +113,7 @@ class EightPairsModeTest {
             NumPairsTheme {
                 AppNavigation(
                     onboardingRepository = FakeOnboardingRepository(),
+                    generatedSessionRepository = FakeGeneratedSessionRepository(),
                     topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
                     generatedModeRegistry = GeneratedModes.registry,
                     generatedPuzzleGenerationUseCaseFactory = eightPairsProviderFactory(puzzleProvider = puzzleProvider)

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/fourpairs/FourPairsActionDiscoveryTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/fourpairs/FourPairsActionDiscoveryTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
 import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryState
@@ -37,6 +38,7 @@ class FourPairsActionDiscoveryTest {
             NumPairsTheme {
                 FourPairsRoute(
                     generationUseCase = generatedPuzzleUseCase(puzzle = samplePuzzle),
+                    generatedSessionRepository = FakeGeneratedSessionRepository(),
                     topAppBarActionDiscoveryRepository = actionDiscoveryRepository
                 )
             }
@@ -70,6 +72,7 @@ class FourPairsActionDiscoveryTest {
             NumPairsTheme {
                 FourPairsRoute(
                     generationUseCase = generatedPuzzleUseCase(puzzle = samplePuzzle),
+                    generatedSessionRepository = FakeGeneratedSessionRepository(),
                     topAppBarActionDiscoveryRepository = actionDiscoveryRepository
                 )
             }

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/fourpairs/FourPairsCompletionActionsTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/fourpairs/FourPairsCompletionActionsTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.test.espresso.Espresso.pressBackUnconditionally
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
 import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
 import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
@@ -169,6 +170,7 @@ class FourPairsCompletionActionsTest {
             NumPairsTheme {
                 AppNavigation(
                     onboardingRepository = FakeOnboardingRepository(),
+                    generatedSessionRepository = FakeGeneratedSessionRepository(),
                     topAppBarActionDiscoveryRepository = actionDiscoveryRepository,
                     generatedModeRegistry = GeneratedModes.registry,
                     generatedPuzzleGenerationUseCaseFactory = fourPairsProviderFactory(puzzleProvider = puzzleProvider)

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleGenerationRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleGenerationRouteTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
 import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
 import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationFailureReason
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
@@ -39,7 +40,8 @@ class GeneratedPuzzleGenerationRouteTest {
                 GeneratedModeRoute(
                     mode = GeneratedModes.FOUR_PAIRS,
                     title = "4 pairs",
-                    generationUseCase = useCase
+                    generationUseCase = useCase,
+                    generatedSessionRepository = FakeGeneratedSessionRepository()
                 )
             }
         }

--- a/app/src/main/java/org/cescfe/numpairs/MainActivity.kt
+++ b/app/src/main/java/org/cescfe/numpairs/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
+import org.cescfe.numpairs.data.generated.session.createGeneratedSessionRepository
 import org.cescfe.numpairs.data.onboarding.createOnboardingRuntime
 import org.cescfe.numpairs.data.preferences.createTopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.feature.generated.ConfiguredGeneratedPuzzleGenerationUseCaseFactory
@@ -20,6 +21,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         val onboardingRuntime = createOnboardingRuntime(applicationContext)
+        val generatedSessionRepository = createGeneratedSessionRepository(applicationContext)
         val topAppBarActionDiscoveryRepository = createTopAppBarActionDiscoveryRepository(applicationContext)
         val generatedModeRegistry = GeneratedModes.registry
         val generatedPuzzleGenerationUseCaseFactory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
@@ -33,6 +35,7 @@ class MainActivity : ComponentActivity() {
             NumPairsTheme {
                 AppNavigation(
                     onboardingRepository = onboardingRuntime.repository,
+                    generatedSessionRepository = generatedSessionRepository,
                     topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
                     generatedModeRegistry = generatedModeRegistry,
                     generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory

--- a/app/src/main/java/org/cescfe/numpairs/feature/fourpairs/FourPairsRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/fourpairs/FourPairsRoute.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.launch
 import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionRepository
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryState
 import org.cescfe.numpairs.feature.game.ui.actions.HintAction
@@ -25,6 +26,7 @@ import org.cescfe.numpairs.feature.tutorial.TutorialOverlayHost
 @Composable
 fun FourPairsRoute(
     topAppBarActionDiscoveryRepository: TopAppBarActionDiscoveryRepository,
+    generatedSessionRepository: GeneratedSessionRepository,
     modifier: Modifier = Modifier,
     generationUseCase: GeneratedPuzzleGenerationUseCase,
     mode: GeneratedModeConfiguration = GeneratedModes.FOUR_PAIRS,
@@ -55,6 +57,7 @@ fun FourPairsRoute(
             mode = mode,
             title = stringResource(R.string.four_pairs_screen_title),
             generationUseCase = generationUseCase,
+            generatedSessionRepository = generatedSessionRepository,
             isRulesHelperEnabled = true,
             isRulesHelperActionDiscoveryDotVisible = actionDiscoveryState?.hasSeenHelpAction == false,
             onRulesHelperActionTapped = {

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelProvider
 import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionRepository
 import org.cescfe.numpairs.feature.game.GameCompletionActions
 import org.cescfe.numpairs.feature.game.GameRoute
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
@@ -37,6 +38,7 @@ fun GeneratedModeRoute(
     mode: GeneratedModeConfiguration,
     title: String,
     generationUseCase: GeneratedPuzzleGenerationUseCase,
+    generatedSessionRepository: GeneratedSessionRepository,
     modifier: Modifier = Modifier,
     isRulesHelperEnabled: Boolean = false,
     isRulesHelperActionDiscoveryDotVisible: Boolean = false,
@@ -47,7 +49,8 @@ fun GeneratedModeRoute(
 ) {
     val viewModel = rememberGeneratedPuzzleViewModel(
         mode = mode,
-        generationUseCase = generationUseCase
+        generationUseCase = generationUseCase,
+        generatedSessionRepository = generatedSessionRepository
     )
     val uiState by viewModel.uiState.collectAsState()
 
@@ -135,7 +138,7 @@ private fun GeneratedPuzzleGameContent(
     Box(modifier = modifier.fillMaxSize()) {
         GameRoute(
             title = title,
-            initialPuzzle = session.initialPuzzle,
+            initialPuzzle = session.currentPuzzle,
             gameSessionKey = session.request.profileId.value,
             puzzleResetKey = session.id,
             completionActions = GameCompletionActions(
@@ -269,17 +272,19 @@ private fun GeneratedPuzzleFailureDialog(onRetry: () -> Unit, onNavigateBack: ()
 @Composable
 private fun rememberGeneratedPuzzleViewModel(
     mode: GeneratedModeConfiguration,
-    generationUseCase: GeneratedPuzzleGenerationUseCase
+    generationUseCase: GeneratedPuzzleGenerationUseCase,
+    generatedSessionRepository: GeneratedSessionRepository
 ): GeneratedPuzzleViewModel {
     val activity = LocalContext.current.findComponentActivity()
         ?: error("GeneratedModeRoute requires a ComponentActivity host.")
 
-    return remember(activity, mode.id, generationUseCase) {
+    return remember(activity, mode.id, generationUseCase, generatedSessionRepository) {
         ViewModelProvider(
             activity,
             GeneratedPuzzleViewModelFactory(
                 mode = mode,
-                generationUseCase = generationUseCase
+                generationUseCase = generationUseCase,
+                generatedSessionRepository = generatedSessionRepository
             )
         )["generated-puzzle-${mode.id.value}", GeneratedPuzzleViewModel::class.java]
     }
@@ -287,7 +292,8 @@ private fun rememberGeneratedPuzzleViewModel(
 
 private class GeneratedPuzzleViewModelFactory(
     private val mode: GeneratedModeConfiguration,
-    private val generationUseCase: GeneratedPuzzleGenerationUseCase
+    private val generationUseCase: GeneratedPuzzleGenerationUseCase,
+    private val generatedSessionRepository: GeneratedSessionRepository
 ) : ViewModelProvider.Factory {
     override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
         require(modelClass.isAssignableFrom(GeneratedPuzzleViewModel::class.java)) {
@@ -298,7 +304,8 @@ private class GeneratedPuzzleViewModelFactory(
             modelClass.cast(
                 GeneratedPuzzleViewModel(
                     mode = mode,
-                    generationUseCase = generationUseCase
+                    generationUseCase = generationUseCase,
+                    generatedSessionRepository = generatedSessionRepository
                 )
             )
         )

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModel.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModel.kt
@@ -2,6 +2,8 @@ package org.cescfe.numpairs.feature.generated
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import java.io.IOException
+import java.util.UUID
 import java.util.concurrent.ThreadLocalRandom
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -9,6 +11,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionId
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionRepository
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionSnapshot
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPuzzleGenerationRequest
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 
@@ -18,6 +23,20 @@ fun interface GeneratedPuzzleSeedSource {
 
 internal object ThreadLocalGeneratedPuzzleSeedSource : GeneratedPuzzleSeedSource {
     override fun nextSeed(): Int = ThreadLocalRandom.current().nextInt()
+}
+
+fun interface GeneratedSessionIdSource {
+    fun nextId(): GeneratedSessionId
+}
+
+internal object UuidGeneratedSessionIdSource : GeneratedSessionIdSource {
+    override fun nextId(): GeneratedSessionId = GeneratedSessionId(UUID.randomUUID().toString())
+}
+
+internal sealed interface GeneratedPuzzlePreparationFailure {
+    data class Generation(val result: GeneratedPuzzleGenerationResult.Failed) : GeneratedPuzzlePreparationFailure
+
+    data object Persistence : GeneratedPuzzlePreparationFailure
 }
 
 internal sealed interface GeneratedPuzzleGenerationUiState {
@@ -30,7 +49,7 @@ internal sealed interface GeneratedPuzzleGenerationUiState {
 
     data class Failed(
         val request: GeneratedPuzzleGenerationRequest,
-        val failure: GeneratedPuzzleGenerationResult.Failed,
+        val failure: GeneratedPuzzlePreparationFailure,
         val previousSession: GeneratedModeGameSession?
     ) : GeneratedPuzzleGenerationUiState
 }
@@ -38,14 +57,15 @@ internal sealed interface GeneratedPuzzleGenerationUiState {
 internal class GeneratedPuzzleViewModel(
     private val mode: GeneratedModeConfiguration,
     private val generationUseCase: GeneratedPuzzleGenerationUseCase,
-    private val seedSource: GeneratedPuzzleSeedSource = ThreadLocalGeneratedPuzzleSeedSource
+    private val generatedSessionRepository: GeneratedSessionRepository,
+    private val seedSource: GeneratedPuzzleSeedSource = ThreadLocalGeneratedPuzzleSeedSource,
+    private val sessionIdSource: GeneratedSessionIdSource = UuidGeneratedSessionIdSource
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<GeneratedPuzzleGenerationUiState>(GeneratedPuzzleGenerationUiState.Idle)
     val uiState: StateFlow<GeneratedPuzzleGenerationUiState> = _uiState.asStateFlow()
 
     private var generationJob: Job? = null
     private var generationToken = 0
-    private var nextSessionId = 0
 
     fun onRouteEntered() {
         if (generationJob != null) {
@@ -106,29 +126,62 @@ internal class GeneratedPuzzleViewModel(
                 return@launch
             }
 
-            generationJob = null
-            _uiState.value = when (outcome) {
+            val nextState = when (outcome) {
                 is GeneratedPuzzleGenerationResult.Generated -> {
-                    GeneratedPuzzleGenerationUiState.Ready(
-                        session = GeneratedModeGameSession(
-                            id = nextSessionId++,
-                            initialPuzzle = outcome.initialPuzzle,
-                            request = outcome.request
-                        )
+                    prepareGeneratedSession(
+                        outcome = outcome,
+                        previousSession = previousSession
                     )
                 }
 
                 is GeneratedPuzzleGenerationResult.Failed -> {
                     GeneratedPuzzleGenerationUiState.Failed(
                         request = outcome.request,
-                        failure = outcome,
+                        failure = GeneratedPuzzlePreparationFailure.Generation(outcome),
                         previousSession = previousSession
                     )
                 }
             }
+            if (token != generationToken) {
+                return@launch
+            }
+
+            generationJob = null
+            _uiState.value = nextState
         }
         generationJob = job
         job.start()
+    }
+
+    private suspend fun prepareGeneratedSession(
+        outcome: GeneratedPuzzleGenerationResult.Generated,
+        previousSession: GeneratedModeGameSession?
+    ): GeneratedPuzzleGenerationUiState {
+        val sessionId = sessionIdSource.nextId()
+        val snapshot = GeneratedSessionSnapshot(
+            sessionId = sessionId,
+            modeId = mode.id.value,
+            profileId = outcome.request.profileId.value,
+            seed = outcome.request.seed,
+            initialPuzzle = outcome.initialPuzzle,
+            currentPuzzle = outcome.initialPuzzle
+        )
+
+        return try {
+            generatedSessionRepository.replace(snapshot)
+            GeneratedPuzzleGenerationUiState.Ready(
+                session = GeneratedModeGameSession(
+                    snapshot = snapshot,
+                    request = outcome.request
+                )
+            )
+        } catch (_: IOException) {
+            GeneratedPuzzleGenerationUiState.Failed(
+                request = outcome.request,
+                failure = GeneratedPuzzlePreparationFailure.Persistence,
+                previousSession = previousSession
+            )
+        }
     }
 
     private fun nextRequest(): GeneratedPuzzleGenerationRequest = GeneratedPuzzleGenerationRequest(
@@ -138,7 +191,24 @@ internal class GeneratedPuzzleViewModel(
 }
 
 internal data class GeneratedModeGameSession(
-    val id: Int,
-    val initialPuzzle: Puzzle,
+    val snapshot: GeneratedSessionSnapshot,
     val request: GeneratedPuzzleGenerationRequest
-)
+) {
+    init {
+        require(snapshot.profileId == request.profileId.value) {
+            "Generated game session profile must match its generation request."
+        }
+        require(snapshot.seed == request.seed) {
+            "Generated game session seed must match its generation request."
+        }
+    }
+
+    val id: GeneratedSessionId
+        get() = snapshot.sessionId
+
+    val initialPuzzle: Puzzle
+        get() = snapshot.initialPuzzle
+
+    val currentPuzzle: Puzzle
+        get() = snapshot.currentPuzzle
+}

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionRepository
 import org.cescfe.numpairs.data.onboarding.OnboardingRepository
 import org.cescfe.numpairs.data.onboarding.OnboardingState
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryRepository
@@ -32,6 +33,7 @@ sealed interface AppDestination {
 @Composable
 fun AppNavigation(
     onboardingRepository: OnboardingRepository,
+    generatedSessionRepository: GeneratedSessionRepository,
     topAppBarActionDiscoveryRepository: TopAppBarActionDiscoveryRepository,
     generatedModeRegistry: GeneratedModeRegistry,
     generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory,
@@ -48,6 +50,7 @@ fun AppNavigation(
             modifier = modifier
         )
         else -> UnlockedAppNavigation(
+            generatedSessionRepository = generatedSessionRepository,
             topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
             generatedModeRegistry = generatedModeRegistry,
             generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory,
@@ -59,6 +62,7 @@ fun AppNavigation(
 
 @Composable
 private fun UnlockedAppNavigation(
+    generatedSessionRepository: GeneratedSessionRepository,
     topAppBarActionDiscoveryRepository: TopAppBarActionDiscoveryRepository,
     generatedModeRegistry: GeneratedModeRegistry,
     generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory,
@@ -104,6 +108,7 @@ private fun UnlockedAppNavigation(
                     modifier = modifier,
                     mode = mode,
                     generationUseCase = generationUseCase,
+                    generatedSessionRepository = generatedSessionRepository,
                     topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
                     onNavigateBack = navigateToMenu
                 )
@@ -114,6 +119,7 @@ private fun UnlockedAppNavigation(
                         stringResource(id = titleResourceId)
                     } ?: mode.id.value,
                     generationUseCase = generationUseCase,
+                    generatedSessionRepository = generatedSessionRepository,
                     modifier = modifier,
                     onNavigateBack = navigateToMenu
                 )

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModelTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModelTest.kt
@@ -1,11 +1,18 @@
 package org.cescfe.numpairs.feature.generated
 
+import java.io.IOException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionId
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionRepository
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionSnapshot
 import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationFailureReason
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
@@ -13,6 +20,7 @@ import org.cescfe.numpairs.domain.generated.generation.GeneratedPuzzleGeneration
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -32,6 +40,39 @@ class GeneratedPuzzleViewModelTest {
     }
 
     @Test
+    fun successful_generation_is_persisted_before_readiness() {
+        val writeGate = CompletableDeferred<Unit>()
+        val repository = RecordingGeneratedSessionRepository(writeGate = writeGate)
+        val viewModel = GeneratedPuzzleViewModel(
+            mode = GeneratedModes.FOUR_PAIRS,
+            generationUseCase = generatedPuzzleUseCase(),
+            generatedSessionRepository = repository,
+            seedSource = QueueGeneratedPuzzleSeedSource(17),
+            sessionIdSource = QueueGeneratedSessionIdSource("stable-session")
+        )
+
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.runCurrent()
+
+        assertTrue(viewModel.uiState.value is GeneratedPuzzleGenerationUiState.Loading)
+        val attemptedSnapshot = repository.replaceAttempts.single()
+        assertEquals(GeneratedSessionId("stable-session"), attemptedSnapshot.sessionId)
+        assertEquals(GeneratedModes.FOUR_PAIRS.id.value, attemptedSnapshot.modeId)
+        assertEquals(GeneratedModes.FOUR_PAIRS.profile.id.value, attemptedSnapshot.profileId)
+        assertEquals(17, attemptedSnapshot.seed)
+        assertEquals(samplePuzzle, attemptedSnapshot.initialPuzzle)
+        assertEquals(samplePuzzle, attemptedSnapshot.currentPuzzle)
+        assertNull(repository.session.value)
+
+        writeGate.complete(Unit)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val ready = viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready
+        assertEquals(attemptedSnapshot, repository.session.value)
+        assertEquals(attemptedSnapshot, ready.session.snapshot)
+    }
+
+    @Test
     fun replay_is_deduplicated_and_a_failure_keeps_the_completed_session_until_retry_succeeds() {
         val firstPuzzle = CompletableDeferred(samplePuzzle)
         val replayFailure = CompletableDeferred(true)
@@ -41,10 +82,13 @@ class GeneratedPuzzleViewModelTest {
             replayFailure = replayFailure,
             retryPuzzle = retryPuzzle
         )
+        val repository = RecordingGeneratedSessionRepository()
         val viewModel = GeneratedPuzzleViewModel(
             mode = GeneratedModes.FOUR_PAIRS,
             generationUseCase = useCase,
-            seedSource = QueueGeneratedPuzzleSeedSource(11, 22, 33)
+            generatedSessionRepository = repository,
+            seedSource = QueueGeneratedPuzzleSeedSource(11, 22, 33),
+            sessionIdSource = QueueGeneratedSessionIdSource("first", "retry")
         )
 
         viewModel.onRouteEntered()
@@ -58,16 +102,80 @@ class GeneratedPuzzleViewModelTest {
         assertEquals(2, useCase.requests.size)
         val failed = viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Failed
         assertEquals(initialSession, failed.previousSession)
-        assertEquals(GeneratedPairsPuzzleGenerationFailureReason.AttemptsExhausted, failed.failure.failure.reason)
+        val generationFailure = failed.failure as GeneratedPuzzlePreparationFailure.Generation
+        assertEquals(
+            GeneratedPairsPuzzleGenerationFailureReason.AttemptsExhausted,
+            generationFailure.result.failure.reason
+        )
+        assertEquals(1, repository.replaceAttempts.size)
 
         viewModel.retry()
         dispatcher.scheduler.advanceUntilIdle()
 
         val ready = viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready
-        assertEquals(1, ready.session.id)
+        assertEquals(GeneratedSessionId("retry"), ready.session.id)
         assertEquals(3, useCase.requests.size)
         assertEquals(listOf(11, 22, 33), useCase.requests.map(GeneratedPuzzleGenerationRequest::seed))
+        assertEquals(2, repository.replaceAttempts.size)
+        assertEquals(ready.session.snapshot, repository.session.value)
     }
+
+    @Test
+    fun generation_cancellation_does_not_replace_the_stored_session() {
+        val generatedPuzzle = CompletableDeferred<Puzzle>()
+        val existingSnapshot = generatedSessionSnapshot(sessionId = "existing")
+        val repository = RecordingGeneratedSessionRepository(initialSession = existingSnapshot)
+        val viewModel = GeneratedPuzzleViewModel(
+            mode = GeneratedModes.FOUR_PAIRS,
+            generationUseCase = generatedPuzzleUseCase(generatedPuzzle),
+            generatedSessionRepository = repository,
+            seedSource = QueueGeneratedPuzzleSeedSource(29),
+            sessionIdSource = QueueGeneratedSessionIdSource("cancelled")
+        )
+
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.runCurrent()
+        viewModel.onRouteExited()
+        generatedPuzzle.complete(samplePuzzle)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(repository.replaceAttempts.isEmpty())
+        assertEquals(existingSnapshot, repository.session.value)
+    }
+
+    @Test
+    fun persistence_failure_keeps_the_previous_stored_session_and_is_recoverable() {
+        val existingSnapshot = generatedSessionSnapshot(sessionId = "existing")
+        val repository = RecordingGeneratedSessionRepository(
+            initialSession = existingSnapshot,
+            replaceFailure = IOException("storage unavailable")
+        )
+        val viewModel = GeneratedPuzzleViewModel(
+            mode = GeneratedModes.FOUR_PAIRS,
+            generationUseCase = generatedPuzzleUseCase(),
+            generatedSessionRepository = repository,
+            seedSource = QueueGeneratedPuzzleSeedSource(31),
+            sessionIdSource = QueueGeneratedSessionIdSource("not-stored")
+        )
+
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val failed = viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Failed
+        assertEquals(GeneratedPuzzlePreparationFailure.Persistence, failed.failure)
+        assertNull(failed.previousSession)
+        assertEquals(existingSnapshot, repository.session.value)
+        assertEquals(1, repository.replaceAttempts.size)
+    }
+}
+
+private fun generatedPuzzleUseCase(
+    puzzle: CompletableDeferred<Puzzle> = CompletableDeferred(samplePuzzle)
+): GeneratedPuzzleGenerationUseCase = GeneratedPuzzleGenerationUseCase { request ->
+    GeneratedPuzzleGenerationResult.Generated(
+        request = request,
+        initialPuzzle = puzzle.await()
+    )
 }
 
 private class ControlledGeneratedPuzzleUseCase(
@@ -114,3 +222,56 @@ private class QueueGeneratedPuzzleSeedSource(vararg seeds: Int) : GeneratedPuzzl
 
     override fun nextSeed(): Int = values.removeFirst()
 }
+
+private class QueueGeneratedSessionIdSource(vararg ids: String) : GeneratedSessionIdSource {
+    private val values = ArrayDeque(ids.toList())
+
+    override fun nextId(): GeneratedSessionId = GeneratedSessionId(values.removeFirst())
+}
+
+private class RecordingGeneratedSessionRepository(
+    initialSession: GeneratedSessionSnapshot? = null,
+    private val writeGate: CompletableDeferred<Unit>? = null,
+    private val replaceFailure: IOException? = null
+) : GeneratedSessionRepository {
+    private val mutableSession = MutableStateFlow(initialSession)
+    override val session: StateFlow<GeneratedSessionSnapshot?> = mutableSession.asStateFlow()
+    val replaceAttempts = mutableListOf<GeneratedSessionSnapshot>()
+
+    override suspend fun replace(snapshot: GeneratedSessionSnapshot) {
+        replaceAttempts += snapshot
+        writeGate?.await()
+        replaceFailure?.let { failure ->
+            throw failure
+        }
+        mutableSession.value = snapshot
+    }
+
+    override suspend fun updateCurrentPuzzle(expectedSessionId: GeneratedSessionId, puzzle: Puzzle): Boolean {
+        val snapshot = mutableSession.value
+        if (snapshot?.sessionId != expectedSessionId) {
+            return false
+        }
+
+        mutableSession.value = snapshot.copy(currentPuzzle = puzzle)
+        return true
+    }
+
+    override suspend fun clear(expectedSessionId: GeneratedSessionId): Boolean {
+        if (mutableSession.value?.sessionId != expectedSessionId) {
+            return false
+        }
+
+        mutableSession.value = null
+        return true
+    }
+}
+
+private fun generatedSessionSnapshot(sessionId: String): GeneratedSessionSnapshot = GeneratedSessionSnapshot(
+    sessionId = GeneratedSessionId(sessionId),
+    modeId = GeneratedModes.FOUR_PAIRS.id.value,
+    profileId = GeneratedModes.FOUR_PAIRS.profile.id.value,
+    seed = 7,
+    initialPuzzle = samplePuzzle,
+    currentPuzzle = samplePuzzle
+)


### PR DESCRIPTION
## Related Issue

Resolves #442

## Summary

- Wire the single application-scoped generated-session repository into generated game composition.
- Persist a versioned snapshot with stable identity and exact puzzle state before publishing a generated game as ready.
- Preserve the previous durable session on generation, cancellation, and storage failures.
- Add deterministic ViewModel coverage for persistence ordering, failure safety, cancellation, and duplicate requests.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
