### PR TITLE
[215] Finalize completion session lifecycle

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/fourpairs/FourPairsCompletionActionsTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/fourpairs/FourPairsCompletionActionsTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.espresso.Espresso.pressBackUnconditionally
@@ -34,6 +35,7 @@ import org.cescfe.numpairs.ui.navigation.AppNavigation
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -52,8 +54,12 @@ class FourPairsCompletionActionsTest {
         val secondPuzzle = generatedPuzzle(seed = 42).initialPuzzle
         assertNotEquals(firstPuzzle.board.tiles[0].result, secondPuzzle.board.tiles[0].result)
         val puzzleProvider = QueueGeneratedPuzzleProvider(firstPuzzle, secondPuzzle)
+        val generatedSessionRepository = FakeGeneratedSessionRepository()
 
-        setContent(puzzleProvider = puzzleProvider)
+        setContent(
+            puzzleProvider = puzzleProvider,
+            generatedSessionRepository = generatedSessionRepository
+        )
 
         navigateToFourPairs()
         completeFirstTile(operator = firstSolvedPuzzle.board.tiles[0].expression.operator)
@@ -61,6 +67,17 @@ class FourPairsCompletionActionsTest {
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY_NEW_PUZZLE)
             .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(string(R.string.success_overlay_new_puzzle_button))
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY_RETURN_TO_MENU)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(string(R.string.success_overlay_return_to_menu_button))
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY_NEW_PUZZLE)
             .performClick()
 
         assertEquals(2, puzzleProvider.requestCount)
@@ -82,6 +99,10 @@ class FourPairsCompletionActionsTest {
         assertEquals(5, stripMask.hiddenEntryIds.size)
         assertFirstTileExpressionIsHidden()
         assertFirstTileShowsResult(secondPuzzle.board.tiles[0].result)
+        composeTestRule.runOnIdle {
+            assertEquals(secondPuzzle, generatedSessionRepository.session.value?.currentPuzzle)
+            assertEquals(GeneratedModes.FOUR_PAIRS.id.value, generatedSessionRepository.session.value?.modeId)
+        }
     }
 
     @Test
@@ -89,8 +110,12 @@ class FourPairsCompletionActionsTest {
         val solvedPuzzle = generatedPuzzle(seed = 81).solvedPuzzle
         val initialPuzzle = solvedPuzzle.withHiddenOperatorAt(tileIndex = 0)
         val puzzleProvider = QueueGeneratedPuzzleProvider(initialPuzzle)
+        val generatedSessionRepository = FakeGeneratedSessionRepository()
 
-        setContent(puzzleProvider = puzzleProvider)
+        setContent(
+            puzzleProvider = puzzleProvider,
+            generatedSessionRepository = generatedSessionRepository
+        )
 
         navigateToFourPairs()
         completeFirstTile(operator = solvedPuzzle.board.tiles[0].expression.operator)
@@ -98,6 +123,11 @@ class FourPairsCompletionActionsTest {
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY_RETURN_TO_MENU)
             .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(string(R.string.success_overlay_return_to_menu_button))
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY_RETURN_TO_MENU)
             .performClick()
 
         composeTestRule
@@ -106,6 +136,12 @@ class FourPairsCompletionActionsTest {
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.SCREEN)
             .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.RESUME_BUTTON)
+            .assertDoesNotExist()
+        composeTestRule.runOnIdle {
+            assertNull(generatedSessionRepository.session.value)
+        }
     }
 
     @Test
@@ -163,14 +199,17 @@ class FourPairsCompletionActionsTest {
         assertEquals(initialStripMask, currentStripMask())
     }
 
-    private fun setContent(puzzleProvider: QueueGeneratedPuzzleProvider) {
+    private fun setContent(
+        puzzleProvider: QueueGeneratedPuzzleProvider,
+        generatedSessionRepository: FakeGeneratedSessionRepository = FakeGeneratedSessionRepository()
+    ) {
         val actionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository()
 
         composeTestRule.setContent {
             NumPairsTheme {
                 AppNavigation(
                     onboardingRepository = FakeOnboardingRepository(),
-                    generatedSessionRepository = FakeGeneratedSessionRepository(),
+                    generatedSessionRepository = generatedSessionRepository,
                     topAppBarActionDiscoveryRepository = actionDiscoveryRepository,
                     generatedModeRegistry = GeneratedModes.registry,
                     generatedPuzzleGenerationUseCaseFactory = fourPairsProviderFactory(puzzleProvider = puzzleProvider)

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -86,8 +86,8 @@
     <string name="success_overlay_message">Puzle completat!</string>
     <string name="success_overlay_badge_text">OK</string>
     <string name="success_overlay_supporting_text">Totes les parelles coincidixen.</string>
-    <string name="success_overlay_new_puzzle_button">Nou puzle</string>
-    <string name="success_overlay_return_to_menu_button">Menú</string>
+    <string name="success_overlay_new_puzzle_button">Juga’n un altre</string>
+    <string name="success_overlay_return_to_menu_button">Torna al menú</string>
     <string name="hint_action_content_description">Obrir pistes de pràctica</string>
     <string name="rules_helper_action_content_description">Ajuda de regles</string>
     <string name="rules_helper_title">Com es juga</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -86,8 +86,8 @@
     <string name="success_overlay_message">¡Puzle completado!</string>
     <string name="success_overlay_badge_text">OK</string>
     <string name="success_overlay_supporting_text">Todos los pares coinciden.</string>
-    <string name="success_overlay_new_puzzle_button">Nuevo puzle</string>
-    <string name="success_overlay_return_to_menu_button">Menú</string>
+    <string name="success_overlay_new_puzzle_button">Jugar otro</string>
+    <string name="success_overlay_return_to_menu_button">Volver al menú</string>
     <string name="hint_action_content_description">Abrir pistas de práctica</string>
     <string name="rules_helper_action_content_description">Ayuda de reglas</string>
     <string name="rules_helper_title">Cómo jugar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,8 +86,8 @@
     <string name="success_overlay_message">Puzzle Completed!</string>
     <string name="success_overlay_badge_text">OK</string>
     <string name="success_overlay_supporting_text">All pairs matched.</string>
-    <string name="success_overlay_new_puzzle_button">New puzzle</string>
-    <string name="success_overlay_return_to_menu_button">Menu</string>
+    <string name="success_overlay_new_puzzle_button">Play another</string>
+    <string name="success_overlay_return_to_menu_button">Back to menu</string>
     <string name="hint_action_content_description">Open practice hints</string>
     <string name="rules_helper_action_content_description">Rules help</string>
     <string name="rules_helper_title">How to play</string>


### PR DESCRIPTION
## Related Issue

Resolves #452

## Summary

- Align the generated completion actions with `Play another` and `Back to menu` in all supported locales.
- Keep the existing two-action hierarchy and validated replay pipeline unchanged.
- Extend compiled completion regressions to prove solved sessions stop exposing `Resume`.
- Verify replay adopts the replacement as the single durable session even when the solved-session clear races with replacement.
- Retain the existing unit coverage for replay failure, cancellation, deduplication, repository recreation, and invalid local data.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
