### PR TITLE
[218] Strengthen shared UI component reuse safeguards

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,10 @@ Resolves #
 ## Summary
 
 - Describe the outcome of this Pull Request.
+
+## UI Consistency
+
+<!-- Complete this section only when the Pull Request changes UI. Remove it otherwise. -->
+
+- Shared components or tokens reused:
+- Intentional deviations from established visual roles:

--- a/docs/technical/code-quality.md
+++ b/docs/technical/code-quality.md
@@ -79,6 +79,10 @@ Design-pattern usage is not a quality target by itself. A simpler implementation
 - Keep transient UI state local only when it has no domain or navigation significance.
 - Keep side effects explicit and lifecycle-aware; do not trigger durable work directly from composition.
 - Use shared theme tokens and components before adding feature-local visual constants.
+- Before using or styling a Material component directly, inspect `NumPairsComponents` and the nearest analogous UI for an established NumPairs visual role.
+- An action specified as a primary CTA must use `NumPairsComponents.PrimaryCtaButton`; do not substitute a raw Material 3 `Button` for that established role.
+- If a shared component cannot express the required behavior, extend its API when the shared role still applies or record in the Pull Request why a direct Material or feature-local implementation is more appropriate.
+- Direct Material components remain appropriate when no established NumPairs role applies. Do not introduce a shared wrapper solely for generic uniformity.
 - Put user-facing text in Android resources and preserve accessibility semantics for interactive behavior.
 
 ## Testing

--- a/docs/technical/delivery-workflow.md
+++ b/docs/technical/delivery-workflow.md
@@ -162,6 +162,13 @@ For each authorized issue:
 
 Do not start dependent implementation from an unmerged branch when the requested workflow requires sequential integration into `main`.
 
+For Compose UI changes, the diff review must include a design-system consistency pass:
+
+- inspect newly introduced or configured direct Material components
+- inspect feature-local shapes, colors, typography, and other visual styling
+- compare each affected visual role with `NumPairsComponents` and the nearest analogous UI
+- identify in the Pull Request any intentional deviation from an established shared component or token
+
 ## Android Validation
 
 For application changes, run the relevant tasks sequentially:


### PR DESCRIPTION
## Related Issue

Resolves #458

## Summary

- Map the primary CTA role explicitly to NumPairsComponents.PrimaryCtaButton while preserving legitimate direct Material component usage.
- Add a Compose design-system consistency pass to implementation diff review.
- Extend the Pull Request template with a conditional UI consistency note for reused shared components and intentional deviations.

## Validation

- `git diff --check`
- Verified the referenced NumPairsComponents.PrimaryCtaButton API exists.
- Reviewed Markdown structure and consistency across the three changed files.
- Android build tasks were not run because this is a documentation-only change.