### PR TITLE
[214] Add generated session choice dialog

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceNavigationTest.kt
@@ -1,0 +1,277 @@
+package org.cescfe.numpairs.ui.navigation
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.espresso.Espresso.pressBackUnconditionally
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionId
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionSnapshot
+import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
+import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
+import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.domain.puzzle.model.Board
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.Strip
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.cescfe.numpairs.domain.puzzle.model.Tile
+import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
+import org.cescfe.numpairs.feature.generated.GeneratedModeConfiguration
+import org.cescfe.numpairs.feature.generated.GeneratedModeId
+import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationResult
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCase
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
+import org.cescfe.numpairs.feature.menu.ui.MenuScreenTestTags
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GeneratedSessionChoiceNavigationTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun generated_mode_starts_directly_when_no_session_is_resumable() {
+        val repository = FakeGeneratedSessionRepository()
+        val recorder = setContent(repository)
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SESSION_CHOICE_DIALOG)
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(listOf(GeneratedModes.FOUR_PAIRS.id), recorder.generatedModes)
+        }
+    }
+
+    @Test
+    fun same_mode_choice_keeps_resume_primary_and_opens_the_stored_session() {
+        val snapshot = resumableFourPairsSnapshot()
+        val repository = FakeGeneratedSessionRepository(initialSession = snapshot)
+        val recorder = setContent(repository)
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
+            .performClick()
+
+        assertChoiceDialogVisible()
+        composeTestRule
+            .onNodeWithText(
+                string(
+                    R.string.generated_session_choice_same_mode_message,
+                    string(R.string.four_pairs_screen_title)
+                )
+            )
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SESSION_CHOICE_RESUME_BUTTON)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(string(R.string.generated_session_choice_new_puzzle_button))
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertTrue(recorder.generatedModes.isEmpty())
+            assertEquals(snapshot, repository.session.value)
+        }
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SESSION_CHOICE_RESUME_BUTTON)
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertTrue(recorder.generatedModes.isEmpty())
+            assertEquals(snapshot, repository.session.value)
+        }
+    }
+
+    @Test
+    fun different_mode_secondary_action_replaces_with_the_selected_mode() {
+        val snapshot = resumableFourPairsSnapshot()
+        val repository = FakeGeneratedSessionRepository(initialSession = snapshot)
+        val recorder = setContent(repository)
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.EIGHT_PAIRS_BUTTON)
+            .performClick()
+
+        assertChoiceDialogVisible()
+        composeTestRule
+            .onNodeWithText(
+                string(
+                    R.string.generated_session_choice_different_mode_message,
+                    string(R.string.four_pairs_screen_title),
+                    string(R.string.eight_pairs_screen_title)
+                )
+            )
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SESSION_CHOICE_RESUME_BUTTON)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                string(
+                    R.string.generated_session_choice_play_mode_button,
+                    string(R.string.eight_pairs_screen_title)
+                )
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SESSION_CHOICE_NEW_PUZZLE_BUTTON)
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(listOf(GeneratedModes.EIGHT_PAIRS.id), recorder.generatedModes)
+            assertEquals(GeneratedModes.EIGHT_PAIRS.id.value, repository.session.value?.modeId)
+        }
+    }
+
+    @Test
+    fun system_back_and_outside_tap_dismiss_without_side_effects() {
+        val snapshot = resumableFourPairsSnapshot()
+        val repository = FakeGeneratedSessionRepository(initialSession = snapshot)
+        val recorder = setContent(repository)
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.EIGHT_PAIRS_BUTTON)
+            .performClick()
+        assertChoiceDialogVisible()
+        pressBackUnconditionally()
+        assertDismissedWithoutSideEffects(snapshot, repository, recorder)
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
+            .performClick()
+        assertChoiceDialogVisible()
+        composeTestRule
+            .onRoot()
+            .performTouchInput {
+                click(Offset(1f, 1f))
+            }
+        assertDismissedWithoutSideEffects(snapshot, repository, recorder)
+    }
+
+    private fun assertChoiceDialogVisible() {
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SESSION_CHOICE_DIALOG)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(string(R.string.generated_session_choice_title))
+            .assertIsDisplayed()
+    }
+
+    private fun assertDismissedWithoutSideEffects(
+        snapshot: GeneratedSessionSnapshot,
+        repository: FakeGeneratedSessionRepository,
+        recorder: GenerationRecorder
+    ) {
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SESSION_CHOICE_DIALOG)
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertTrue(recorder.generatedModes.isEmpty())
+            assertEquals(snapshot, repository.session.value)
+        }
+    }
+
+    private fun setContent(repository: FakeGeneratedSessionRepository): GenerationRecorder {
+        val recorder = GenerationRecorder()
+        composeTestRule.setContent {
+            NumPairsTheme {
+                AppNavigation(
+                    onboardingRepository = FakeOnboardingRepository(),
+                    generatedSessionRepository = repository,
+                    topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
+                    generatedModeRegistry = GeneratedModes.registry,
+                    generatedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory { mode ->
+                        GeneratedPuzzleGenerationUseCase { request ->
+                            recorder.generatedModes += mode.id
+                            GeneratedPuzzleGenerationResult.Generated(
+                                request = request,
+                                initialPuzzle = initialPuzzleFor(mode)
+                            )
+                        }
+                    }
+                )
+            }
+        }
+        return recorder
+    }
+
+    private fun initialPuzzleFor(mode: GeneratedModeConfiguration): Puzzle = when (mode.id) {
+        GeneratedModes.FOUR_PAIRS.id -> samplePuzzle
+        GeneratedModes.EIGHT_PAIRS.id -> eightPairsPuzzle()
+        else -> error("Unsupported test mode ${mode.id.value}.")
+    }
+
+    private fun eightPairsPuzzle(): Puzzle = Puzzle(
+        board = Board(
+            tiles = List(EIGHT_PAIRS_ENTRY_COUNT) { index ->
+                Tile(
+                    expression = Expression(
+                        leftOperand = Expression.Operand.Hidden,
+                        operator = Operator.Hidden,
+                        rightOperand = Expression.Operand.Hidden
+                    ),
+                    result = index + 2
+                )
+            }
+        ),
+        strip = Strip.fromItems(
+            items = List(EIGHT_PAIRS_ENTRY_COUNT) {
+                StripItem.Hidden
+            }
+        )
+    )
+
+    private fun string(stringResId: Int, vararg formatArgs: Any): String =
+        composeTestRule.activity.getString(stringResId, *formatArgs)
+
+    private class GenerationRecorder {
+        val generatedModes = mutableListOf<GeneratedModeId>()
+    }
+
+    private companion object {
+        const val EIGHT_PAIRS_ENTRY_COUNT = 16
+    }
+}
+
+private fun resumableFourPairsSnapshot(): GeneratedSessionSnapshot = GeneratedSessionSnapshot(
+    sessionId = GeneratedSessionId("session-choice"),
+    modeId = GeneratedModes.FOUR_PAIRS.id.value,
+    profileId = GeneratedModes.FOUR_PAIRS.profile.id.value,
+    seed = 214,
+    initialPuzzle = samplePuzzle,
+    currentPuzzle = samplePuzzle
+)

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/GeneratedSessionChoiceDialog.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/GeneratedSessionChoiceDialog.kt
@@ -1,0 +1,92 @@
+package org.cescfe.numpairs.feature.menu.ui
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.DialogProperties
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.ui.theme.NumPairsComponents
+
+@Composable
+internal fun GeneratedSessionChoiceDialog(
+    savedModeName: String,
+    selectedModeName: String,
+    isSameMode: Boolean,
+    onResume: () -> Unit,
+    onNewPuzzle: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        modifier = Modifier.testTag(MenuScreenTestTags.SESSION_CHOICE_DIALOG),
+        onDismissRequest = onDismiss,
+        shape = NumPairsComponents.LargeShape,
+        containerColor = NumPairsComponents.raisedSurfaceColor(),
+        titleContentColor = MaterialTheme.colorScheme.onSurface,
+        textContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        title = {
+            Text(
+                text = stringResource(R.string.generated_session_choice_title),
+                style = MaterialTheme.typography.titleMedium
+            )
+        },
+        text = {
+            Text(
+                text = if (isSameMode) {
+                    stringResource(
+                        R.string.generated_session_choice_same_mode_message,
+                        savedModeName
+                    )
+                } else {
+                    stringResource(
+                        R.string.generated_session_choice_different_mode_message,
+                        savedModeName,
+                        selectedModeName
+                    )
+                },
+                style = MaterialTheme.typography.bodyMedium
+            )
+        },
+        confirmButton = {
+            Button(
+                onClick = onResume,
+                modifier = Modifier.testTag(MenuScreenTestTags.SESSION_CHOICE_RESUME_BUTTON)
+            ) {
+                Text(
+                    text = stringResource(R.string.menu_resume_button),
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+        },
+        dismissButton = {
+            OutlinedButton(
+                onClick = onNewPuzzle,
+                modifier = Modifier.testTag(MenuScreenTestTags.SESSION_CHOICE_NEW_PUZZLE_BUTTON),
+                shape = NumPairsComponents.MediumShape,
+                colors = NumPairsComponents.secondaryButtonColors(),
+                border = NumPairsComponents.secondaryButtonBorder()
+            ) {
+                Text(
+                    text = if (isSameMode) {
+                        stringResource(R.string.generated_session_choice_new_puzzle_button)
+                    } else {
+                        stringResource(
+                            R.string.generated_session_choice_play_mode_button,
+                            selectedModeName
+                        )
+                    },
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+        },
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true
+        )
+    )
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTestTags.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTestTags.kt
@@ -6,4 +6,7 @@ object MenuScreenTestTags {
     const val TUTORIAL_BUTTON = "menu_tutorial_button"
     const val FOUR_PAIRS_BUTTON = "menu_four_pairs_button"
     const val EIGHT_PAIRS_BUTTON = "menu_eight_pairs_button"
+    const val SESSION_CHOICE_DIALOG = "generated_session_choice_dialog"
+    const val SESSION_CHOICE_RESUME_BUTTON = "generated_session_choice_resume_button"
+    const val SESSION_CHOICE_NEW_PUZZLE_BUTTON = "generated_session_choice_new_puzzle_button"
 }

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -14,6 +14,7 @@ import org.cescfe.numpairs.data.onboarding.OnboardingRepository
 import org.cescfe.numpairs.data.onboarding.OnboardingState
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.feature.fourpairs.FourPairsRoute
+import org.cescfe.numpairs.feature.generated.GeneratedModeConfiguration
 import org.cescfe.numpairs.feature.generated.GeneratedModeId
 import org.cescfe.numpairs.feature.generated.GeneratedModeLaunchIntent
 import org.cescfe.numpairs.feature.generated.GeneratedModeRegistry
@@ -21,6 +22,7 @@ import org.cescfe.numpairs.feature.generated.GeneratedModeRoute
 import org.cescfe.numpairs.feature.generated.GeneratedModes
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
 import org.cescfe.numpairs.feature.menu.MenuRoute
+import org.cescfe.numpairs.feature.menu.ui.GeneratedSessionChoiceDialog
 import org.cescfe.numpairs.feature.onboarding.OnboardingLoadingScreen
 import org.cescfe.numpairs.feature.onboarding.RequiredOnboardingRoute
 import org.cescfe.numpairs.feature.tutorial.GuidedIntroductionRoute
@@ -77,11 +79,28 @@ private fun UnlockedAppNavigation(
     val resumableSession = generatedSessionSnapshot.toResumableGeneratedSessionOrNull(
         modeRegistry = generatedModeRegistry
     )
+    var pendingGeneratedModeChoice by remember {
+        mutableStateOf<GeneratedModeConfiguration?>(null)
+    }
     var currentDestination by remember(startDestination) {
         mutableStateOf(startDestination)
     }
     val navigateToMenu: () -> Unit = {
+        pendingGeneratedModeChoice = null
         currentDestination = AppDestination.Menu
+    }
+    val navigateToNewGeneratedPuzzle: (GeneratedModeConfiguration) -> Unit = { mode ->
+        currentDestination = AppDestination.GeneratedMode(
+            modeId = mode.id,
+            launchIntent = GeneratedModeLaunchIntent.newPuzzle()
+        )
+    }
+    val onGeneratedModeSelected: (GeneratedModeConfiguration) -> Unit = { selectedMode ->
+        if (resumableSession == null) {
+            navigateToNewGeneratedPuzzle(selectedMode)
+        } else {
+            pendingGeneratedModeChoice = selectedMode
+        }
     }
 
     BackHandler(enabled = currentDestination != AppDestination.Menu) {
@@ -89,33 +108,64 @@ private fun UnlockedAppNavigation(
     }
 
     when (val destination = currentDestination) {
-        AppDestination.Menu -> MenuRoute(
-            modifier = modifier,
-            resumeModeName = resumableSession?.mode?.let { mode ->
-                mode.titleResourceIdOrNull()?.let { titleResourceId ->
-                    stringResource(id = titleResourceId)
-                } ?: mode.id.value
-            },
-            onResumeSelected = {
-                resumableSession?.let { session ->
-                    currentDestination = AppDestination.GeneratedMode(
-                        modeId = session.mode.id,
-                        launchIntent = GeneratedModeLaunchIntent.ResumeSession(
-                            expectedSessionId = session.sessionId
+        AppDestination.Menu -> {
+            MenuRoute(
+                modifier = modifier,
+                resumeModeName = resumableSession?.mode?.localizedTitle(),
+                onResumeSelected = {
+                    resumableSession?.let { session ->
+                        currentDestination = AppDestination.GeneratedMode(
+                            modeId = session.mode.id,
+                            launchIntent = GeneratedModeLaunchIntent.ResumeSession(
+                                expectedSessionId = session.sessionId
+                            )
                         )
-                    )
+                    }
+                },
+                onTutorialSelected = {
+                    currentDestination = AppDestination.Tutorial
+                },
+                onFourPairsSelected = {
+                    onGeneratedModeSelected(GeneratedModes.FOUR_PAIRS)
+                },
+                onEightPairsSelected = {
+                    onGeneratedModeSelected(GeneratedModes.EIGHT_PAIRS)
                 }
-            },
-            onTutorialSelected = {
-                currentDestination = AppDestination.Tutorial
-            },
-            onFourPairsSelected = {
-                currentDestination = AppDestination.GeneratedMode(modeId = GeneratedModes.FOUR_PAIRS.id)
-            },
-            onEightPairsSelected = {
-                currentDestination = AppDestination.GeneratedMode(modeId = GeneratedModes.EIGHT_PAIRS.id)
+            )
+            val selectedMode = pendingGeneratedModeChoice
+            if (selectedMode != null && resumableSession != null) {
+                val actionGuard = remember(selectedMode.id, resumableSession.sessionId) {
+                    GeneratedSessionChoiceActionGuard()
+                }
+                GeneratedSessionChoiceDialog(
+                    savedModeName = resumableSession.mode.localizedTitle(),
+                    selectedModeName = selectedMode.localizedTitle(),
+                    isSameMode = resumableSession.mode.id == selectedMode.id,
+                    onResume = {
+                        actionGuard.handle {
+                            pendingGeneratedModeChoice = null
+                            currentDestination = AppDestination.GeneratedMode(
+                                modeId = resumableSession.mode.id,
+                                launchIntent = GeneratedModeLaunchIntent.ResumeSession(
+                                    expectedSessionId = resumableSession.sessionId
+                                )
+                            )
+                        }
+                    },
+                    onNewPuzzle = {
+                        actionGuard.handle {
+                            pendingGeneratedModeChoice = null
+                            navigateToNewGeneratedPuzzle(selectedMode)
+                        }
+                    },
+                    onDismiss = {
+                        if (!actionGuard.isHandled) {
+                            pendingGeneratedModeChoice = null
+                        }
+                    }
+                )
             }
-        )
+        }
         AppDestination.Tutorial -> GuidedIntroductionRoute(
             modifier = modifier,
             onNavigateBack = navigateToMenu
@@ -140,9 +190,7 @@ private fun UnlockedAppNavigation(
                 else -> GeneratedModeRoute(
                     mode = mode,
                     launchIntent = destination.launchIntent,
-                    title = mode.titleResourceIdOrNull()?.let { titleResourceId ->
-                        stringResource(id = titleResourceId)
-                    } ?: mode.id.value,
+                    title = mode.localizedTitle(),
                     generationUseCase = generationUseCase,
                     generatedSessionRepository = generatedSessionRepository,
                     modifier = modifier,
@@ -152,3 +200,8 @@ private fun UnlockedAppNavigation(
         }
     }
 }
+
+@Composable
+private fun GeneratedModeConfiguration.localizedTitle(): String = titleResourceIdOrNull()?.let { titleResourceId ->
+    stringResource(id = titleResourceId)
+} ?: id.value

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceActionGuard.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceActionGuard.kt
@@ -1,0 +1,15 @@
+package org.cescfe.numpairs.ui.navigation
+
+internal class GeneratedSessionChoiceActionGuard {
+    var isHandled: Boolean = false
+        private set
+
+    fun handle(action: () -> Unit) {
+        if (isHandled) {
+            return
+        }
+
+        isHandled = true
+        action()
+    }
+}

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -9,6 +9,11 @@
     <string name="menu_tutorial_button">Com jugar</string>
     <string name="menu_four_pairs_button">Juga a 4 parelles</string>
     <string name="menu_eight_pairs_button">Juga a 8 parelles</string>
+    <string name="generated_session_choice_title">Puzle sense acabar</string>
+    <string name="generated_session_choice_same_mode_message">Tens un puzle de %1$s sense acabar. Vols continuar-lo o començar-ne un de nou?</string>
+    <string name="generated_session_choice_different_mode_message">Tens un puzle de %1$s sense acabar. Vols continuar-lo o substituir-lo per un de nou de %2$s?</string>
+    <string name="generated_session_choice_new_puzzle_button">Puzle nou</string>
+    <string name="generated_session_choice_play_mode_button">Juga a %1$s</string>
 
     <!-- Four pairs screen -->
     <string name="four_pairs_screen_title">4 parelles</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -9,6 +9,11 @@
     <string name="menu_tutorial_button">Cómo jugar</string>
     <string name="menu_four_pairs_button">Jugar 4 pares</string>
     <string name="menu_eight_pairs_button">Jugar 8 pares</string>
+    <string name="generated_session_choice_title">Puzle sin terminar</string>
+    <string name="generated_session_choice_same_mode_message">Tienes un puzle de %1$s sin terminar. ¿Quieres continuarlo o empezar uno nuevo?</string>
+    <string name="generated_session_choice_different_mode_message">Tienes un puzle de %1$s sin terminar. ¿Quieres continuarlo o sustituirlo por uno nuevo de %2$s?</string>
+    <string name="generated_session_choice_new_puzzle_button">Nuevo puzle</string>
+    <string name="generated_session_choice_play_mode_button">Jugar %1$s</string>
 
     <!-- Four pairs screen -->
     <string name="four_pairs_screen_title">4 pares</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,11 @@
     <string name="menu_tutorial_button">How to play</string>
     <string name="menu_four_pairs_button">Play 4 pairs</string>
     <string name="menu_eight_pairs_button">Play 8 pairs</string>
+    <string name="generated_session_choice_title">Unfinished puzzle</string>
+    <string name="generated_session_choice_same_mode_message">You have an unfinished %1$s puzzle. Resume it or start a new puzzle?</string>
+    <string name="generated_session_choice_different_mode_message">You have an unfinished %1$s puzzle. Resume it or replace it with a new %2$s puzzle?</string>
+    <string name="generated_session_choice_new_puzzle_button">New puzzle</string>
+    <string name="generated_session_choice_play_mode_button">Play %1$s</string>
 
     <!-- Four pairs screen -->
     <string name="four_pairs_screen_title">4 pairs</string>

--- a/app/src/test/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceActionGuardTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceActionGuardTest.kt
@@ -1,0 +1,23 @@
+package org.cescfe.numpairs.ui.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GeneratedSessionChoiceActionGuardTest {
+    @Test
+    fun `only the first session choice action is handled`() {
+        val guard = GeneratedSessionChoiceActionGuard()
+        var handledCount = 0
+
+        guard.handle {
+            handledCount++
+        }
+        guard.handle {
+            handledCount++
+        }
+
+        assertTrue(guard.isHandled)
+        assertEquals(1, handledCount)
+    }
+}


### PR DESCRIPTION
## Related Issue

Resolves #449

## Summary

- Intercept both generated-mode actions with one shared session choice whenever any unfinished session is resumable.
- Keep `Resume` primary and start a new puzzle for the originally selected mode from the secondary action.
- Provide localized same-mode and different-mode copy without a separate cross-mode flow or visible cancel action.
- Dismiss through outside tap or system back without side effects and guard all choices against duplicate handling.
- Add unit and compiled navigation coverage for both modes, both actions, direct no-session launch, and both dismissal paths.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
