### PR TITLE
[216] Document reliable generated sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Players complete hidden expressions on a board by using numbers from a strip. Th
 ### Current product work: v6 and v7
 
 - 🎓 [PRD v6 Guided First Run](./docs/product/prd/prd-v6.md) defines the implemented guided-onboarding baseline.
-- 🔁 [PRD v7 Reliable Sessions & Replay Controls](./docs/product/prd/prd-v7.md) defines the active generated-session milestone.
+- 🔁 [PRD v7 Reliable Sessions & Replay Controls](./docs/product/prd/prd-v7.md) defines the implemented one-slot generated-session and replay baseline.
 
-### Implemented generated-mode baseline: v5 - Shared Generated Modes
+### Implemented generated-mode baseline: v7 - Reliable Sessions & Replay Controls
 
 Historical snapshots:
 - 🔧 [PRD v0 Playable Prototype](./docs/product/prd/prd-v0.md)
@@ -26,6 +26,8 @@ Historical snapshots:
 The PRDs are historical planning snapshots. Current generated-mode and profile behavior is documented in [puzzle-generation.md](./docs/product/puzzle-generation.md).
 
 Both built-in generated profiles are implemented: `4 Pairs Low` and `8 Pairs Medium`.
+
+Generated play stores one exact resumable session shared by both modes, restores committed progress after process death, and replaces that session only after a successor is ready.
 
 ---
 
@@ -76,7 +78,7 @@ Core responsibilities:
 
 - `domain`: puzzle model, rules, validation, assignments, and generated puzzle logic.
 - `feature`: Menu, Tutorial, generated modes, and reusable Game screen behavior.
-- `data`: seed puzzle and persistence-backed preferences.
+- `data`: seed puzzle, persistence-backed preferences, and the versioned generated-session snapshot.
 - `ui`: app navigation, theme, and shared visual defaults.
 
 ---
@@ -87,6 +89,7 @@ Core responsibilities:
 - Visual design system: [visual-design-system.md](./docs/product/visual-design-system.md)
 - Rules helper requirements: [rules-helper.md](./docs/product/rules-helper.md)
 - Puzzle generation: [puzzle-generation.md](./docs/product/puzzle-generation.md)
+- Generated-session persistence: [generated-session-persistence.md](./docs/technical/generated-session-persistence.md)
 - UX decisions: `docs/product/ux-decisions.md`
 - Architectural Decision Records: `docs/technical/adr/`
 - Delivery workflow: [delivery-workflow.md](./docs/technical/delivery-workflow.md)

--- a/docs/product/prd/prd-v7.md
+++ b/docs/product/prd/prd-v7.md
@@ -1,6 +1,6 @@
 # PRD - NumPairs 🔁 v7 Reliable Sessions & Replay Controls
 
-> Active product reference for the v7 milestone. The product entering this milestone is the completed v6 Guided First Run baseline.
+> Implemented product reference for the v7 milestone. The product entering this milestone was the completed v6 Guided First Run baseline.
 
 ## Product Summary
 

--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -6,10 +6,12 @@
 - Implemented profiles: generated `4 Pairs Low` and `8 Pairs Medium`
 - Related references:
   - `docs/product/prd/prd-v5.md`
+  - `docs/product/prd/prd-v7.md`
+  - `docs/technical/generated-session-persistence.md`
   - `docs/game-rules.md`
   - `docs/ubiquitous-language.md`
 
-This document owns generated puzzle construction, difficulty profiles, solved-to-initial masking, validation expectations, deterministic generation, and failure bounds.
+This document owns generated puzzle construction, difficulty profiles, solved-to-initial masking, validation expectations, deterministic generation, and failure bounds. The generated-session persistence and replacement boundary is documented in `docs/technical/generated-session-persistence.md`.
 
 ---
 
@@ -57,7 +59,11 @@ Every run is an explicit request containing its profile, seed, and positive exec
 
 Value-pair and strip-mask searches share the same budget and observe cancellation. Strip-mask selection enumerates candidate masks lazily, so it does not first materialize all combinations in memory.
 
-The application executes generation on an injected non-main dispatcher. The generated-mode presentation owner exposes loading, ready, and recoverable-failure states; replay keeps the completed session visible until a replacement is ready, and duplicate replay requests are ignored. A generated session survives recomposition and configuration recreation. Process-death restoration is intentionally out of scope: the complete puzzle session is not persisted and entering the mode after process death creates a new request.
+The application executes generation on an injected non-main dispatcher. The generated-mode presentation owner exposes loading, ready, restoration, resume-unavailable, and recoverable-failure states. Replay keeps the completed session visible until a replacement is stored and ready, and duplicate replay requests are ignored.
+
+Successful generation persists the exact initial puzzle before publishing it as playable. Generated play keeps one application-wide versioned session slot shared by `4 Pairs Low` and `8 Pairs Medium`. The slot stores the exact initial and current puzzles plus stable session, mode, profile, and seed metadata. Process-death restoration reads that snapshot directly; it never regenerates historical content from the seed.
+
+Committed puzzle changes update the current snapshot through the stable session id, solved puzzles clear resumability, and stale callbacks cannot mutate a replacement. Generation, storage failure, or cancellation leaves the previous unfinished slot intact. See `docs/technical/generated-session-persistence.md` for the storage, ordering, validation, and backup contract.
 
 ### `4 Pairs Low`
 
@@ -198,4 +204,6 @@ Guaranteed unique solutions are not required unless explicitly added to a future
 
 - `docs/game-rules.md` owns core NumPairs rules shared by handcrafted and generated puzzles.
 - `docs/product/prd/prd-v5.md` owns v5 product scope.
+- `docs/product/prd/prd-v7.md` owns the reliable-session and replay-control product contract.
+- `docs/technical/generated-session-persistence.md` owns the implemented session storage and coordination boundary.
 - `docs/ubiquitous-language.md` owns shared terminology.

--- a/docs/technical/generated-session-persistence.md
+++ b/docs/technical/generated-session-persistence.md
@@ -1,0 +1,115 @@
+# Generated Session Persistence
+
+## Document Status
+
+- Status: implemented technical reference for v7
+- Product contract: `docs/product/prd/prd-v7.md`
+- Related generation reference: `docs/product/puzzle-generation.md`
+
+This document owns the persistence and coordination boundary for the single resumable generated puzzle. It does not redefine puzzle rules, generation profiles, or menu copy.
+
+---
+
+## Scope And Ownership
+
+NumPairs stores at most one generated session for the whole application. The slot may belong to `4 Pairs Low` or `8 Pairs Medium`; there is no independent save per mode, history, account sync, or manual save management.
+
+`MainActivity` creates one application-scoped `GeneratedSessionRepository` from application-private storage and passes it only through generated-play and unlocked-navigation composition. Tutorial and onboarding do not receive generated-session persistence callbacks and cannot replace the slot.
+
+---
+
+## Versioned Snapshot
+
+Schema version `1` stores:
+
+- stable generated-session id
+- generated-mode id
+- generated-profile id
+- generation seed
+- exact initial `Puzzle`
+- exact current `Puzzle`
+
+The seed is diagnostic and generation metadata. Restoration never reruns the generator because a generator or profile implementation may change after the session was created.
+
+The initial and current puzzles preserve:
+
+- board tile order and results
+- expression operands, operators, and strip-entry references
+- strip entry ids, order, and origin state (`Hidden`, `Known`, or `PlayerEntered`)
+
+Snapshot construction rejects changed board results, changed strip-entry identity sets, changed known values, and invalid initial player-entered values. Puzzle completion remains derived from `currentPuzzle.isSolved`; no separate persisted completion flag is a second source of truth.
+
+The deterministic codec returns typed decoded, unsupported-version, or invalid-data outcomes. Unsupported or invalid session bytes are exposed as an empty slot, so they do not block startup or a later replacement.
+
+---
+
+## Repository Contract
+
+The repository exposes one observable nullable snapshot and three atomic mutations:
+
+- `replace(snapshot)` adopts a successor
+- `updateCurrentPuzzle(expectedSessionId, puzzle)` updates only the owning session
+- `clear(expectedSessionId)` clears only the owning session
+
+Update and clear compare the expected stable id inside the DataStore edit. A callback from an older screen therefore cannot update or clear a newer replacement.
+
+Generated gameplay forwards only committed domain `Puzzle` changes. Draft text, open selectors, dialogs, overlays, highlights, scroll position, and other presentation state are not persisted. The generated presentation owner orders progress writes so a slower older update cannot finish after a newer update for the same session.
+
+---
+
+## Lifecycle
+
+### Create And Replace
+
+1. Generate and validate a puzzle through the bounded generation pipeline.
+2. Build a new versioned snapshot with identical initial and current puzzles.
+3. Store the snapshot.
+4. Publish the playable successor.
+
+The previous slot remains intact while generation or storage is pending. Failure or cancellation keeps it intact. A successful stored successor becomes the single session before it is shown as ready.
+
+### Restore
+
+Resume identifies the expected stable session id. Restoration reads the slot and requires matching session, mode, and profile ids plus an unsolved current puzzle. It then presents the exact current puzzle without invoking generation or mutating the repository.
+
+Missing, stale, mismatched, solved, corrupt, or unsupported sessions are not presented as resumable gameplay. The route offers a safe return to the menu.
+
+### Progress And Completion
+
+Committed strip values, operand assignments, operator assignments, and tile resets replace `currentPuzzle` for the active id. When the puzzle becomes solved, the same identity guard clears the slot. The solved game remains visible in memory for its completion actions, but the normal menu no longer exposes `Resume`.
+
+`Play another` uses the create-and-replace pipeline. A late clear from the solved session cannot clear the successor because their stable ids differ.
+
+---
+
+## Local Storage And Transfer
+
+The snapshot is encoded as one byte-array value in the dedicated Preferences DataStore file:
+
+`datastore/generated_session.preferences_pb`
+
+Room or another relational database is not used because the product owns one versioned aggregate with atomic replacement, not a queryable collection.
+
+The file is excluded from:
+
+- legacy Android Auto Backup in `res/xml/backup_rules.xml`
+- Android cloud backup in `res/xml/data_extraction_rules.xml`
+- Android device-to-device transfer in `res/xml/data_extraction_rules.xml`
+
+This keeps the session local to the installation and avoids restoring a transient unfinished puzzle as cross-device progression.
+
+---
+
+## Verification Boundaries
+
+The non-device test suite protects:
+
+- deterministic snapshot round trips and malformed/versioned input
+- one-slot replacement, identity-guarded update/clear, and DataStore recreation
+- persistence before readiness
+- exact restoration without generation or writes
+- ordered committed progress and solved clearing
+- stale callback rejection
+- replacement success, failure, cancellation, and duplicate-request handling
+
+Instrumented sources compile the menu, dialog, resume, completion, and committed-change navigation regressions. Repository work does not require starting an emulator during delivery validation.

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -13,6 +13,26 @@ A replayable gameplay configuration identified by a stable generated-mode identi
 
 A generated mode resolves to one difficulty profile in the application layer. The mode identity is used for profile selection, navigation, and game-session identity; Android strings and mode-specific learning capabilities remain outside the profile.
 
+## Generated Session
+A playable generated-puzzle lifecycle identified by a stable session identity.
+
+NumPairs owns at most one generated session slot for the application, shared by all generated modes. A generated session carries its mode, profile, seed metadata, exact initial puzzle, and exact current puzzle.
+
+## Resumable Generated Session
+The generated session currently stored in the application-wide slot when its current puzzle is valid, belongs to a configured mode/profile, and is not solved.
+
+An opened but untouched generated puzzle is resumable. A solved, stale, mismatched, corrupt, unsupported, or missing snapshot is not resumable.
+
+## Generated Session Snapshot
+The versioned local representation of one generated session.
+
+The snapshot preserves stable session, mode, profile, board, tile, expression, strip-entry, and strip-item identity needed to restore the exact current puzzle. Its seed is metadata; the snapshot is not restored by regenerating from the seed.
+
+## Current Puzzle
+The latest committed domain state of the puzzle being played in a generated session.
+
+Current puzzle changes include committed strip values, operand assignments, operator assignments, and tile resets. Transient presentation state such as drafts, open selectors, dialogs, overlays, highlights, and scroll position is not part of the current puzzle.
+
 ## Tutorial
 A gameplay mode that teaches the core NumPairs rules through authored content and guided player practice.
 

--- a/docs/ui-behavior.md
+++ b/docs/ui-behavior.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document defines the current in-puzzle interaction model for NumPairs.
+This document defines the current menu, generated-session routing, completion, and in-puzzle interaction model for NumPairs.
 
 It complements the game rules described in [game-rules.md](./game-rules.md) and focuses on:
 
@@ -10,10 +10,11 @@ It complements the game rules described in [game-rules.md](./game-rules.md) and 
 2. Result grid behavior
 3. Contextual editing flows
 4. Gameplay top bar helper behavior
+5. Generated-session menu, replacement, and completion behavior
 
-This is the interaction baseline shared by Tutorial and generated `4 Pairs` gameplay.
+This is the interaction baseline shared where applicable by Tutorial, generated `4 Pairs`, and generated `8 Pairs` gameplay.
 
-It intentionally focuses on in-puzzle behavior. Splash, menu, and replay routing are defined at the product level in `docs/product/prd/prd-v4.md`.
+Required-onboarding behavior is documented in `docs/product/prd/prd-v6.md`. The reliable-session product contract is documented in `docs/product/prd/prd-v7.md`, and its storage boundary is documented in `docs/technical/generated-session-persistence.md`.
 
 ---
 
@@ -44,6 +45,45 @@ In this document, strip items are rendered as chips.
 
 ---
 
+## Normal Menu And Generated Session Routing
+
+The unlocked normal menu renders actions in this order:
+
+1. `Resume`, only while one valid unfinished generated session is available
+2. `Play 4 Pairs`
+3. `Play 8 Pairs`
+4. `How to play`
+
+`Resume` and both generated-mode actions use the primary CTA treatment. `How to play` remains the final secondary action. The localized `Resume` accessibility description identifies whether the saved puzzle belongs to 4 or 8 Pairs.
+
+The application derives menu resumability from the one global generated-session slot. Missing, solved, unknown-mode, mode/profile-mismatched, corrupt, and unsupported snapshots do not expose `Resume`.
+
+Selecting `Resume` opens the saved mode and exact current puzzle without generation.
+
+Selecting either generated-mode action while a resumable session exists opens the same modal choice:
+
+- primary: `Resume`
+- secondary: start a new puzzle for the mode the player selected
+
+For the saved mode, supporting copy may use the concise secondary label `New puzzle`. For a different selected mode, copy and the secondary label identify that mode, such as `Play 8 pairs`. This variation clarifies the outcomes; it is not a separate cross-mode protection flow.
+
+The choice dialog has no visible cancel, back, close, or third action. Tapping outside or pressing system back dismisses it without navigation, generation, or session mutation. Action handling is deduplicated.
+
+Selecting `How to play`, entering required onboarding, or using Tutorial never replaces or updates the generated session.
+
+### Generated Completion And Replay
+
+A solved generated puzzle shows exactly:
+
+- primary: `Play another`
+- secondary: `Back to menu`
+
+`Play another` runs the existing bounded generation and safe-replacement pipeline. The solved puzzle remains visible while its successor is pending. Failure or cancellation keeps the completion surface available; a successfully stored successor replaces it.
+
+Solving clears menu resumability before `Back to menu` returns to the menu. There is no `Change difficulty`, restart, timer, or additional completion action.
+
+---
+
 ## Game Top Bar
 
 Gameplay screens should show:
@@ -53,6 +93,8 @@ Gameplay screens should show:
 - an optional rules helper action
 
 The rules helper action should be available in generated `4 Pairs` for v3. It should not be shown in Tutorial because Tutorial has its own guided instructional surface. It is intentionally not part of the menu screen in the first implementation.
+
+Reliable sessions do not add a new-puzzle, restart, resume, or overflow action to the gameplay TopAppBar. Session choices remain in the normal menu and completion surface.
 
 ### Rules Helper Behavior
 


### PR DESCRIPTION
## Related Issue

Resolves #453

## Summary

- Document the implemented one-slot generated-session persistence and coordination boundary.
- Replace obsolete memory-only guidance with exact process-death restoration, ordered committed progress, solved clearing, and safe replacement behavior.
- Add the final menu, dialog, completion, localization, Tutorial-isolation, and unchanged-TopAppBar baseline to UI documentation.
- Extend ubiquitous language with generated session, resumability, versioned snapshot, and current puzzle.
- Keep README focused on both v6 and v7 while marking v7 as the delivered generated-mode baseline.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew lintDebug`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
