### PR TITLE
[213] Add conditional Resume menu action

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionResumeNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionResumeNavigationTest.kt
@@ -1,0 +1,139 @@
+package org.cescfe.numpairs.ui.navigation
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionId
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionSnapshot
+import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
+import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
+import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
+import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationResult
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCase
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
+import org.cescfe.numpairs.feature.menu.ui.MenuScreenTestTags
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GeneratedSessionResumeNavigationTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun menu_hides_resume_without_a_resumable_session() {
+        setContent(repository = FakeGeneratedSessionRepository())
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.RESUME_BUTTON)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun menu_orders_resume_first_and_opens_the_exact_session_without_generation() {
+        val currentPuzzle = samplePuzzle.copy(
+            strip = samplePuzzle.strip.withUpdatedEntry(index = 1, value = 2)
+        )
+        val snapshot = GeneratedSessionSnapshot(
+            sessionId = GeneratedSessionId("resume-from-menu"),
+            modeId = GeneratedModes.FOUR_PAIRS.id.value,
+            profileId = GeneratedModes.FOUR_PAIRS.profile.id.value,
+            seed = 213,
+            initialPuzzle = samplePuzzle,
+            currentPuzzle = currentPuzzle
+        )
+        val repository = FakeGeneratedSessionRepository(initialSession = snapshot)
+        val generationCounter = GenerationCounter()
+        setContent(repository = repository, generationCounter = generationCounter)
+
+        val resumeNode = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.RESUME_BUTTON)
+            .assertIsDisplayed()
+            .assertContentDescriptionEquals(
+                string(
+                    R.string.menu_resume_content_description,
+                    string(R.string.four_pairs_screen_title)
+                )
+            )
+        val resumeTop = resumeNode.fetchSemanticsNode().boundsInRoot.top
+        val fourPairsTop = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
+            .fetchSemanticsNode()
+            .boundsInRoot
+            .top
+        val eightPairsTop = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.EIGHT_PAIRS_BUTTON)
+            .fetchSemanticsNode()
+            .boundsInRoot
+            .top
+        val tutorialTop = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.TUTORIAL_BUTTON)
+            .fetchSemanticsNode()
+            .boundsInRoot
+            .top
+        assertTrue(resumeTop < fourPairsTop)
+        assertTrue(fourPairsTop < eightPairsTop)
+        assertTrue(eightPairsTop < tutorialTop)
+
+        resumeNode.performClick()
+
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.stripItem(1))
+            .performScrollTo()
+            .assertContentDescriptionEquals(
+                string(R.string.strip_item_player_entered_content_description, "2")
+            )
+        composeTestRule.runOnIdle {
+            assertEquals(0, generationCounter.count)
+            assertEquals(snapshot, repository.session.value)
+        }
+    }
+
+    private fun setContent(
+        repository: FakeGeneratedSessionRepository,
+        generationCounter: GenerationCounter = GenerationCounter()
+    ) {
+        composeTestRule.setContent {
+            NumPairsTheme {
+                AppNavigation(
+                    onboardingRepository = FakeOnboardingRepository(),
+                    generatedSessionRepository = repository,
+                    topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
+                    generatedModeRegistry = GeneratedModes.registry,
+                    generatedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory {
+                        GeneratedPuzzleGenerationUseCase { request ->
+                            generationCounter.count++
+                            GeneratedPuzzleGenerationResult.Generated(
+                                request = request,
+                                initialPuzzle = samplePuzzle
+                            )
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    private fun string(stringResId: Int, vararg formatArgs: Any): String =
+        composeTestRule.activity.getString(stringResId, *formatArgs)
+
+    private class GenerationCounter {
+        var count: Int = 0
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/MenuRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/MenuRoute.kt
@@ -7,12 +7,16 @@ import org.cescfe.numpairs.feature.menu.ui.MenuScreen
 @Composable
 fun MenuRoute(
     modifier: Modifier = Modifier,
+    resumeModeName: String? = null,
+    onResumeSelected: () -> Unit = {},
     onTutorialSelected: () -> Unit = {},
     onFourPairsSelected: () -> Unit = {},
     onEightPairsSelected: () -> Unit = {}
 ) {
     MenuScreen(
         modifier = modifier,
+        resumeModeName = resumeModeName,
+        onResumeSelected = onResumeSelected,
         onTutorialSelected = onTutorialSelected,
         onFourPairsSelected = onFourPairsSelected,
         onEightPairsSelected = onEightPairsSelected

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -31,6 +33,8 @@ import org.cescfe.numpairs.ui.theme.NumPairsTheme
 @Composable
 fun MenuScreen(
     modifier: Modifier = Modifier,
+    resumeModeName: String? = null,
+    onResumeSelected: () -> Unit = {},
     onTutorialSelected: () -> Unit = {},
     onFourPairsSelected: () -> Unit = {},
     onEightPairsSelected: () -> Unit = {}
@@ -62,6 +66,24 @@ fun MenuScreen(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
+                    resumeModeName?.let { modeName ->
+                        val resumeContentDescription = stringResource(
+                            R.string.menu_resume_content_description,
+                            modeName
+                        )
+                        NumPairsComponents.PrimaryCtaButton(
+                            onClick = onResumeSelected,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(NumPairsComponents.ButtonHeight)
+                                .semantics {
+                                    contentDescription = resumeContentDescription
+                                }
+                                .testTag(MenuScreenTestTags.RESUME_BUTTON)
+                        ) {
+                            MenuButtonText(text = stringResource(R.string.menu_resume_button))
+                        }
+                    }
                     NumPairsComponents.PrimaryCtaButton(
                         onClick = onFourPairsSelected,
                         modifier = Modifier

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTestTags.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTestTags.kt
@@ -2,6 +2,7 @@ package org.cescfe.numpairs.feature.menu.ui
 
 object MenuScreenTestTags {
     const val SCREEN = "menu_screen"
+    const val RESUME_BUTTON = "menu_resume_button"
     const val TUTORIAL_BUTTON = "menu_tutorial_button"
     const val FOUR_PAIRS_BUTTON = "menu_four_pairs_button"
     const val EIGHT_PAIRS_BUTTON = "menu_eight_pairs_button"

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -73,6 +73,10 @@ private fun UnlockedAppNavigation(
     modifier: Modifier,
     startDestination: AppDestination
 ) {
+    val generatedSessionSnapshot by generatedSessionRepository.session.collectAsState(initial = null)
+    val resumableSession = generatedSessionSnapshot.toResumableGeneratedSessionOrNull(
+        modeRegistry = generatedModeRegistry
+    )
     var currentDestination by remember(startDestination) {
         mutableStateOf(startDestination)
     }
@@ -87,6 +91,21 @@ private fun UnlockedAppNavigation(
     when (val destination = currentDestination) {
         AppDestination.Menu -> MenuRoute(
             modifier = modifier,
+            resumeModeName = resumableSession?.mode?.let { mode ->
+                mode.titleResourceIdOrNull()?.let { titleResourceId ->
+                    stringResource(id = titleResourceId)
+                } ?: mode.id.value
+            },
+            onResumeSelected = {
+                resumableSession?.let { session ->
+                    currentDestination = AppDestination.GeneratedMode(
+                        modeId = session.mode.id,
+                        launchIntent = GeneratedModeLaunchIntent.ResumeSession(
+                            expectedSessionId = session.sessionId
+                        )
+                    )
+                }
+            },
             onTutorialSelected = {
                 currentDestination = AppDestination.Tutorial
             },

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/ResumableGeneratedSession.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/ResumableGeneratedSession.kt
@@ -1,0 +1,29 @@
+package org.cescfe.numpairs.ui.navigation
+
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionId
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionSnapshot
+import org.cescfe.numpairs.feature.generated.GeneratedModeConfiguration
+import org.cescfe.numpairs.feature.generated.GeneratedModeRegistry
+
+internal data class ResumableGeneratedSession(val sessionId: GeneratedSessionId, val mode: GeneratedModeConfiguration)
+
+internal fun GeneratedSessionSnapshot?.toResumableGeneratedSessionOrNull(
+    modeRegistry: GeneratedModeRegistry
+): ResumableGeneratedSession? {
+    val snapshot = this ?: return null
+    if (snapshot.currentPuzzle.isSolved) {
+        return null
+    }
+
+    val mode = modeRegistry.all.singleOrNull { configuration ->
+        configuration.id.value == snapshot.modeId
+    } ?: return null
+    if (mode.profile.id.value != snapshot.profileId) {
+        return null
+    }
+
+    return ResumableGeneratedSession(
+        sessionId = snapshot.sessionId,
+        mode = mode
+    )
+}

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -4,6 +4,8 @@
     <string name="back_button_content_description">Arrere</string>
 
     <!-- Menu screen -->
+    <string name="menu_resume_button">Continua</string>
+    <string name="menu_resume_content_description">Continua el puzle de %1$s</string>
     <string name="menu_tutorial_button">Com jugar</string>
     <string name="menu_four_pairs_button">Juga a 4 parelles</string>
     <string name="menu_eight_pairs_button">Juga a 8 parelles</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4,6 +4,8 @@
     <string name="back_button_content_description">Atrás</string>
 
     <!-- Menu screen -->
+    <string name="menu_resume_button">Continuar</string>
+    <string name="menu_resume_content_description">Continuar puzle de %1$s</string>
     <string name="menu_tutorial_button">Cómo jugar</string>
     <string name="menu_four_pairs_button">Jugar 4 pares</string>
     <string name="menu_eight_pairs_button">Jugar 8 pares</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="back_button_content_description">Back</string>
 
     <!-- Menu screen -->
+    <string name="menu_resume_button">Resume</string>
+    <string name="menu_resume_content_description">Resume %1$s puzzle</string>
     <string name="menu_tutorial_button">How to play</string>
     <string name="menu_four_pairs_button">Play 4 pairs</string>
     <string name="menu_eight_pairs_button">Play 8 pairs</string>

--- a/app/src/test/java/org/cescfe/numpairs/ui/navigation/ResumableGeneratedSessionTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/ui/navigation/ResumableGeneratedSessionTest.kt
@@ -1,0 +1,78 @@
+package org.cescfe.numpairs.ui.navigation
+
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionId
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionSnapshot
+import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.feature.game.presentation.support.solvedPuzzleWithKnownStripAndAssignments
+import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ResumableGeneratedSessionTest {
+    @Test
+    fun `valid unfinished snapshot resolves its configured generated mode`() {
+        val snapshot = snapshot()
+
+        assertEquals(
+            ResumableGeneratedSession(
+                sessionId = snapshot.sessionId,
+                mode = GeneratedModes.FOUR_PAIRS
+            ),
+            snapshot.toResumableGeneratedSessionOrNull(GeneratedModes.registry)
+        )
+    }
+
+    @Test
+    fun `missing unknown mismatched and solved snapshots are not resumable`() {
+        val solvedPuzzle = solvedPuzzleWithKnownStripAndAssignments()
+        val unavailableSnapshots = listOf(
+            null,
+            snapshot(modeId = "unknown-mode"),
+            snapshot(profileId = GeneratedModes.EIGHT_PAIRS.profile.id.value),
+            snapshot(
+                initialPuzzle = initialPuzzleFor(solvedPuzzle),
+                currentPuzzle = solvedPuzzle
+            )
+        )
+
+        unavailableSnapshots.forEach { unavailableSnapshot ->
+            assertNull(
+                unavailableSnapshot.toResumableGeneratedSessionOrNull(
+                    modeRegistry = GeneratedModes.registry
+                )
+            )
+        }
+    }
+}
+
+private fun snapshot(
+    modeId: String = GeneratedModes.FOUR_PAIRS.id.value,
+    profileId: String = GeneratedModes.FOUR_PAIRS.profile.id.value,
+    initialPuzzle: Puzzle = samplePuzzle,
+    currentPuzzle: Puzzle = samplePuzzle
+): GeneratedSessionSnapshot = GeneratedSessionSnapshot(
+    sessionId = GeneratedSessionId("session-213"),
+    modeId = modeId,
+    profileId = profileId,
+    seed = 213,
+    initialPuzzle = initialPuzzle,
+    currentPuzzle = currentPuzzle
+)
+
+private fun initialPuzzleFor(solvedPuzzle: Puzzle): Puzzle = solvedPuzzle.copy(
+    board = solvedPuzzle.board.copy(
+        tiles = solvedPuzzle.board.tiles.map { tile ->
+            tile.copy(
+                expression = tile.expression.copy(
+                    leftOperand = Expression.Operand.Hidden,
+                    operator = Operator.Hidden,
+                    rightOperand = Expression.Operand.Hidden
+                )
+            )
+        }
+    )
+)


### PR DESCRIPTION
## Related Issue

Resolves #448

## Summary

- Derive one typed resumable menu session only for configured, matching, unfinished snapshots.
- Show a localized primary `Resume` action before both generated-mode actions and identify its mode to accessibility.
- Navigate directly with the stable session id without invoking puzzle generation.
- Add resolver unit tests and compiled menu/navigation coverage for hidden, visible, ordered, and direct-resume behavior.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
