### PR TITLE
[217] Refine the unfinished-puzzle choice dialog

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceNavigationTest.kt
@@ -80,7 +80,7 @@ class GeneratedSessionChoiceNavigationTest {
         composeTestRule
             .onNodeWithText(
                 string(
-                    R.string.generated_session_choice_same_mode_message,
+                    R.string.generated_session_choice_mode_message,
                     string(R.string.four_pairs_screen_title)
                 )
             )
@@ -89,7 +89,12 @@ class GeneratedSessionChoiceNavigationTest {
             .onNodeWithTag(MenuScreenTestTags.SESSION_CHOICE_RESUME_BUTTON)
             .assertIsDisplayed()
         composeTestRule
-            .onNodeWithText(string(R.string.generated_session_choice_new_puzzle_button))
+            .onNodeWithText(
+                string(
+                    R.string.generated_session_choice_new_mode_button,
+                    string(R.string.four_pairs_screen_title)
+                )
+            )
             .assertIsDisplayed()
         composeTestRule.runOnIdle {
             assertTrue(recorder.generatedModes.isEmpty())
@@ -123,9 +128,8 @@ class GeneratedSessionChoiceNavigationTest {
         composeTestRule
             .onNodeWithText(
                 string(
-                    R.string.generated_session_choice_different_mode_message,
-                    string(R.string.four_pairs_screen_title),
-                    string(R.string.eight_pairs_screen_title)
+                    R.string.generated_session_choice_mode_message,
+                    string(R.string.four_pairs_screen_title)
                 )
             )
             .assertIsDisplayed()
@@ -135,7 +139,7 @@ class GeneratedSessionChoiceNavigationTest {
         composeTestRule
             .onNodeWithText(
                 string(
-                    R.string.generated_session_choice_play_mode_button,
+                    R.string.generated_session_choice_new_mode_button,
                     string(R.string.eight_pairs_screen_title)
                 )
             )

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/GeneratedSessionChoiceDialog.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/GeneratedSessionChoiceDialog.kt
@@ -1,7 +1,6 @@
 package org.cescfe.numpairs.feature.menu.ui
 
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -17,7 +16,6 @@ import org.cescfe.numpairs.ui.theme.NumPairsComponents
 internal fun GeneratedSessionChoiceDialog(
     savedModeName: String,
     selectedModeName: String,
-    isSameMode: Boolean,
     onResume: () -> Unit,
     onNewPuzzle: () -> Unit,
     onDismiss: () -> Unit
@@ -37,23 +35,15 @@ internal fun GeneratedSessionChoiceDialog(
         },
         text = {
             Text(
-                text = if (isSameMode) {
-                    stringResource(
-                        R.string.generated_session_choice_same_mode_message,
-                        savedModeName
-                    )
-                } else {
-                    stringResource(
-                        R.string.generated_session_choice_different_mode_message,
-                        savedModeName,
-                        selectedModeName
-                    )
-                },
-                style = MaterialTheme.typography.bodyMedium
+                text = stringResource(
+                    R.string.generated_session_choice_mode_message,
+                    savedModeName
+                ),
+                style = MaterialTheme.typography.bodyLarge
             )
         },
         confirmButton = {
-            Button(
+            NumPairsComponents.PrimaryCtaButton(
                 onClick = onResume,
                 modifier = Modifier.testTag(MenuScreenTestTags.SESSION_CHOICE_RESUME_BUTTON)
             ) {
@@ -72,14 +62,10 @@ internal fun GeneratedSessionChoiceDialog(
                 border = NumPairsComponents.secondaryButtonBorder()
             ) {
                 Text(
-                    text = if (isSameMode) {
-                        stringResource(R.string.generated_session_choice_new_puzzle_button)
-                    } else {
-                        stringResource(
-                            R.string.generated_session_choice_play_mode_button,
-                            selectedModeName
-                        )
-                    },
+                    text = stringResource(
+                        R.string.generated_session_choice_new_mode_button,
+                        selectedModeName
+                    ),
                     style = MaterialTheme.typography.labelLarge
                 )
             }

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -140,7 +140,6 @@ private fun UnlockedAppNavigation(
                 GeneratedSessionChoiceDialog(
                     savedModeName = resumableSession.mode.localizedTitle(),
                     selectedModeName = selectedMode.localizedTitle(),
-                    isSameMode = resumableSession.mode.id == selectedMode.id,
                     onResume = {
                         actionGuard.handle {
                             pendingGeneratedModeChoice = null

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -10,10 +10,8 @@
     <string name="menu_four_pairs_button">Juga a 4 parelles</string>
     <string name="menu_eight_pairs_button">Juga a 8 parelles</string>
     <string name="generated_session_choice_title">Puzle sense acabar</string>
-    <string name="generated_session_choice_same_mode_message">Tens un puzle de %1$s sense acabar. Vols continuar-lo o començar-ne un de nou?</string>
-    <string name="generated_session_choice_different_mode_message">Tens un puzle de %1$s sense acabar. Vols continuar-lo o substituir-lo per un de nou de %2$s?</string>
-    <string name="generated_session_choice_new_puzzle_button">Puzle nou</string>
-    <string name="generated_session_choice_play_mode_button">Juga a %1$s</string>
+    <string name="generated_session_choice_mode_message">Tens un puzle de %1$s sense acabar.</string>
+    <string name="generated_session_choice_new_mode_button">Puzle nou de %1$s</string>
 
     <!-- Four pairs screen -->
     <string name="four_pairs_screen_title">4 parelles</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -10,10 +10,8 @@
     <string name="menu_four_pairs_button">Jugar 4 pares</string>
     <string name="menu_eight_pairs_button">Jugar 8 pares</string>
     <string name="generated_session_choice_title">Puzle sin terminar</string>
-    <string name="generated_session_choice_same_mode_message">Tienes un puzle de %1$s sin terminar. ¿Quieres continuarlo o empezar uno nuevo?</string>
-    <string name="generated_session_choice_different_mode_message">Tienes un puzle de %1$s sin terminar. ¿Quieres continuarlo o sustituirlo por uno nuevo de %2$s?</string>
-    <string name="generated_session_choice_new_puzzle_button">Nuevo puzle</string>
-    <string name="generated_session_choice_play_mode_button">Jugar %1$s</string>
+    <string name="generated_session_choice_mode_message">Tienes un puzle de %1$s sin terminar.</string>
+    <string name="generated_session_choice_new_mode_button">Nuevo puzle de %1$s</string>
 
     <!-- Four pairs screen -->
     <string name="four_pairs_screen_title">4 pares</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,10 +10,8 @@
     <string name="menu_four_pairs_button">Play 4 pairs</string>
     <string name="menu_eight_pairs_button">Play 8 pairs</string>
     <string name="generated_session_choice_title">Unfinished puzzle</string>
-    <string name="generated_session_choice_same_mode_message">You have an unfinished %1$s puzzle. Resume it or start a new puzzle?</string>
-    <string name="generated_session_choice_different_mode_message">You have an unfinished %1$s puzzle. Resume it or replace it with a new %2$s puzzle?</string>
-    <string name="generated_session_choice_new_puzzle_button">New puzzle</string>
-    <string name="generated_session_choice_play_mode_button">Play %1$s</string>
+    <string name="generated_session_choice_mode_message">You have an unfinished %1$s puzzle.</string>
+    <string name="generated_session_choice_new_mode_button">New %1$s</string>
 
     <!-- Four pairs screen -->
     <string name="four_pairs_screen_title">4 pairs</string>

--- a/docs/product/prd/prd-v7.md
+++ b/docs/product/prd/prd-v7.md
@@ -102,8 +102,8 @@ The baseline does not include:
 - Selecting `Resume` opens the stored mode and exact committed puzzle state without generation.
 - Selecting either generated-mode action while a resumable session exists opens a modal choice.
 - The modal always offers `Resume` as its primary action.
-- The modal secondary action starts a new puzzle for the mode the player selected.
-- Same-mode and different-mode selection may use different supporting copy or secondary labels for clarity, but neither is a separate protection flow.
+- The modal identifies the unfinished puzzle's mode with one concise supporting message.
+- The modal secondary action uses `New <selected mode>` and starts a new puzzle for the mode the player selected.
 - The modal has no visible cancel, back, or close action.
 - Tapping outside the modal or pressing system back dismisses it without changing the session.
 - Selecting `How to play` never replaces or modifies the generated session.
@@ -183,18 +183,9 @@ When either `Play 4 Pairs` or `Play 8 Pairs` is selected while a resumable sessi
 - dismiss without side effects on system back
 - ignore duplicate action taps while a choice is being handled
 
-For same-mode selection:
+Use the same concise supporting copy for same-mode and different-mode selection: `You have an unfinished <saved mode> puzzle.` The secondary label always identifies the requested replacement mode as `New <selected mode>`, while the primary label remains `Resume`.
 
-- explain that the player can resume the unfinished puzzle or generate a new puzzle
-- use a concise secondary label such as `New puzzle`
-
-For different-mode selection:
-
-- explain that the unfinished puzzle can be resumed or replaced by the selected mode
-- keep the primary label as `Resume`
-- let the secondary label identify the selected mode, such as `Play 8 Pairs`
-
-Both cases use the same session ownership and replacement rules. Different copy exists only to make the selected outcome clear.
+The supporting message uses the larger body text treatment, and the primary action uses the shared primary CTA treatment and established button shape.
 
 ### Safe New-Puzzle Replacement
 
@@ -264,7 +255,7 @@ Work:
 1. Render the conditional `Resume` CTA in the required menu order and visual hierarchy.
 2. Navigate `Resume` to the stored mode and session without generation.
 3. Add the shared generated-mode selection dialog.
-4. Provide clear same-mode and different-mode copy with `Resume` primary and selected new-puzzle action secondary.
+4. Provide concise mode-aware copy with `Resume` primary and `New <selected mode>` secondary.
 5. Support outside-tap and system-back dismissal without a visible cancel action.
 6. Localize and test the flow in English, Spanish, and Catalan.
 
@@ -311,7 +302,7 @@ Work:
 - Restoration preserves stable strip-entry identities and repeated-value assignments.
 - Selecting either generated-mode CTA while a session exists shows the documented modal.
 - The modal always uses `Resume` as its primary action.
-- Same-mode and different-mode selections communicate the selected new-puzzle outcome clearly.
+- Same-mode and different-mode selections use the same concise message and communicate the selected new-puzzle outcome clearly.
 - Outside tap and system back dismiss the modal without changing the session.
 - Starting a new generated puzzle replaces the old session only after generation, validation, and storage succeed.
 - A failed or cancelled replacement leaves the previous session resumable.

--- a/docs/ui-behavior.md
+++ b/docs/ui-behavior.md
@@ -65,7 +65,9 @@ Selecting either generated-mode action while a resumable session exists opens th
 - primary: `Resume`
 - secondary: start a new puzzle for the mode the player selected
 
-For the saved mode, supporting copy may use the concise secondary label `New puzzle`. For a different selected mode, copy and the secondary label identify that mode, such as `Play 8 pairs`. This variation clarifies the outcomes; it is not a separate cross-mode protection flow.
+Both same-mode and different-mode selections use one concise supporting message: `You have an unfinished <saved mode> puzzle.` The message uses the larger body text treatment. The secondary label always identifies the requested replacement mode as `New <selected mode>`.
+
+The primary action uses the shared primary CTA treatment and established button shape.
 
 The choice dialog has no visible cancel, back, close, or third action. Tapping outside or pressing system back dismisses it without navigation, generation, or session mutation. Action handling is deduplicated.
 


### PR DESCRIPTION
## Related Issue

Resolves #456

## Summary

- Unify the unfinished-puzzle message and replacement CTA across same-mode and different-mode choices.
- Increase supporting copy to the larger body style and apply the shared primary CTA component to Resume.
- Update English, Spanish, and Catalan resources, navigation coverage, and the implemented v7 documentation.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew lintDebug`