### PR TITLE
[212] Synchronize generated session progress

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleGenerationRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleGenerationRouteTest.kt
@@ -7,6 +7,9 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CompletableDeferred
 import org.cescfe.numpairs.R
@@ -18,6 +21,7 @@ import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGener
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPuzzleGenerationRequest
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
 import org.junit.Assert.assertEquals
@@ -152,6 +156,47 @@ class GeneratedPuzzleGenerationRouteTest {
         composeTestRule.runOnIdle {
             assertTrue(didNavigateBack)
             assertEquals(0, useCase.requestCount)
+        }
+    }
+
+    @Test
+    fun committed_game_change_updates_the_durable_session_without_persisting_input_drafts() {
+        val repository = FakeGeneratedSessionRepository()
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                GeneratedModeRoute(
+                    mode = GeneratedModes.FOUR_PAIRS,
+                    title = "4 pairs",
+                    generationUseCase = CountingGeneratedPuzzleUseCase(),
+                    generatedSessionRepository = repository
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.stripItem(1))
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.STRIP_ENTRY_INPUT)
+            .performTextInput("2")
+        composeTestRule.runOnIdle {
+            assertEquals(samplePuzzle, repository.session.value?.currentPuzzle)
+        }
+
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.STRIP_ENTRY_INPUT)
+            .performImeAction()
+        composeTestRule.waitUntil {
+            repository.session.value
+                ?.currentPuzzle
+                ?.strip
+                ?.items
+                ?.get(1) == StripItem.PlayerEntered(2)
         }
     }
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
@@ -28,7 +28,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelProvider
 import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionId
 import org.cescfe.numpairs.data.generated.session.GeneratedSessionRepository
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.feature.game.GameCompletionActions
 import org.cescfe.numpairs.feature.game.GameRoute
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
@@ -78,6 +80,7 @@ fun GeneratedModeRoute(
                     onRulesHelperPlayTutorialRequested = onRulesHelperPlayTutorialRequested,
                     topBarActions = topBarActions,
                     onNewPuzzleRequested = viewModel::onNewPuzzleRequested,
+                    onPuzzleChanged = viewModel::onPuzzleChanged,
                     onNavigateBack = onNavigateBack,
                     overlay = { GeneratedPuzzleLoadingOverlay() }
                 )
@@ -94,6 +97,7 @@ fun GeneratedModeRoute(
             onRulesHelperPlayTutorialRequested = onRulesHelperPlayTutorialRequested,
             topBarActions = topBarActions,
             onNewPuzzleRequested = viewModel::onNewPuzzleRequested,
+            onPuzzleChanged = viewModel::onPuzzleChanged,
             onNavigateBack = onNavigateBack
         )
 
@@ -109,6 +113,7 @@ fun GeneratedModeRoute(
                     onRulesHelperPlayTutorialRequested = onRulesHelperPlayTutorialRequested,
                     topBarActions = topBarActions,
                     onNewPuzzleRequested = viewModel::onNewPuzzleRequested,
+                    onPuzzleChanged = viewModel::onPuzzleChanged,
                     onNavigateBack = onNavigateBack,
                     overlay = {
                         GeneratedPuzzleFailureDialog(
@@ -144,6 +149,7 @@ private fun GeneratedPuzzleGameContent(
     onRulesHelperPlayTutorialRequested: (() -> Unit)?,
     topBarActions: @Composable RowScope.() -> Unit,
     onNewPuzzleRequested: () -> Unit,
+    onPuzzleChanged: (GeneratedSessionId, Puzzle) -> Unit,
     onNavigateBack: () -> Unit,
     overlay: @Composable () -> Unit = {}
 ) {
@@ -162,6 +168,9 @@ private fun GeneratedPuzzleGameContent(
             onRulesHelperActionTapped = onRulesHelperActionTapped,
             onRulesHelperPlayTutorialRequested = onRulesHelperPlayTutorialRequested,
             topBarActions = topBarActions,
+            onPuzzleChanged = { puzzle ->
+                onPuzzleChanged(session.id, puzzle)
+            },
             onNavigateBack = onNavigateBack
         )
         overlay()

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModel.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModel.kt
@@ -72,6 +72,7 @@ internal class GeneratedPuzzleViewModel(
     private var generationJob: Job? = null
     private var generationToken = 0
     private var activeLaunchIntent: GeneratedModeLaunchIntent? = null
+    private var sessionWriteJob: Job? = null
 
     fun onRouteEntered(launchIntent: GeneratedModeLaunchIntent = GeneratedModeLaunchIntent.DefaultNewPuzzle) {
         if (launchIntent != activeLaunchIntent) {
@@ -138,6 +139,60 @@ internal class GeneratedPuzzleViewModel(
             request = nextRequest(),
             previousSession = state.session
         )
+    }
+
+    fun onPuzzleChanged(expectedSessionId: GeneratedSessionId, puzzle: Puzzle) {
+        if (!updateVisibleSession(expectedSessionId = expectedSessionId, puzzle = puzzle)) {
+            return
+        }
+
+        val precedingWrite = sessionWriteJob
+        sessionWriteJob = viewModelScope.launch {
+            precedingWrite?.join()
+            try {
+                if (puzzle.isSolved) {
+                    generatedSessionRepository.clear(expectedSessionId = expectedSessionId)
+                } else {
+                    generatedSessionRepository.updateCurrentPuzzle(
+                        expectedSessionId = expectedSessionId,
+                        puzzle = puzzle
+                    )
+                }
+            } catch (_: IOException) {
+                // Keep the playable in-memory session when local persistence is temporarily unavailable.
+            }
+        }
+    }
+
+    private fun updateVisibleSession(expectedSessionId: GeneratedSessionId, puzzle: Puzzle): Boolean {
+        val state = _uiState.value
+        val visibleSession = when (state) {
+            is GeneratedPuzzleGenerationUiState.Ready -> state.session
+            is GeneratedPuzzleGenerationUiState.Loading -> state.previousSession
+            is GeneratedPuzzleGenerationUiState.Failed -> state.previousSession
+            GeneratedPuzzleGenerationUiState.Idle,
+            is GeneratedPuzzleGenerationUiState.Restoring,
+            is GeneratedPuzzleGenerationUiState.ResumeUnavailable -> null
+        }
+        if (
+            visibleSession?.id != expectedSessionId ||
+            visibleSession.currentPuzzle == puzzle
+        ) {
+            return false
+        }
+
+        val updatedSession = visibleSession.copy(
+            snapshot = visibleSession.snapshot.copy(currentPuzzle = puzzle)
+        )
+        _uiState.value = when (state) {
+            is GeneratedPuzzleGenerationUiState.Ready -> state.copy(session = updatedSession)
+            is GeneratedPuzzleGenerationUiState.Loading -> state.copy(previousSession = updatedSession)
+            is GeneratedPuzzleGenerationUiState.Failed -> state.copy(previousSession = updatedSession)
+            GeneratedPuzzleGenerationUiState.Idle,
+            is GeneratedPuzzleGenerationUiState.Restoring,
+            is GeneratedPuzzleGenerationUiState.ResumeUnavailable -> state
+        }
+        return true
     }
 
     private fun startResume(launchIntent: GeneratedModeLaunchIntent.ResumeSession) {

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModelTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModelTest.kt
@@ -208,19 +208,7 @@ class GeneratedPuzzleViewModelTest {
     fun resume_rejects_missing_stale_mismatched_and_solved_sessions() {
         val expectedSessionId = GeneratedSessionId("expected")
         val solvedPuzzle = solvedPuzzleWithKnownStripAndAssignments()
-        val solvedInitialPuzzle = solvedPuzzle.copy(
-            board = solvedPuzzle.board.copy(
-                tiles = solvedPuzzle.board.tiles.map { tile ->
-                    tile.copy(
-                        expression = tile.expression.copy(
-                            leftOperand = Expression.Operand.Hidden,
-                            operator = Operator.Hidden,
-                            rightOperand = Expression.Operand.Hidden
-                        )
-                    )
-                }
-            )
-        )
+        val solvedInitialPuzzle = initialPuzzleFor(solvedPuzzle)
         val unavailableSnapshots = listOf(
             null,
             generatedSessionSnapshot(sessionId = "stale"),
@@ -262,6 +250,135 @@ class GeneratedPuzzleViewModelTest {
             assertEquals(0, generationUseCase.requestCount)
             assertTrue(repository.replaceAttempts.isEmpty())
         }
+    }
+
+    @Test
+    fun committed_puzzle_changes_update_the_visible_and_durable_session_in_order() {
+        val firstWriteGate = CompletableDeferred<Unit>()
+        val repository = RecordingGeneratedSessionRepository(firstUpdateGate = firstWriteGate)
+        val viewModel = GeneratedPuzzleViewModel(
+            mode = GeneratedModes.FOUR_PAIRS,
+            generationUseCase = generatedPuzzleUseCase(),
+            generatedSessionRepository = repository,
+            seedSource = QueueGeneratedPuzzleSeedSource(41),
+            sessionIdSource = QueueGeneratedSessionIdSource("active")
+        )
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.advanceUntilIdle()
+        val sessionId = (viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready).session.id
+        val firstPuzzle = samplePuzzle.copy(
+            strip = samplePuzzle.strip.withUpdatedEntry(index = 1, value = 1)
+        )
+        val latestPuzzle = samplePuzzle.copy(
+            strip = samplePuzzle.strip.withUpdatedEntry(index = 1, value = 2)
+        )
+
+        viewModel.onPuzzleChanged(sessionId, firstPuzzle)
+        dispatcher.scheduler.runCurrent()
+        viewModel.onPuzzleChanged(sessionId, latestPuzzle)
+        dispatcher.scheduler.runCurrent()
+
+        val visibleSession = (viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready).session
+        assertEquals(latestPuzzle, visibleSession.currentPuzzle)
+        assertEquals(samplePuzzle, repository.session.value?.currentPuzzle)
+
+        firstWriteGate.complete(Unit)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf(firstPuzzle, latestPuzzle), repository.updateAttempts)
+        assertEquals(latestPuzzle, repository.session.value?.currentPuzzle)
+    }
+
+    @Test
+    fun solved_puzzle_clears_resumability_while_remaining_visible() {
+        val solvedPuzzle = solvedPuzzleWithKnownStripAndAssignments()
+        val initialPuzzle = initialPuzzleFor(solvedPuzzle)
+        val repository = RecordingGeneratedSessionRepository()
+        val viewModel = GeneratedPuzzleViewModel(
+            mode = GeneratedModes.FOUR_PAIRS,
+            generationUseCase = generatedPuzzleUseCase(CompletableDeferred(initialPuzzle)),
+            generatedSessionRepository = repository,
+            seedSource = QueueGeneratedPuzzleSeedSource(43),
+            sessionIdSource = QueueGeneratedSessionIdSource("solved")
+        )
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.advanceUntilIdle()
+        val sessionId = (viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready).session.id
+
+        viewModel.onPuzzleChanged(sessionId, solvedPuzzle)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val visibleSession = (viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready).session
+        assertEquals(solvedPuzzle, visibleSession.currentPuzzle)
+        assertEquals(listOf(sessionId), repository.clearAttempts)
+        assertNull(repository.session.value)
+    }
+
+    @Test
+    fun stale_puzzle_callback_cannot_change_a_replacement_session() {
+        val replacementPuzzle = CompletableDeferred<Puzzle>()
+        val repository = RecordingGeneratedSessionRepository()
+        val viewModel = GeneratedPuzzleViewModel(
+            mode = GeneratedModes.FOUR_PAIRS,
+            generationUseCase = QueueGeneratedPuzzleUseCase(
+                CompletableDeferred(samplePuzzle),
+                replacementPuzzle
+            ),
+            generatedSessionRepository = repository,
+            seedSource = QueueGeneratedPuzzleSeedSource(47, 53),
+            sessionIdSource = QueueGeneratedSessionIdSource("previous", "replacement")
+        )
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.advanceUntilIdle()
+        val previousSession = (viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready).session
+
+        viewModel.onNewPuzzleRequested()
+        dispatcher.scheduler.runCurrent()
+        replacementPuzzle.complete(samplePuzzle)
+        dispatcher.scheduler.advanceUntilIdle()
+        val replacementSession = (viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready).session
+        val stalePuzzle = samplePuzzle.copy(
+            strip = samplePuzzle.strip.withUpdatedEntry(index = 1, value = 2)
+        )
+
+        viewModel.onPuzzleChanged(previousSession.id, stalePuzzle)
+        viewModel.onPuzzleChanged(previousSession.id, solvedPuzzleWithKnownStripAndAssignments())
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(GeneratedSessionId("replacement"), replacementSession.id)
+        assertEquals(replacementSession.snapshot, repository.session.value)
+        assertTrue(repository.updateAttempts.isEmpty())
+        assertTrue(repository.clearAttempts.isEmpty())
+    }
+
+    @Test
+    fun cancelling_replacement_keeps_the_previous_session_visible_and_stored() {
+        val replacementPuzzle = CompletableDeferred<Puzzle>()
+        val repository = RecordingGeneratedSessionRepository()
+        val viewModel = GeneratedPuzzleViewModel(
+            mode = GeneratedModes.FOUR_PAIRS,
+            generationUseCase = QueueGeneratedPuzzleUseCase(
+                CompletableDeferred(samplePuzzle),
+                replacementPuzzle
+            ),
+            generatedSessionRepository = repository,
+            seedSource = QueueGeneratedPuzzleSeedSource(59, 61),
+            sessionIdSource = QueueGeneratedSessionIdSource("previous", "cancelled")
+        )
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.advanceUntilIdle()
+        val previousSession = (viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready).session
+
+        viewModel.onNewPuzzleRequested()
+        dispatcher.scheduler.runCurrent()
+        viewModel.onRouteExited()
+        replacementPuzzle.complete(samplePuzzle)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val loading = viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Loading
+        assertEquals(previousSession, loading.previousSession)
+        assertEquals(previousSession.snapshot, repository.session.value)
+        assertEquals(1, repository.replaceAttempts.size)
     }
 }
 
@@ -322,6 +439,17 @@ private class UnexpectedGeneratedPuzzleUseCase : GeneratedPuzzleGenerationUseCas
     }
 }
 
+private class QueueGeneratedPuzzleUseCase(private vararg val puzzles: CompletableDeferred<Puzzle>) :
+    GeneratedPuzzleGenerationUseCase {
+    private val remainingPuzzles = ArrayDeque(puzzles.toList())
+
+    override suspend fun generate(request: GeneratedPuzzleGenerationRequest): GeneratedPuzzleGenerationResult =
+        GeneratedPuzzleGenerationResult.Generated(
+            request = request,
+            initialPuzzle = remainingPuzzles.removeFirst().await()
+        )
+}
+
 private class QueueGeneratedPuzzleSeedSource(vararg seeds: Int) : GeneratedPuzzleSeedSource {
     private val values = ArrayDeque(seeds.toList())
 
@@ -337,11 +465,15 @@ private class QueueGeneratedSessionIdSource(vararg ids: String) : GeneratedSessi
 private class RecordingGeneratedSessionRepository(
     initialSession: GeneratedSessionSnapshot? = null,
     private val writeGate: CompletableDeferred<Unit>? = null,
-    private val replaceFailure: IOException? = null
+    private val replaceFailure: IOException? = null,
+    firstUpdateGate: CompletableDeferred<Unit>? = null
 ) : GeneratedSessionRepository {
     private val mutableSession = MutableStateFlow(initialSession)
+    private var pendingUpdateGate = firstUpdateGate
     override val session: StateFlow<GeneratedSessionSnapshot?> = mutableSession.asStateFlow()
     val replaceAttempts = mutableListOf<GeneratedSessionSnapshot>()
+    val updateAttempts = mutableListOf<Puzzle>()
+    val clearAttempts = mutableListOf<GeneratedSessionId>()
 
     override suspend fun replace(snapshot: GeneratedSessionSnapshot) {
         replaceAttempts += snapshot
@@ -353,6 +485,11 @@ private class RecordingGeneratedSessionRepository(
     }
 
     override suspend fun updateCurrentPuzzle(expectedSessionId: GeneratedSessionId, puzzle: Puzzle): Boolean {
+        updateAttempts += puzzle
+        pendingUpdateGate?.let { gate ->
+            pendingUpdateGate = null
+            gate.await()
+        }
         val snapshot = mutableSession.value
         if (snapshot?.sessionId != expectedSessionId) {
             return false
@@ -363,6 +500,7 @@ private class RecordingGeneratedSessionRepository(
     }
 
     override suspend fun clear(expectedSessionId: GeneratedSessionId): Boolean {
+        clearAttempts += expectedSessionId
         if (mutableSession.value?.sessionId != expectedSessionId) {
             return false
         }
@@ -385,4 +523,18 @@ private fun generatedSessionSnapshot(
     seed = 7,
     initialPuzzle = initialPuzzle,
     currentPuzzle = currentPuzzle
+)
+
+private fun initialPuzzleFor(solvedPuzzle: Puzzle): Puzzle = solvedPuzzle.copy(
+    board = solvedPuzzle.board.copy(
+        tiles = solvedPuzzle.board.tiles.map { tile ->
+            tile.copy(
+                expression = tile.expression.copy(
+                    leftOperand = Expression.Operand.Hidden,
+                    operator = Operator.Hidden,
+                    rightOperand = Expression.Operand.Hidden
+                )
+            )
+        }
+    )
 )


### PR DESCRIPTION
## Related Issue

Resolves #444

## Summary

- Forward exact committed generated-game puzzle changes with their stable session identity.
- Keep visible and durable session progress synchronized through ordered identity-guarded writes.
- Clear resumability on solved state and reject stale update or clear callbacks after replacement.
- Preserve the previous session through replacement generation failure and cancellation, with coverage for successful adoption and deduplication.
- Add route coverage proving transient input drafts are not persisted before commit.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
