### PR TITLE
[220] Separate Warm appearance and gameplay semantic colors

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/strip/AvailableNumberChip.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/strip/AvailableNumberChip.kt
@@ -50,6 +50,7 @@ import org.cescfe.numpairs.feature.game.ui.semantics.stripEntryInputInvalid
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 import org.cescfe.numpairs.ui.theme.NumPairsTextStyles
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.cescfe.numpairs.ui.theme.numPairsSemanticColors
 
 enum class AvailableNumberChipStyle {
     KNOWN,
@@ -71,8 +72,9 @@ fun AvailableNumberChip(
     onClick: (() -> Unit)? = null
 ) {
     val chipColors = chipColorsFor(style)
+    val semanticColors = MaterialTheme.numPairsSemanticColors
     val chipBorder = if (isHighlighted) {
-        BorderStroke(width = HIGHLIGHTED_CHIP_BORDER_WIDTH, color = MaterialTheme.colorScheme.tertiary)
+        BorderStroke(width = HIGHLIGHTED_CHIP_BORDER_WIDTH, color = semanticColors.tutorialHighlight)
     } else {
         chipColors.border
     }
@@ -139,9 +141,10 @@ fun AvailableNumberInputChip(
     isHighlighted: Boolean = false
 ) {
     val chipColors = chipColorsFor(style)
+    val semanticColors = MaterialTheme.numPairsSemanticColors
     val chipBorder = when {
         isInvalid -> NumPairsComponents.errorBorder()
-        isHighlighted -> BorderStroke(width = HIGHLIGHTED_CHIP_BORDER_WIDTH, color = MaterialTheme.colorScheme.tertiary)
+        isHighlighted -> BorderStroke(width = HIGHLIGHTED_CHIP_BORDER_WIDTH, color = semanticColors.tutorialHighlight)
         else -> chipColors.border
     }
     val focusRequester = remember { FocusRequester() }

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/strip/AvailableNumberChipDefaults.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/strip/AvailableNumberChipDefaults.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
+import org.cescfe.numpairs.ui.theme.numPairsSemanticColors
 
 internal val CHIP_MIN_HEIGHT = 48.dp
 internal val CHIP_CONTENT_HORIZONTAL_PADDING = 4.dp
@@ -21,6 +22,7 @@ internal val HIGHLIGHTED_CHIP_BORDER_WIDTH = 3.dp
 @Composable
 internal fun chipColorsFor(style: AvailableNumberChipStyle): AvailableNumberChipColors {
     val colorScheme = MaterialTheme.colorScheme
+    val semanticColors = MaterialTheme.numPairsSemanticColors
 
     return when (style) {
         AvailableNumberChipStyle.KNOWN -> AvailableNumberChipColors(
@@ -30,20 +32,20 @@ internal fun chipColorsFor(style: AvailableNumberChipStyle): AvailableNumberChip
         )
 
         AvailableNumberChipStyle.HIDDEN -> AvailableNumberChipColors(
-            containerColor = NumPairsComponents.hiddenContainerColor(),
-            contentColor = NumPairsComponents.hiddenContentColor(),
+            containerColor = semanticColors.hiddenContainer,
+            contentColor = semanticColors.onHiddenContainer,
             border = BorderStroke(
                 width = MODIFIABLE_CHIP_BORDER_WIDTH,
-                color = colorScheme.onSurfaceVariant
+                color = semanticColors.hiddenBorder
             )
         )
 
         AvailableNumberChipStyle.PLAYER_ENTERED -> AvailableNumberChipColors(
-            containerColor = colorScheme.secondaryContainer,
-            contentColor = colorScheme.onSecondaryContainer,
+            containerColor = semanticColors.selectionContainer,
+            contentColor = semanticColors.onSelectionContainer,
             border = BorderStroke(
                 width = MODIFIABLE_CHIP_BORDER_WIDTH,
-                color = colorScheme.secondary
+                color = semanticColors.selection
             )
         )
     }

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/tile/PuzzleTile.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/tile/PuzzleTile.kt
@@ -32,6 +32,7 @@ import org.cescfe.numpairs.feature.game.ui.semantics.gameHighlightSemantics
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 import org.cescfe.numpairs.ui.theme.NumPairsTextStyles
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.cescfe.numpairs.ui.theme.numPairsSemanticColors
 
 @Composable
 fun PuzzleTile(
@@ -55,8 +56,9 @@ fun PuzzleTile(
     onResetClick: (() -> Unit)? = null
 ) {
     val statePalette = tileStatePalette(tile.visualState)
+    val semanticColors = MaterialTheme.numPairsSemanticColors
     val tileBorder = if (isHighlighted) {
-        BorderStroke(width = HIGHLIGHTED_TILE_BORDER_WIDTH, color = MaterialTheme.colorScheme.tertiary)
+        BorderStroke(width = HIGHLIGHTED_TILE_BORDER_WIDTH, color = semanticColors.tutorialHighlight)
     } else {
         statePalette.border
     }

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/tile/PuzzleTileDefaults.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/tile/PuzzleTileDefaults.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import org.cescfe.numpairs.feature.game.presentation.TileVisualState
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
+import org.cescfe.numpairs.ui.theme.numPairsSemanticColors
 
 internal val TILE_HORIZONTAL_PADDING = 10.dp
 internal val TILE_VERTICAL_PADDING = 16.dp
@@ -29,6 +30,7 @@ internal val HIGHLIGHTED_TILE_EXPRESSION_SLOT_CORNER_RADIUS = 8.dp
 @Composable
 internal fun tileStatePalette(visualState: TileVisualState): TileStatePalette {
     val colorScheme = MaterialTheme.colorScheme
+    val semanticColors = MaterialTheme.numPairsSemanticColors
 
     return when (visualState) {
         TileVisualState.NORMAL -> TileStatePalette(
@@ -39,8 +41,8 @@ internal fun tileStatePalette(visualState: TileVisualState): TileStatePalette {
         )
 
         TileVisualState.INCORRECT -> TileStatePalette(
-            containerColor = colorScheme.errorContainer,
-            expressionContentColor = colorScheme.onErrorContainer,
+            containerColor = semanticColors.errorContainer,
+            expressionContentColor = semanticColors.onErrorContainer,
             resultContentColor = colorScheme.onSurface,
             border = NumPairsComponents.errorBorder()
         )
@@ -49,13 +51,13 @@ internal fun tileStatePalette(visualState: TileVisualState): TileStatePalette {
             containerColor = NumPairsComponents.raisedSurfaceColor(),
             expressionContentColor = colorScheme.onSurfaceVariant,
             resultContentColor = colorScheme.onSurface,
-            border = BorderStroke(2.dp, colorScheme.error)
+            border = BorderStroke(2.dp, semanticColors.error)
         )
 
         TileVisualState.LIVE_RULE_CONFLICT -> TileStatePalette(
-            containerColor = colorScheme.errorContainer,
-            expressionContentColor = colorScheme.onErrorContainer,
-            resultContentColor = colorScheme.onErrorContainer,
+            containerColor = semanticColors.errorContainer,
+            expressionContentColor = semanticColors.onErrorContainer,
+            resultContentColor = semanticColors.onErrorContainer,
             border = NumPairsComponents.errorBorder()
         )
     }

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/tile/PuzzleTileSlots.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/tile/PuzzleTileSlots.kt
@@ -37,6 +37,7 @@ import org.cescfe.numpairs.feature.game.presentation.TileUiState
 import org.cescfe.numpairs.feature.game.ui.semantics.gameHighlightSemantics
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 import org.cescfe.numpairs.ui.theme.NumPairsTextStyles
+import org.cescfe.numpairs.ui.theme.numPairsSemanticColors
 
 @Composable
 internal fun TileResetAction(modifier: Modifier = Modifier, onClick: () -> Unit) {
@@ -185,7 +186,7 @@ private fun Modifier.highlightBorder(isHighlighted: Boolean): Modifier = if (isH
     border(
         border = BorderStroke(
             width = HIGHLIGHTED_TILE_EXPRESSION_SLOT_BORDER_WIDTH,
-            color = MaterialTheme.colorScheme.tertiary
+            color = MaterialTheme.numPairsSemanticColors.tutorialHighlight
         ),
         shape = RoundedCornerShape(HIGHLIGHTED_TILE_EXPRESSION_SLOT_CORNER_RADIUS)
     )

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/indicators/OperandUsageIndicators.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/indicators/OperandUsageIndicators.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.Color
 import org.cescfe.numpairs.R
 import org.cescfe.numpairs.domain.puzzle.model.Operator
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
+import org.cescfe.numpairs.ui.theme.numPairsSemanticColors
 
 internal enum class OperandUsageIndicatorState(@get:StringRes val stateDescriptionResId: Int) {
     AVAILABLE(R.string.tile_operand_usage_state_available),
@@ -33,8 +34,10 @@ internal val Operator.usageIndicatorSymbol: String
 internal data class OperandUsageIndicatorColors(val container: Color, val content: Color, val border: BorderStroke)
 
 @Composable
-internal fun operandUsageIndicatorColors(state: OperandUsageIndicatorState): OperandUsageIndicatorColors =
-    when (state) {
+internal fun operandUsageIndicatorColors(state: OperandUsageIndicatorState): OperandUsageIndicatorColors {
+    val semanticColors = MaterialTheme.numPairsSemanticColors
+
+    return when (state) {
         OperandUsageIndicatorState.AVAILABLE -> OperandUsageIndicatorColors(
             container = NumPairsComponents.subtleSurfaceColor(),
             content = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -42,11 +45,12 @@ internal fun operandUsageIndicatorColors(state: OperandUsageIndicatorState): Ope
         )
 
         OperandUsageIndicatorState.USED -> OperandUsageIndicatorColors(
-            container = MaterialTheme.colorScheme.secondary,
-            content = MaterialTheme.colorScheme.onSecondary,
+            container = semanticColors.selection,
+            content = semanticColors.onSelection,
             border = BorderStroke(
                 width = NumPairsComponents.ThinBorderWidth,
-                color = MaterialTheme.colorScheme.secondary
+                color = semanticColors.selection
             )
         )
     }
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenDialogs.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenDialogs.kt
@@ -51,6 +51,7 @@ import org.cescfe.numpairs.feature.game.ui.semantics.OperandSelectorUsageHintVis
 import org.cescfe.numpairs.feature.game.ui.semantics.operandSelectorUsageHintVisualState
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 import org.cescfe.numpairs.ui.theme.NumPairsTextStyles
+import org.cescfe.numpairs.ui.theme.numPairsSemanticColors
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -240,10 +241,10 @@ private fun operandSelectorUsageHintColors(
 @Composable
 private fun operandSelectorPartialUsageHintColors(): OperandUsageIndicatorColors = OperandUsageIndicatorColors(
     container = NumPairsComponents.subtleSurfaceColor(),
-    content = MaterialTheme.colorScheme.secondary,
+    content = MaterialTheme.numPairsSemanticColors.selection,
     border = BorderStroke(
         width = NumPairsComponents.FocusBorderWidth,
-        color = MaterialTheme.colorScheme.secondary
+        color = MaterialTheme.numPairsSemanticColors.selection
     )
 )
 
@@ -363,19 +364,19 @@ internal fun TileOperatorSelectionMenu(
                         },
                     shape = RoundedCornerShape(TILE_OPERATOR_MENU_CORNER_RADIUS),
                     color = if (isSelected) {
-                        MaterialTheme.colorScheme.secondaryContainer
+                        MaterialTheme.numPairsSemanticColors.selectionContainer
                     } else {
                         NumPairsComponents.subtleSurfaceColor()
                     },
                     contentColor = if (isSelected) {
-                        MaterialTheme.colorScheme.onSecondaryContainer
+                        MaterialTheme.numPairsSemanticColors.onSelectionContainer
                     } else {
                         MaterialTheme.colorScheme.onSurfaceVariant
                     },
                     border = if (isSelected) {
                         BorderStroke(
                             width = NumPairsComponents.StrongBorderWidth,
-                            color = MaterialTheme.colorScheme.secondary
+                            color = MaterialTheme.numPairsSemanticColors.selection
                         )
                     } else {
                         NumPairsComponents.subtleBorder()

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenFeedback.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenFeedback.kt
@@ -34,6 +34,7 @@ import org.cescfe.numpairs.feature.game.GameCompletionActions
 import org.cescfe.numpairs.feature.game.presentation.PuzzleOutcomeUiState
 import org.cescfe.numpairs.feature.game.presentation.RuleConflictUiState
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
+import org.cescfe.numpairs.ui.theme.numPairsSemanticColors
 
 @Composable
 internal fun SuccessOverlay(onDismiss: () -> Unit, completionActions: GameCompletionActions? = null) {
@@ -71,7 +72,7 @@ internal fun SuccessOverlay(onDismiss: () -> Unit, completionActions: GameComple
             shape = RoundedCornerShape(SUCCESS_OVERLAY_CARD_CORNER_RADIUS),
             color = NumPairsComponents.successContainerColor(),
             contentColor = NumPairsComponents.successContentColor(),
-            border = NumPairsComponents.focusBorder()
+            border = NumPairsComponents.successBorder()
         ) {
             Column(
                 modifier = Modifier
@@ -85,8 +86,8 @@ internal fun SuccessOverlay(onDismiss: () -> Unit, completionActions: GameComple
             ) {
                 Surface(
                     shape = CircleShape,
-                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.16f),
-                    contentColor = MaterialTheme.colorScheme.primary
+                    color = MaterialTheme.numPairsSemanticColors.success.copy(alpha = 0.16f),
+                    contentColor = MaterialTheme.numPairsSemanticColors.success
                 ) {
                     Box(
                         modifier = Modifier

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenSections.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenSections.kt
@@ -44,6 +44,7 @@ import org.cescfe.numpairs.feature.game.ui.components.strip.CHIP_HORIZONTAL_CONT
 import org.cescfe.numpairs.feature.game.ui.components.tile.PuzzleTile
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 import org.cescfe.numpairs.ui.theme.NumPairsTextStyles
+import org.cescfe.numpairs.ui.theme.numPairsSemanticColors
 
 @Composable
 internal fun BoardSection(
@@ -360,7 +361,7 @@ private fun StripEntryFeedback(message: String, isError: Boolean, modifier: Modi
             }
         },
         color = if (isError) {
-            MaterialTheme.colorScheme.error
+            MaterialTheme.numPairsSemanticColors.error
         } else {
             MaterialTheme.colorScheme.onSurfaceVariant
         },

--- a/app/src/main/java/org/cescfe/numpairs/ui/theme/NumPairsComponents.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/theme/NumPairsComponents.kt
@@ -172,34 +172,28 @@ object NumPairsComponents {
     )
 
     @Composable
-    fun focusBorder(): BorderStroke = BorderStroke(
+    fun successBorder(): BorderStroke = BorderStroke(
         width = FocusBorderWidth,
-        color = MaterialTheme.colorScheme.primary
+        color = MaterialTheme.numPairsSemanticColors.success
     )
 
     @Composable
     fun errorBorder(): BorderStroke = BorderStroke(
         width = StrongBorderWidth,
-        color = MaterialTheme.colorScheme.error
+        color = MaterialTheme.numPairsSemanticColors.error
     )
 
     @Composable
-    fun successContainerColor() = MaterialTheme.colorScheme.primaryContainer
+    fun successContainerColor() = MaterialTheme.numPairsSemanticColors.successContainer
 
     @Composable
-    fun successContentColor() = MaterialTheme.colorScheme.onPrimaryContainer
+    fun successContentColor() = MaterialTheme.numPairsSemanticColors.onSuccessContainer
 
     @Composable
-    fun errorContainerColor() = MaterialTheme.colorScheme.errorContainer
+    fun errorContainerColor() = MaterialTheme.numPairsSemanticColors.errorContainer
 
     @Composable
-    fun errorContentColor() = MaterialTheme.colorScheme.onErrorContainer
-
-    @Composable
-    fun hiddenContainerColor() = MaterialTheme.colorScheme.surfaceVariant
-
-    @Composable
-    fun hiddenContentColor() = MaterialTheme.colorScheme.onSurfaceVariant
+    fun errorContentColor() = MaterialTheme.numPairsSemanticColors.onErrorContainer
 
     @Composable
     fun topAppBarColors(): TopAppBarColors = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/java/org/cescfe/numpairs/ui/theme/NumPairsThemeDefinition.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/theme/NumPairsThemeDefinition.kt
@@ -1,0 +1,91 @@
+package org.cescfe.numpairs.ui.theme
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+
+internal enum class NumPairsThemeId(val persistedValue: String) {
+    WARM("warm")
+}
+
+@Immutable
+internal data class NumPairsSemanticColors(
+    val success: Color,
+    val onSuccess: Color,
+    val successContainer: Color,
+    val onSuccessContainer: Color,
+    val error: Color,
+    val onError: Color,
+    val errorContainer: Color,
+    val onErrorContainer: Color,
+    val selection: Color,
+    val onSelection: Color,
+    val selectionContainer: Color,
+    val onSelectionContainer: Color,
+    val tutorialHighlight: Color,
+    val onTutorialHighlight: Color,
+    val hiddenContainer: Color,
+    val onHiddenContainer: Color,
+    val hiddenBorder: Color
+)
+
+@Immutable
+internal data class NumPairsThemeDefinition(
+    val id: NumPairsThemeId,
+    val appearanceColors: ColorScheme,
+    val semanticColors: NumPairsSemanticColors
+)
+
+internal val WarmThemeDefinition = NumPairsThemeDefinition(
+    id = NumPairsThemeId.WARM,
+    appearanceColors = darkColorScheme(
+        primary = NumPairsGreen,
+        onPrimary = NumPairsOnGreen,
+        primaryContainer = NumPairsGreenSoft,
+        onPrimaryContainer = NumPairsOnGreenSoft,
+        secondary = NumPairsFocus,
+        onSecondary = NumPairsOnFocus,
+        secondaryContainer = NumPairsSurfaceSubtle,
+        onSecondaryContainer = NumPairsOnSurface,
+        tertiary = NumPairsSand,
+        onTertiary = NumPairsOnSand,
+        tertiaryContainer = NumPairsSurfaceSubtle,
+        onTertiaryContainer = NumPairsOnSurface,
+        background = NumPairsBackground,
+        onBackground = NumPairsOnSurface,
+        surface = NumPairsSurface,
+        onSurface = NumPairsOnSurface,
+        surfaceVariant = NumPairsSurfaceSubtle,
+        onSurfaceVariant = NumPairsOnSurfaceVariant,
+        surfaceContainer = NumPairsSurface,
+        surfaceContainerHigh = NumPairsSurfaceRaised,
+        surfaceContainerHighest = NumPairsSurfaceRaised,
+        outline = NumPairsOutline,
+        outlineVariant = NumPairsOutlineVariant,
+        error = NumPairsError,
+        onError = NumPairsBackground,
+        errorContainer = NumPairsErrorSoft,
+        onErrorContainer = NumPairsOnErrorSoft,
+        scrim = NumPairsScrim
+    ),
+    semanticColors = NumPairsSemanticColors(
+        success = NumPairsGreen,
+        onSuccess = NumPairsOnGreen,
+        successContainer = NumPairsGreenSoft,
+        onSuccessContainer = NumPairsOnGreenSoft,
+        error = NumPairsError,
+        onError = NumPairsBackground,
+        errorContainer = NumPairsErrorSoft,
+        onErrorContainer = NumPairsOnErrorSoft,
+        selection = NumPairsFocus,
+        onSelection = NumPairsOnFocus,
+        selectionContainer = NumPairsSurfaceSubtle,
+        onSelectionContainer = NumPairsOnSurface,
+        tutorialHighlight = NumPairsSand,
+        onTutorialHighlight = NumPairsOnSand,
+        hiddenContainer = NumPairsSurfaceSubtle,
+        onHiddenContainer = NumPairsOnSurfaceVariant,
+        hiddenBorder = NumPairsOnSurfaceVariant
+    )
+)

--- a/app/src/main/java/org/cescfe/numpairs/ui/theme/Theme.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/theme/Theme.kt
@@ -1,54 +1,31 @@
 package org.cescfe.numpairs.ui.theme
 
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
 
-private val NumPairsColorScheme = darkColorScheme(
-    primary = NumPairsGreen,
-    onPrimary = NumPairsOnGreen,
-    primaryContainer = NumPairsGreenSoft,
-    onPrimaryContainer = NumPairsOnGreenSoft,
+private val LocalNumPairsSemanticColors = staticCompositionLocalOf {
+    WarmThemeDefinition.semanticColors
+}
 
-    secondary = NumPairsFocus,
-    onSecondary = NumPairsOnFocus,
-    secondaryContainer = NumPairsSurfaceSubtle,
-    onSecondaryContainer = NumPairsOnSurface,
-
-    tertiary = NumPairsSand,
-    onTertiary = NumPairsOnSand,
-    tertiaryContainer = NumPairsSurfaceSubtle,
-    onTertiaryContainer = NumPairsOnSurface,
-
-    background = NumPairsBackground,
-    onBackground = NumPairsOnSurface,
-
-    surface = NumPairsSurface,
-    onSurface = NumPairsOnSurface,
-
-    surfaceVariant = NumPairsSurfaceSubtle,
-    onSurfaceVariant = NumPairsOnSurfaceVariant,
-
-    surfaceContainer = NumPairsSurface,
-    surfaceContainerHigh = NumPairsSurfaceRaised,
-    surfaceContainerHighest = NumPairsSurfaceRaised,
-
-    outline = NumPairsOutline,
-    outlineVariant = NumPairsOutlineVariant,
-
-    error = NumPairsError,
-    onError = NumPairsBackground,
-    errorContainer = NumPairsErrorSoft,
-    onErrorContainer = NumPairsOnErrorSoft,
-
-    scrim = NumPairsScrim
-)
+internal val MaterialTheme.numPairsSemanticColors: NumPairsSemanticColors
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalNumPairsSemanticColors.current
 
 @Composable
 fun NumPairsTheme(content: @Composable () -> Unit) {
-    MaterialTheme(
-        colorScheme = NumPairsColorScheme,
-        typography = Typography,
-        content = content
-    )
+    val themeDefinition = WarmThemeDefinition
+
+    CompositionLocalProvider(
+        LocalNumPairsSemanticColors provides themeDefinition.semanticColors
+    ) {
+        MaterialTheme(
+            colorScheme = themeDefinition.appearanceColors,
+            typography = Typography,
+            content = content
+        )
+    }
 }

--- a/app/src/test/java/org/cescfe/numpairs/ui/theme/NumPairsThemeDefinitionTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/ui/theme/NumPairsThemeDefinitionTest.kt
@@ -1,0 +1,64 @@
+package org.cescfe.numpairs.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NumPairsThemeDefinitionTest {
+    @Test
+    fun `Warm text colors meet WCAG AA contrast`() {
+        val appearance = WarmThemeDefinition.appearanceColors
+        val semantic = WarmThemeDefinition.semanticColors
+
+        mapOf(
+            "on background" to (appearance.onBackground to appearance.background),
+            "on surface" to (appearance.onSurface to appearance.surface),
+            "on surface variant" to (appearance.onSurfaceVariant to appearance.surfaceVariant),
+            "on primary" to (appearance.onPrimary to appearance.primary),
+            "on primary container" to (appearance.onPrimaryContainer to appearance.primaryContainer),
+            "on selection" to (semantic.onSelection to semantic.selection),
+            "on selection container" to (semantic.onSelectionContainer to semantic.selectionContainer),
+            "on success" to (semantic.onSuccess to semantic.success),
+            "on success container" to (semantic.onSuccessContainer to semantic.successContainer),
+            "on error" to (semantic.onError to semantic.error),
+            "on error container" to (semantic.onErrorContainer to semantic.errorContainer),
+            "on tutorial highlight" to (semantic.onTutorialHighlight to semantic.tutorialHighlight),
+            "on hidden container" to (semantic.onHiddenContainer to semantic.hiddenContainer)
+        ).forEach { (name, colors) ->
+            assertContrastAtLeast(name, colors.first, colors.second, minimum = 4.5f)
+        }
+    }
+
+    @Test
+    fun `Warm meaningful boundaries meet non-text contrast`() {
+        val appearance = WarmThemeDefinition.appearanceColors
+        val semantic = WarmThemeDefinition.semanticColors
+
+        mapOf(
+            "success boundary" to (semantic.success to semantic.successContainer),
+            "error boundary" to (semantic.error to semantic.errorContainer),
+            "selection boundary" to (semantic.selection to semantic.selectionContainer),
+            "tutorial highlight" to (semantic.tutorialHighlight to appearance.surfaceContainerHigh),
+            "hidden boundary" to (semantic.hiddenBorder to semantic.hiddenContainer)
+        ).forEach { (name, colors) ->
+            assertContrastAtLeast(name, colors.first, colors.second, minimum = 3f)
+        }
+    }
+
+    private fun assertContrastAtLeast(name: String, foreground: Color, background: Color, minimum: Float) {
+        val ratio = contrastRatio(foreground, background)
+
+        assertTrue(
+            "$name contrast was $ratio:1, expected at least $minimum:1",
+            ratio >= minimum
+        )
+    }
+
+    private fun contrastRatio(first: Color, second: Color): Float {
+        val lighter = maxOf(first.luminance(), second.luminance())
+        val darker = minOf(first.luminance(), second.luminance())
+
+        return (lighter + 0.05f) / (darker + 0.05f)
+    }
+}


### PR DESCRIPTION
## Related Issue

Resolves #462

## Summary

- Adds an explicit Warm theme definition with independently owned appearance and gameplay semantic colors.
- Routes success, error, selection, tutorial highlight, hidden-value, and used-value UI through semantic tokens.
- Adds deterministic WCAG contrast tests for text and meaningful non-text boundaries.
- Preserves the current Warm palette, typography, shapes, elevation, and behavior.

## UI Consistency

- Shared components or tokens reused: `NumPairsTheme`, `NumPairsComponents`, and the new `NumPairsSemanticColors` tokens.
- Intentional deviations from established visual roles: None. Every semantic token maps to the exact Warm color previously rendered.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- UI diff review: token-for-token mappings preserve the existing Warm rendering; no layout, typography, shape, elevation, or interaction changed.