### PR TITLE
[222] Persist and apply the selected NumPairs theme

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/PersonalizationThemeProviderTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/PersonalizationThemeProviderTest.kt
@@ -1,0 +1,67 @@
+package org.cescfe.numpairs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.cescfe.numpairs.data.preferences.PersonalizationPreferences
+import org.cescfe.numpairs.data.preferences.PersonalizationPreferencesRepository
+import org.cescfe.numpairs.data.preferences.PersonalizationTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Rule
+import org.junit.Test
+
+class PersonalizationThemeProviderTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun changingPreferenceUpdatesThemeWithoutForgettingChildState() {
+        val repository = FakePersonalizationPreferencesRepository()
+        var firstRememberedValue: Any? = null
+        var latestRememberedValue: Any? = null
+        var latestPrimary = Color.Unspecified
+
+        composeTestRule.setContent {
+            PersonalizationThemeProvider(repository) {
+                val rememberedValue = remember { Any() }
+                val primary = MaterialTheme.colorScheme.primary
+                SideEffect {
+                    firstRememberedValue = firstRememberedValue ?: rememberedValue
+                    latestRememberedValue = rememberedValue
+                    latestPrimary = primary
+                }
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            assertEquals(Color(0xFF9CBD7B), latestPrimary)
+            repository.state.value = PersonalizationPreferences(
+                selectedTheme = PersonalizationTheme.FROST
+            )
+        }
+
+        composeTestRule.runOnIdle {
+            assertEquals(Color(0xFF215EA8), latestPrimary)
+            assertSame(firstRememberedValue, latestRememberedValue)
+        }
+    }
+
+    private class FakePersonalizationPreferencesRepository : PersonalizationPreferencesRepository {
+        val state = MutableStateFlow(PersonalizationPreferences())
+
+        override val preferences: Flow<PersonalizationPreferences> = state
+
+        override suspend fun selectTheme(theme: PersonalizationTheme) {
+            state.value = state.value.copy(selectedTheme = theme)
+        }
+
+        override suspend fun setGeneratedGameHapticsEnabled(enabled: Boolean) {
+            state.value = state.value.copy(generatedGameHapticsEnabled = enabled)
+        }
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/MainActivity.kt
+++ b/app/src/main/java/org/cescfe/numpairs/MainActivity.kt
@@ -4,16 +4,28 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.luminance
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.cescfe.numpairs.data.generated.session.createGeneratedSessionRepository
 import org.cescfe.numpairs.data.onboarding.createOnboardingRuntime
+import org.cescfe.numpairs.data.preferences.PersonalizationPreferences
+import org.cescfe.numpairs.data.preferences.PersonalizationPreferencesRepository
+import org.cescfe.numpairs.data.preferences.PersonalizationTheme
+import org.cescfe.numpairs.data.preferences.createPersonalizationPreferencesRepository
 import org.cescfe.numpairs.data.preferences.createTopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.feature.generated.ConfiguredGeneratedPuzzleGenerationUseCaseFactory
 import org.cescfe.numpairs.feature.generated.GeneratedModes
 import org.cescfe.numpairs.ui.navigation.AppNavigation
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.cescfe.numpairs.ui.theme.NumPairsThemeId
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -22,6 +34,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         val onboardingRuntime = createOnboardingRuntime(applicationContext)
         val generatedSessionRepository = createGeneratedSessionRepository(applicationContext)
+        val personalizationPreferencesRepository = createPersonalizationPreferencesRepository(applicationContext)
         val topAppBarActionDiscoveryRepository = createTopAppBarActionDiscoveryRepository(applicationContext)
         val generatedModeRegistry = GeneratedModes.registry
         val generatedPuzzleGenerationUseCaseFactory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
@@ -32,7 +45,14 @@ class MainActivity : ComponentActivity() {
         }
 
         setContent {
-            NumPairsTheme {
+            PersonalizationThemeProvider(personalizationPreferencesRepository) {
+                val useDarkSystemBarIcons = MaterialTheme.colorScheme.background.luminance() > 0.5f
+                SideEffect {
+                    WindowCompat.getInsetsController(window, window.decorView).apply {
+                        isAppearanceLightStatusBars = useDarkSystemBarIcons
+                        isAppearanceLightNavigationBars = useDarkSystemBarIcons
+                    }
+                }
                 AppNavigation(
                     onboardingRepository = onboardingRuntime.repository,
                     generatedSessionRepository = generatedSessionRepository,
@@ -43,4 +63,25 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
+}
+
+@Composable
+internal fun PersonalizationThemeProvider(
+    repository: PersonalizationPreferencesRepository,
+    content: @Composable () -> Unit
+) {
+    val preferences by repository.preferences.collectAsState(initial = PersonalizationPreferences())
+
+    NumPairsTheme(
+        themeId = preferences.selectedTheme.toNumPairsThemeId(),
+        content = content
+    )
+}
+
+private fun PersonalizationTheme.toNumPairsThemeId(): NumPairsThemeId = when (this) {
+    PersonalizationTheme.WARM -> NumPairsThemeId.WARM
+    PersonalizationTheme.FROST -> NumPairsThemeId.FROST
+    PersonalizationTheme.OBSIDIAN -> NumPairsThemeId.OBSIDIAN
+    PersonalizationTheme.TERMINAL -> NumPairsThemeId.TERMINAL
+    PersonalizationTheme.EMBER -> NumPairsThemeId.EMBER
 }

--- a/app/src/main/java/org/cescfe/numpairs/data/preferences/DataStorePersonalizationPreferencesRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/preferences/DataStorePersonalizationPreferencesRepository.kt
@@ -1,0 +1,49 @@
+package org.cescfe.numpairs.data.preferences
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import java.io.IOException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+class DataStorePersonalizationPreferencesRepository(private val dataStore: DataStore<Preferences>) :
+    PersonalizationPreferencesRepository {
+    override val preferences: Flow<PersonalizationPreferences> = dataStore.data
+        .catch { throwable ->
+            if (throwable is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw throwable
+            }
+        }
+        .map { preferences ->
+            PersonalizationPreferences(
+                selectedTheme = PersonalizationTheme.fromPersistedValue(
+                    preferences[PreferenceKeys.SELECTED_THEME]
+                ),
+                generatedGameHapticsEnabled = preferences[PreferenceKeys.GENERATED_GAME_HAPTICS_ENABLED] ?: true
+            )
+        }
+
+    override suspend fun selectTheme(theme: PersonalizationTheme) {
+        dataStore.edit { preferences ->
+            preferences[PreferenceKeys.SELECTED_THEME] = theme.persistedValue
+        }
+    }
+
+    override suspend fun setGeneratedGameHapticsEnabled(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferenceKeys.GENERATED_GAME_HAPTICS_ENABLED] = enabled
+        }
+    }
+
+    private object PreferenceKeys {
+        val SELECTED_THEME = stringPreferencesKey("personalization_selected_theme")
+        val GENERATED_GAME_HAPTICS_ENABLED = booleanPreferencesKey("personalization_generated_game_haptics_enabled")
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/preferences/PersonalizationPreferencesRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/preferences/PersonalizationPreferencesRepository.kt
@@ -1,0 +1,29 @@
+package org.cescfe.numpairs.data.preferences
+
+import kotlinx.coroutines.flow.Flow
+
+enum class PersonalizationTheme(internal val persistedValue: String) {
+    WARM("warm"),
+    FROST("frost"),
+    OBSIDIAN("obsidian"),
+    TERMINAL("terminal"),
+    EMBER("ember");
+
+    companion object {
+        internal fun fromPersistedValue(value: String?): PersonalizationTheme =
+            entries.firstOrNull { theme -> theme.persistedValue == value } ?: WARM
+    }
+}
+
+data class PersonalizationPreferences(
+    val selectedTheme: PersonalizationTheme = PersonalizationTheme.WARM,
+    val generatedGameHapticsEnabled: Boolean = true
+)
+
+interface PersonalizationPreferencesRepository {
+    val preferences: Flow<PersonalizationPreferences>
+
+    suspend fun selectTheme(theme: PersonalizationTheme)
+
+    suspend fun setGeneratedGameHapticsEnabled(enabled: Boolean)
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/preferences/PersonalizationPreferencesRepositoryFactory.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/preferences/PersonalizationPreferencesRepositoryFactory.kt
@@ -1,0 +1,6 @@
+package org.cescfe.numpairs.data.preferences
+
+import android.content.Context
+
+fun createPersonalizationPreferencesRepository(context: Context): PersonalizationPreferencesRepository =
+    DataStorePersonalizationPreferencesRepository(context.applicationContext.userPreferencesDataStore)

--- a/app/src/main/java/org/cescfe/numpairs/ui/theme/Theme.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/theme/Theme.kt
@@ -17,7 +17,15 @@ internal val MaterialTheme.numPairsSemanticColors: NumPairsSemanticColors
 
 @Composable
 fun NumPairsTheme(content: @Composable () -> Unit) {
-    val themeDefinition = WarmThemeDefinition
+    NumPairsTheme(
+        themeId = NumPairsThemeId.WARM,
+        content = content
+    )
+}
+
+@Composable
+internal fun NumPairsTheme(themeId: NumPairsThemeId, content: @Composable () -> Unit) {
+    val themeDefinition = themeId.definition()
 
     CompositionLocalProvider(
         LocalNumPairsSemanticColors provides themeDefinition.semanticColors

--- a/app/src/test/java/org/cescfe/numpairs/data/preferences/DataStorePersonalizationPreferencesRepositoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/preferences/DataStorePersonalizationPreferencesRepositoryTest.kt
@@ -1,0 +1,140 @@
+package org.cescfe.numpairs.data.preferences
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import java.io.File
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DataStorePersonalizationPreferencesRepositoryTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val dataStoreJobs = mutableListOf<Job>()
+
+    @After
+    fun tearDown() {
+        dataStoreJobs.forEach(Job::cancel)
+    }
+
+    @Test
+    fun freshPreferencesDefaultToWarmWithGeneratedGameHapticsEnabled() = runBlocking {
+        val fixture = createRepository()
+
+        assertEquals(
+            PersonalizationPreferences(
+                selectedTheme = PersonalizationTheme.WARM,
+                generatedGameHapticsEnabled = true
+            ),
+            fixture.repository.preferences.first()
+        )
+    }
+
+    @Test
+    fun everyThemeIdentityRoundTripsThroughItsPersistedValue() {
+        PersonalizationTheme.entries.forEach { theme ->
+            assertEquals(
+                theme,
+                PersonalizationTheme.fromPersistedValue(theme.persistedValue)
+            )
+        }
+    }
+
+    @Test
+    fun themeAndHapticsPersistIndependentlyAcrossRepositoryInstances() = runBlocking {
+        val dataStoreFile = createDataStoreFile()
+        val firstFixture = createRepository(dataStoreFile)
+
+        firstFixture.repository.selectTheme(PersonalizationTheme.TERMINAL)
+        firstFixture.repository.setGeneratedGameHapticsEnabled(false)
+        firstFixture.close()
+
+        val secondFixture = createRepository(dataStoreFile)
+
+        assertEquals(
+            PersonalizationPreferences(
+                selectedTheme = PersonalizationTheme.TERMINAL,
+                generatedGameHapticsEnabled = false
+            ),
+            secondFixture.repository.preferences.first()
+        )
+    }
+
+    @Test
+    fun unknownStoredThemeFallsBackToWarmWithoutChangingHaptics() = runBlocking {
+        val fixture = createRepository()
+        fixture.dataStore.edit { preferences ->
+            preferences[stringPreferencesKey("personalization_selected_theme")] = "future-theme"
+        }
+        fixture.repository.setGeneratedGameHapticsEnabled(false)
+
+        assertEquals(
+            PersonalizationPreferences(
+                selectedTheme = PersonalizationTheme.WARM,
+                generatedGameHapticsEnabled = false
+            ),
+            fixture.repository.preferences.first()
+        )
+    }
+
+    @Test
+    fun selectingThemeDoesNotOverwriteHapticsPreference() = runBlocking {
+        val fixture = createRepository()
+
+        fixture.repository.setGeneratedGameHapticsEnabled(false)
+        fixture.repository.selectTheme(PersonalizationTheme.EMBER)
+
+        assertEquals(
+            PersonalizationPreferences(
+                selectedTheme = PersonalizationTheme.EMBER,
+                generatedGameHapticsEnabled = false
+            ),
+            fixture.repository.preferences.first()
+        )
+    }
+
+    private fun createRepository(dataStoreFile: File = createDataStoreFile()): RepositoryFixture {
+        val job = SupervisorJob()
+        val scope = CoroutineScope(job + Dispatchers.IO)
+        dataStoreJobs += job
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { dataStoreFile }
+        )
+
+        return RepositoryFixture(
+            repository = DataStorePersonalizationPreferencesRepository(dataStore),
+            dataStore = dataStore,
+            job = job
+        )
+    }
+
+    private fun createDataStoreFile(): File = File(
+        temporaryFolder.root,
+        "${UUID.randomUUID()}.preferences_pb"
+    )
+
+    private data class RepositoryFixture(
+        val repository: PersonalizationPreferencesRepository,
+        val dataStore: DataStore<Preferences>,
+        private val job: Job
+    ) {
+        suspend fun close() {
+            job.cancelAndJoin()
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue

Resolves #465

## Summary

- Adds application-private personalization preferences for stable theme identity and generated-game haptics.
- Defaults missing or unknown theme values to Warm and haptics to enabled without coupling either preference to onboarding or generated sessions.
- Applies the selected palette at the application root and updates light/dark system-bar icon appearance.
- Keeps the navigation subtree stable while theme preferences change.
- Adds DataStore round-trip, independence, fallback, and all-theme identity tests plus a compiled Compose state-preservation test.

## UI Consistency

- Shared components or tokens reused: `NumPairsTheme` remains the single application theme provider and resolves the definitions added in #467.
- Intentional deviations from established visual roles: None. Existing installations have no stored v9 preference and therefore retain Warm exactly; selecting another stored identity only changes colors.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- UI diff review: Warm remains the default; typography, shapes, spacing, elevation, layout, touch geometry, navigation, onboarding, and game state are unchanged.