### PR TITLE
[211] Restore durable generated sessions

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleGenerationRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleGenerationRouteTest.kt
@@ -11,12 +11,17 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
 import org.cescfe.numpairs.R
 import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionId
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionSnapshot
 import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationFailureReason
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPuzzleGenerationRequest
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -83,6 +88,73 @@ class GeneratedPuzzleGenerationRouteTest {
             .assertIsDisplayed()
     }
 
+    @Test
+    fun resume_shows_the_stored_current_puzzle_without_generating_a_replacement() {
+        val currentPuzzle = samplePuzzle.copy(
+            strip = samplePuzzle.strip.withUpdatedEntry(index = 1, value = 1)
+        )
+        val snapshot = generatedSessionSnapshot(currentPuzzle = currentPuzzle)
+        val repository = FakeGeneratedSessionRepository(initialSession = snapshot)
+        val useCase = CountingGeneratedPuzzleUseCase()
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                GeneratedModeRoute(
+                    mode = GeneratedModes.FOUR_PAIRS,
+                    launchIntent = GeneratedModeLaunchIntent.ResumeSession(snapshot.sessionId),
+                    title = "4 pairs",
+                    generationUseCase = useCase,
+                    generatedSessionRepository = repository
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("1")
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(0, useCase.requestCount)
+            assertEquals(snapshot, repository.session.value)
+        }
+    }
+
+    @Test
+    fun unavailable_resume_offers_a_safe_route_back() {
+        var didNavigateBack = false
+        val useCase = CountingGeneratedPuzzleUseCase()
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                GeneratedModeRoute(
+                    mode = GeneratedModes.FOUR_PAIRS,
+                    launchIntent = GeneratedModeLaunchIntent.ResumeSession(
+                        expectedSessionId = GeneratedSessionId("missing")
+                    ),
+                    title = "4 pairs",
+                    generationUseCase = useCase,
+                    generatedSessionRepository = FakeGeneratedSessionRepository(),
+                    onNavigateBack = {
+                        didNavigateBack = true
+                    }
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(GENERATED_SESSION_RESUME_UNAVAILABLE_TAG)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(string(R.string.generated_puzzle_back_to_menu_button))
+            .performClick()
+        composeTestRule.runOnIdle {
+            assertTrue(didNavigateBack)
+            assertEquals(0, useCase.requestCount)
+        }
+    }
+
     private fun string(stringResId: Int): String = composeTestRule.activity.getString(stringResId)
 }
 
@@ -121,3 +193,24 @@ private class RetryingGeneratedPuzzleUseCase(
         }
     }
 }
+
+private class CountingGeneratedPuzzleUseCase : GeneratedPuzzleGenerationUseCase {
+    var requestCount: Int = 0
+
+    override suspend fun generate(request: GeneratedPuzzleGenerationRequest): GeneratedPuzzleGenerationResult {
+        requestCount++
+        return GeneratedPuzzleGenerationResult.Generated(
+            request = request,
+            initialPuzzle = samplePuzzle
+        )
+    }
+}
+
+private fun generatedSessionSnapshot(currentPuzzle: Puzzle) = GeneratedSessionSnapshot(
+    sessionId = GeneratedSessionId("resume-session"),
+    modeId = GeneratedModes.FOUR_PAIRS.id.value,
+    profileId = GeneratedModes.FOUR_PAIRS.profile.id.value,
+    seed = 211,
+    initialPuzzle = samplePuzzle,
+    currentPuzzle = currentPuzzle
+)

--- a/app/src/main/java/org/cescfe/numpairs/feature/fourpairs/FourPairsRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/fourpairs/FourPairsRoute.kt
@@ -17,6 +17,7 @@ import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryState
 import org.cescfe.numpairs.feature.game.ui.actions.HintAction
 import org.cescfe.numpairs.feature.game.ui.help.SolvingTipsDialog
 import org.cescfe.numpairs.feature.generated.GeneratedModeConfiguration
+import org.cescfe.numpairs.feature.generated.GeneratedModeLaunchIntent
 import org.cescfe.numpairs.feature.generated.GeneratedModeRoute
 import org.cescfe.numpairs.feature.generated.GeneratedModes
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCase
@@ -29,6 +30,7 @@ fun FourPairsRoute(
     generatedSessionRepository: GeneratedSessionRepository,
     modifier: Modifier = Modifier,
     generationUseCase: GeneratedPuzzleGenerationUseCase,
+    launchIntent: GeneratedModeLaunchIntent = GeneratedModeLaunchIntent.DefaultNewPuzzle,
     mode: GeneratedModeConfiguration = GeneratedModes.FOUR_PAIRS,
     tutorialOverlayMode: TutorialMode? = null,
     onTutorialOverlayClosed: () -> Unit = {},
@@ -55,6 +57,7 @@ fun FourPairsRoute(
     ) {
         GeneratedModeRoute(
             mode = mode,
+            launchIntent = launchIntent,
             title = stringResource(R.string.four_pairs_screen_title),
             generationUseCase = generationUseCase,
             generatedSessionRepository = generatedSessionRepository,

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeLaunchIntent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeLaunchIntent.kt
@@ -1,0 +1,29 @@
+package org.cescfe.numpairs.feature.generated
+
+import java.util.UUID
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionId
+
+@JvmInline
+value class GeneratedModeLaunchId(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "Generated mode launch id must not be blank."
+        }
+    }
+}
+
+sealed interface GeneratedModeLaunchIntent {
+    data class NewPuzzle(val launchId: GeneratedModeLaunchId) : GeneratedModeLaunchIntent
+
+    data class ResumeSession(val expectedSessionId: GeneratedSessionId) : GeneratedModeLaunchIntent
+
+    companion object {
+        val DefaultNewPuzzle: NewPuzzle = NewPuzzle(
+            launchId = GeneratedModeLaunchId("default-new-puzzle")
+        )
+
+        fun newPuzzle(): NewPuzzle = NewPuzzle(
+            launchId = GeneratedModeLaunchId(UUID.randomUUID().toString())
+        )
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
@@ -36,6 +36,7 @@ import org.cescfe.numpairs.ui.theme.NumPairsComponents
 @Composable
 fun GeneratedModeRoute(
     mode: GeneratedModeConfiguration,
+    launchIntent: GeneratedModeLaunchIntent = GeneratedModeLaunchIntent.DefaultNewPuzzle,
     title: String,
     generationUseCase: GeneratedPuzzleGenerationUseCase,
     generatedSessionRepository: GeneratedSessionRepository,
@@ -54,13 +55,17 @@ fun GeneratedModeRoute(
     )
     val uiState by viewModel.uiState.collectAsState()
 
-    DisposableEffect(viewModel) {
-        viewModel.onRouteEntered()
+    DisposableEffect(viewModel, launchIntent) {
+        viewModel.onRouteEntered(launchIntent = launchIntent)
         onDispose(viewModel::onRouteExited)
     }
 
     when (val state = uiState) {
         GeneratedPuzzleGenerationUiState.Idle -> Unit
+        is GeneratedPuzzleGenerationUiState.Restoring -> {
+            GeneratedPuzzleInitialLoadingScreen(modifier = modifier)
+        }
+
         is GeneratedPuzzleGenerationUiState.Loading -> {
             state.previousSession?.let { session ->
                 GeneratedPuzzleGameContent(
@@ -115,6 +120,13 @@ fun GeneratedModeRoute(
             } ?: GeneratedPuzzleInitialFailureScreen(
                 modifier = modifier,
                 onRetry = viewModel::retry,
+                onNavigateBack = onNavigateBack
+            )
+        }
+
+        is GeneratedPuzzleGenerationUiState.ResumeUnavailable -> {
+            GeneratedSessionResumeUnavailableScreen(
+                modifier = modifier,
                 onNavigateBack = onNavigateBack
             )
         }
@@ -229,6 +241,33 @@ private fun GeneratedPuzzleInitialFailureScreen(modifier: Modifier, onRetry: () 
 }
 
 @Composable
+private fun GeneratedSessionResumeUnavailableScreen(modifier: Modifier, onNavigateBack: () -> Unit) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .testTag(GENERATED_SESSION_RESUME_UNAVAILABLE_TAG),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = stringResource(R.string.generated_session_resume_unavailable_message),
+            color = MaterialTheme.colorScheme.onBackground,
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Button(
+            onClick = onNavigateBack,
+            modifier = Modifier.padding(top = 16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.generated_puzzle_back_to_menu_button),
+                style = MaterialTheme.typography.labelLarge
+            )
+        }
+    }
+}
+
+@Composable
 private fun GeneratedPuzzleFailureDialog(onRetry: () -> Unit, onNavigateBack: () -> Unit) {
     AlertDialog(
         onDismissRequest = onNavigateBack,
@@ -320,3 +359,4 @@ private tailrec fun Context.findComponentActivity(): ComponentActivity? = when (
 
 internal const val GENERATED_PUZZLE_LOADING_TAG = "generatedPuzzleLoading"
 internal const val GENERATED_PUZZLE_FAILURE_TAG = "generatedPuzzleFailure"
+internal const val GENERATED_SESSION_RESUME_UNAVAILABLE_TAG = "generatedSessionResumeUnavailable"

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModel.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.cescfe.numpairs.data.generated.session.GeneratedSessionId
 import org.cescfe.numpairs.data.generated.session.GeneratedSessionRepository
@@ -42,6 +43,8 @@ internal sealed interface GeneratedPuzzlePreparationFailure {
 internal sealed interface GeneratedPuzzleGenerationUiState {
     data object Idle : GeneratedPuzzleGenerationUiState
 
+    data class Restoring(val expectedSessionId: GeneratedSessionId) : GeneratedPuzzleGenerationUiState
+
     data class Loading(val request: GeneratedPuzzleGenerationRequest, val previousSession: GeneratedModeGameSession?) :
         GeneratedPuzzleGenerationUiState
 
@@ -52,6 +55,8 @@ internal sealed interface GeneratedPuzzleGenerationUiState {
         val failure: GeneratedPuzzlePreparationFailure,
         val previousSession: GeneratedModeGameSession?
     ) : GeneratedPuzzleGenerationUiState
+
+    data class ResumeUnavailable(val expectedSessionId: GeneratedSessionId) : GeneratedPuzzleGenerationUiState
 }
 
 internal class GeneratedPuzzleViewModel(
@@ -66,8 +71,26 @@ internal class GeneratedPuzzleViewModel(
 
     private var generationJob: Job? = null
     private var generationToken = 0
+    private var activeLaunchIntent: GeneratedModeLaunchIntent? = null
 
-    fun onRouteEntered() {
+    fun onRouteEntered(launchIntent: GeneratedModeLaunchIntent = GeneratedModeLaunchIntent.DefaultNewPuzzle) {
+        if (launchIntent != activeLaunchIntent) {
+            generationToken++
+            generationJob?.cancel()
+            generationJob = null
+            activeLaunchIntent = launchIntent
+
+            when (launchIntent) {
+                is GeneratedModeLaunchIntent.NewPuzzle -> startGeneration(
+                    request = nextRequest(),
+                    previousSession = (_uiState.value as? GeneratedPuzzleGenerationUiState.Ready)?.session
+                )
+
+                is GeneratedModeLaunchIntent.ResumeSession -> startResume(launchIntent)
+            }
+            return
+        }
+
         if (generationJob != null) {
             return
         }
@@ -83,8 +106,15 @@ internal class GeneratedPuzzleViewModel(
                 previousSession = state.previousSession
             )
 
+            is GeneratedPuzzleGenerationUiState.Restoring -> startResume(
+                GeneratedModeLaunchIntent.ResumeSession(
+                    expectedSessionId = state.expectedSessionId
+                )
+            )
+
             is GeneratedPuzzleGenerationUiState.Ready,
-            is GeneratedPuzzleGenerationUiState.Failed -> Unit
+            is GeneratedPuzzleGenerationUiState.Failed,
+            is GeneratedPuzzleGenerationUiState.ResumeUnavailable -> Unit
         }
     }
 
@@ -108,6 +138,46 @@ internal class GeneratedPuzzleViewModel(
             request = nextRequest(),
             previousSession = state.session
         )
+    }
+
+    private fun startResume(launchIntent: GeneratedModeLaunchIntent.ResumeSession) {
+        if (generationJob != null) {
+            return
+        }
+
+        val token = ++generationToken
+        _uiState.value = GeneratedPuzzleGenerationUiState.Restoring(
+            expectedSessionId = launchIntent.expectedSessionId
+        )
+        val job = viewModelScope.launch(start = CoroutineStart.LAZY) {
+            val snapshot = generatedSessionRepository.session.first()
+                ?.takeIf { storedSnapshot ->
+                    storedSnapshot.sessionId == launchIntent.expectedSessionId &&
+                        storedSnapshot.modeId == mode.id.value &&
+                        storedSnapshot.profileId == mode.profile.id.value &&
+                        !storedSnapshot.currentPuzzle.isSolved
+                }
+            if (token != generationToken) {
+                return@launch
+            }
+
+            generationJob = null
+            _uiState.value = snapshot?.let { resumableSnapshot ->
+                GeneratedPuzzleGenerationUiState.Ready(
+                    session = GeneratedModeGameSession(
+                        snapshot = resumableSnapshot,
+                        request = GeneratedPuzzleGenerationRequest(
+                            profile = mode.profile,
+                            seed = resumableSnapshot.seed
+                        )
+                    )
+                )
+            } ?: GeneratedPuzzleGenerationUiState.ResumeUnavailable(
+                expectedSessionId = launchIntent.expectedSessionId
+            )
+        }
+        generationJob = job
+        job.start()
     }
 
     private fun startGeneration(request: GeneratedPuzzleGenerationRequest, previousSession: GeneratedModeGameSession?) {

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -15,6 +15,7 @@ import org.cescfe.numpairs.data.onboarding.OnboardingState
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.feature.fourpairs.FourPairsRoute
 import org.cescfe.numpairs.feature.generated.GeneratedModeId
+import org.cescfe.numpairs.feature.generated.GeneratedModeLaunchIntent
 import org.cescfe.numpairs.feature.generated.GeneratedModeRegistry
 import org.cescfe.numpairs.feature.generated.GeneratedModeRoute
 import org.cescfe.numpairs.feature.generated.GeneratedModes
@@ -27,7 +28,10 @@ import org.cescfe.numpairs.feature.tutorial.GuidedIntroductionRoute
 sealed interface AppDestination {
     data object Menu : AppDestination
     data object Tutorial : AppDestination
-    data class GeneratedMode(val modeId: GeneratedModeId) : AppDestination
+    data class GeneratedMode(
+        val modeId: GeneratedModeId,
+        val launchIntent: GeneratedModeLaunchIntent = GeneratedModeLaunchIntent.newPuzzle()
+    ) : AppDestination
 }
 
 @Composable
@@ -107,6 +111,7 @@ private fun UnlockedAppNavigation(
                 GeneratedModes.FOUR_PAIRS.id -> FourPairsRoute(
                     modifier = modifier,
                     mode = mode,
+                    launchIntent = destination.launchIntent,
                     generationUseCase = generationUseCase,
                     generatedSessionRepository = generatedSessionRepository,
                     topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
@@ -115,6 +120,7 @@ private fun UnlockedAppNavigation(
 
                 else -> GeneratedModeRoute(
                     mode = mode,
+                    launchIntent = destination.launchIntent,
                     title = mode.titleResourceIdOrNull()?.let { titleResourceId ->
                         stringResource(id = titleResourceId)
                     } ?: mode.id.value,

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -20,6 +20,7 @@
     <string name="generated_puzzle_failure_message">No s’ha pogut crear un puzle. Torna-ho a provar.</string>
     <string name="generated_puzzle_retry_button">Torna-ho a provar</string>
     <string name="generated_puzzle_back_to_menu_button">Torna al menú</string>
+    <string name="generated_session_resume_unavailable_message">Aquest puzle sense acabar ja no està disponible.</string>
 
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -20,6 +20,7 @@
     <string name="generated_puzzle_failure_message">No se ha podido crear un puzle. Inténtalo de nuevo.</string>
     <string name="generated_puzzle_retry_button">Reintentar</string>
     <string name="generated_puzzle_back_to_menu_button">Volver al menú</string>
+    <string name="generated_session_resume_unavailable_message">Este puzle sin terminar ya no está disponible.</string>
 
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="generated_puzzle_failure_message">We could not create a puzzle. Please try again.</string>
     <string name="generated_puzzle_retry_button">Retry</string>
     <string name="generated_puzzle_back_to_menu_button">Back to menu</string>
+    <string name="generated_session_resume_unavailable_message">This unfinished puzzle is no longer available.</string>
 
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModelTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModelTest.kt
@@ -17,7 +17,10 @@ import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationFailureReason
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPuzzleGenerationRequest
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.Operator
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.feature.game.presentation.support.solvedPuzzleWithKnownStripAndAssignments
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -167,6 +170,99 @@ class GeneratedPuzzleViewModelTest {
         assertEquals(existingSnapshot, repository.session.value)
         assertEquals(1, repository.replaceAttempts.size)
     }
+
+    @Test
+    fun resume_restores_the_exact_current_puzzle_and_metadata_without_generation_or_writes() {
+        val currentPuzzle = samplePuzzle.copy(
+            strip = samplePuzzle.strip.withUpdatedEntry(index = 1, value = 1)
+        )
+        val snapshot = generatedSessionSnapshot(
+            sessionId = "resume-me",
+            currentPuzzle = currentPuzzle
+        )
+        val repository = RecordingGeneratedSessionRepository(initialSession = snapshot)
+        val generationUseCase = UnexpectedGeneratedPuzzleUseCase()
+        val viewModel = GeneratedPuzzleViewModel(
+            mode = GeneratedModes.FOUR_PAIRS,
+            generationUseCase = generationUseCase,
+            generatedSessionRepository = repository
+        )
+
+        viewModel.onRouteEntered(
+            GeneratedModeLaunchIntent.ResumeSession(
+                expectedSessionId = snapshot.sessionId
+            )
+        )
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val ready = viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready
+        assertEquals(snapshot, ready.session.snapshot)
+        assertEquals(currentPuzzle, ready.session.currentPuzzle)
+        assertEquals(snapshot.seed, ready.session.request.seed)
+        assertEquals(snapshot.profileId, ready.session.request.profileId.value)
+        assertEquals(0, generationUseCase.requestCount)
+        assertTrue(repository.replaceAttempts.isEmpty())
+    }
+
+    @Test
+    fun resume_rejects_missing_stale_mismatched_and_solved_sessions() {
+        val expectedSessionId = GeneratedSessionId("expected")
+        val solvedPuzzle = solvedPuzzleWithKnownStripAndAssignments()
+        val solvedInitialPuzzle = solvedPuzzle.copy(
+            board = solvedPuzzle.board.copy(
+                tiles = solvedPuzzle.board.tiles.map { tile ->
+                    tile.copy(
+                        expression = tile.expression.copy(
+                            leftOperand = Expression.Operand.Hidden,
+                            operator = Operator.Hidden,
+                            rightOperand = Expression.Operand.Hidden
+                        )
+                    )
+                }
+            )
+        )
+        val unavailableSnapshots = listOf(
+            null,
+            generatedSessionSnapshot(sessionId = "stale"),
+            generatedSessionSnapshot(
+                sessionId = expectedSessionId.value,
+                modeId = GeneratedModes.EIGHT_PAIRS.id.value
+            ),
+            generatedSessionSnapshot(
+                sessionId = expectedSessionId.value,
+                profileId = GeneratedModes.EIGHT_PAIRS.profile.id.value
+            ),
+            generatedSessionSnapshot(
+                sessionId = expectedSessionId.value,
+                initialPuzzle = solvedInitialPuzzle,
+                currentPuzzle = solvedPuzzle
+            )
+        )
+
+        unavailableSnapshots.forEach { storedSnapshot ->
+            val repository = RecordingGeneratedSessionRepository(initialSession = storedSnapshot)
+            val generationUseCase = UnexpectedGeneratedPuzzleUseCase()
+            val viewModel = GeneratedPuzzleViewModel(
+                mode = GeneratedModes.FOUR_PAIRS,
+                generationUseCase = generationUseCase,
+                generatedSessionRepository = repository
+            )
+
+            viewModel.onRouteEntered(
+                GeneratedModeLaunchIntent.ResumeSession(
+                    expectedSessionId = expectedSessionId
+                )
+            )
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(
+                GeneratedPuzzleGenerationUiState.ResumeUnavailable(expectedSessionId),
+                viewModel.uiState.value
+            )
+            assertEquals(0, generationUseCase.requestCount)
+            assertTrue(repository.replaceAttempts.isEmpty())
+        }
+    }
 }
 
 private fun generatedPuzzleUseCase(
@@ -214,6 +310,15 @@ private class ControlledGeneratedPuzzleUseCase(
 
             else -> error("Unexpected generated puzzle request.")
         }
+    }
+}
+
+private class UnexpectedGeneratedPuzzleUseCase : GeneratedPuzzleGenerationUseCase {
+    var requestCount: Int = 0
+
+    override suspend fun generate(request: GeneratedPuzzleGenerationRequest): GeneratedPuzzleGenerationResult {
+        requestCount++
+        error("Resume must not invoke generated puzzle creation.")
     }
 }
 
@@ -267,11 +372,17 @@ private class RecordingGeneratedSessionRepository(
     }
 }
 
-private fun generatedSessionSnapshot(sessionId: String): GeneratedSessionSnapshot = GeneratedSessionSnapshot(
+private fun generatedSessionSnapshot(
+    sessionId: String,
+    modeId: String = GeneratedModes.FOUR_PAIRS.id.value,
+    profileId: String = GeneratedModes.FOUR_PAIRS.profile.id.value,
+    initialPuzzle: Puzzle = samplePuzzle,
+    currentPuzzle: Puzzle = samplePuzzle
+): GeneratedSessionSnapshot = GeneratedSessionSnapshot(
     sessionId = GeneratedSessionId(sessionId),
-    modeId = GeneratedModes.FOUR_PAIRS.id.value,
-    profileId = GeneratedModes.FOUR_PAIRS.profile.id.value,
+    modeId = modeId,
+    profileId = profileId,
     seed = 7,
-    initialPuzzle = samplePuzzle,
-    currentPuzzle = samplePuzzle
+    initialPuzzle = initialPuzzle,
+    currentPuzzle = currentPuzzle
 )


### PR DESCRIPTION
## Related Issue

Resolves #443

## Summary

- Model new-puzzle and stable-session resume as distinct generated-mode launch intents.
- Restore only matching, unfinished snapshots and present their exact current puzzle without generation or repository mutation.
- Surface missing, stale, mismatched, and completed resume requests through a safe localized unavailable state.
- Add unit and compiled Compose coverage for successful and unavailable restoration.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
