### PR TITLE
[225] Expose one-shot tile assignment commits

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/game/GameRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/game/GameRouteTest.kt
@@ -1,6 +1,7 @@
 package org.cescfe.numpairs.feature.game
 
 import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
@@ -24,6 +25,7 @@ import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.domain.puzzle.model.Strip
 import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.cescfe.numpairs.feature.game.presentation.GameUiState
+import org.cescfe.numpairs.feature.game.presentation.TileAssignmentCommit
 import org.cescfe.numpairs.feature.game.ui.screen.GameScreenRobot
 import org.cescfe.numpairs.feature.generated.GeneratedModes
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
@@ -159,6 +161,55 @@ class GameRouteTest {
     }
 
     @Test
+    fun exposes_each_tile_assignment_commit_once_without_replaying_it() {
+        val commits = mutableListOf<TileAssignmentCommit>()
+        var recompositionMarker by mutableStateOf(0)
+        var puzzleResetKey by mutableStateOf(0)
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                Column {
+                    Text(text = recompositionMarker.toString())
+                    GameRoute(
+                        title = "4 pairs",
+                        initialPuzzle = oneOperatorAwayFromSolvedOnePairPuzzle(),
+                        gameSessionKey = "assignment-commit",
+                        puzzleResetKey = puzzleResetKey,
+                        onTileAssignmentCommitted = commits::add
+                    )
+                }
+            }
+        }
+
+        GameScreenRobot(
+            activity = composeTestRule.activity,
+            interactions = composeTestRule
+        ).scrollToBoard()
+            .tapTileOperator(index = 1)
+            .tapOperatorOption(Operator.MULTIPLICATION)
+
+        composeTestRule.waitUntil {
+            commits.size == 1
+        }
+        composeTestRule.runOnIdle {
+            assertEquals(
+                TileAssignmentCommit(tileIndex = 1, madeTileCorrect = true),
+                commits.single()
+            )
+            recompositionMarker += 1
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle {
+            assertEquals(1, commits.size)
+            puzzleResetKey += 1
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnIdle {
+            assertEquals(1, commits.size)
+        }
+    }
+
+    @Test
     fun solved_puzzle_shows_the_success_overlay_by_default() {
         composeTestRule.setContent {
             NumPairsTheme {
@@ -280,6 +331,26 @@ private fun solvedOnePairPuzzle(): Puzzle {
                 StripItem.Known(1),
                 StripItem.Known(2)
             )
+        )
+    )
+}
+
+private fun oneOperatorAwayFromSolvedOnePairPuzzle(): Puzzle {
+    val solvedPuzzle = solvedOnePairPuzzle()
+    val multiplicationTile = solvedPuzzle.board.tiles[1]
+
+    return solvedPuzzle.copy(
+        board = Board(
+            tiles = solvedPuzzle.board.tiles.toMutableList().apply {
+                set(
+                    1,
+                    multiplicationTile.copy(
+                        expression = multiplicationTile.expression.copy(
+                            operator = Operator.Hidden
+                        )
+                    )
+                )
+            }
         )
     )
 }

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/GameRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/GameRoute.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.ViewModelProvider
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.feature.game.presentation.GameUiState
 import org.cescfe.numpairs.feature.game.presentation.GameViewModel
+import org.cescfe.numpairs.feature.game.presentation.TileAssignmentCommit
 import org.cescfe.numpairs.feature.game.ui.screen.GameScreen
 
 @Composable
@@ -39,6 +40,7 @@ fun GameRoute(
     contentBeforePuzzle: @Composable ColumnScope.() -> Unit = {},
     onGameUiStateChanged: (GameUiState) -> Unit = {},
     onPuzzleChanged: (Puzzle) -> Unit = {},
+    onTileAssignmentCommitted: (TileAssignmentCommit) -> Unit = {},
     onNavigateBack: () -> Unit = {}
 ) {
     val gameViewModel = rememberGameViewModel(
@@ -48,6 +50,7 @@ fun GameRoute(
     val uiState by gameViewModel.uiState.collectAsState()
     val currentOnGameUiStateChanged by rememberUpdatedState(onGameUiStateChanged)
     val currentOnPuzzleChanged by rememberUpdatedState(onPuzzleChanged)
+    val currentOnTileAssignmentCommitted by rememberUpdatedState(onTileAssignmentCommitted)
 
     LaunchedEffect(gameViewModel, puzzleResetKey) {
         gameViewModel.reset(initialPuzzle = initialPuzzle)
@@ -109,6 +112,7 @@ fun GameRoute(
 
             if (interactionPolicy.canConfirmTileOperand(dialog.tileIndex, dialog.slot, stripEntryId)) {
                 gameViewModel.onTileOperandSelectionConfirmed(stripEntryId)
+                    ?.let(currentOnTileAssignmentCommitted)
             }
         },
         onTileOperatorTapped = { index ->
@@ -127,6 +131,7 @@ fun GameRoute(
 
             if (interactionPolicy.canConfirmTileOperator(tileIndex, operator)) {
                 gameViewModel.onTileOperatorSelectionConfirmed(operator)
+                    ?.let(currentOnTileAssignmentCommitted)
             }
         },
         onSuccessOverlayDismissed = gameViewModel::onSuccessOverlayDismissed,

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/presentation/GameViewModel.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/presentation/GameViewModel.kt
@@ -12,6 +12,7 @@ import org.cescfe.numpairs.domain.puzzle.model.Operator
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.cescfe.numpairs.domain.puzzle.model.Tile
+import org.cescfe.numpairs.domain.puzzle.model.TileResolutionState
 
 class GameViewModel(initialPuzzle: Puzzle = samplePuzzle) : ViewModel() {
     private var puzzle: Puzzle = initialPuzzle
@@ -171,26 +172,32 @@ class GameViewModel(initialPuzzle: Puzzle = samplePuzzle) : ViewModel() {
         return true
     }
 
-    fun onTileOperandSelectionConfirmed(stripEntryId: Int) {
-        val target = (presentationState.modal as? GameModalState.TileOperandSelection)?.target ?: return
+    fun onTileOperandSelectionConfirmed(stripEntryId: Int): TileAssignmentCommit? {
+        val target = (presentationState.modal as? GameModalState.TileOperandSelection)?.target ?: return null
         val updatedPuzzle = puzzle.withSelectedOperand(
             target = target,
             stripEntryId = stripEntryId
-        ) ?: return
+        ) ?: return null
 
-        commit(updatedPuzzle = updatedPuzzle) {
+        return commitTileAssignment(
+            tileIndex = target.tileIndex,
+            updatedPuzzle = updatedPuzzle
+        ) {
             dismissTileOperandSelection()
         }
     }
 
-    fun onTileOperatorSelectionConfirmed(operator: Operator) {
-        val tileIndex = (presentationState.modal as? GameModalState.TileOperatorSelection)?.tileIndex ?: return
+    fun onTileOperatorSelectionConfirmed(operator: Operator): TileAssignmentCommit? {
+        val tileIndex = (presentationState.modal as? GameModalState.TileOperatorSelection)?.tileIndex ?: return null
         val updatedPuzzle = puzzle.withSelectedOperator(
             tileIndex = tileIndex,
             operator = operator
-        ) ?: return
+        ) ?: return null
 
-        commit(updatedPuzzle = updatedPuzzle) {
+        return commitTileAssignment(
+            tileIndex = tileIndex,
+            updatedPuzzle = updatedPuzzle
+        ) {
             dismissTileOperatorSelection()
         }
     }
@@ -257,6 +264,31 @@ class GameViewModel(initialPuzzle: Puzzle = samplePuzzle) : ViewModel() {
                 _currentPuzzle.value = puzzle
             }
             publishUiState()
+        }
+    }
+
+    private fun commitTileAssignment(
+        tileIndex: Int,
+        updatedPuzzle: Puzzle,
+        updatePresentation: GamePresentationState.() -> GamePresentationState
+    ): TileAssignmentCommit? {
+        val previousTile = puzzle.board.tiles.getOrNull(tileIndex) ?: return null
+        val updatedTile = updatedPuzzle.board.tiles.getOrNull(tileIndex) ?: return null
+        val hasPuzzleChanged = updatedPuzzle != puzzle
+
+        commit(
+            updatedPuzzle = updatedPuzzle,
+            updatePresentation = updatePresentation
+        )
+
+        return if (hasPuzzleChanged) {
+            TileAssignmentCommit(
+                tileIndex = tileIndex,
+                madeTileCorrect = previousTile.resolutionState != TileResolutionState.CORRECT &&
+                    updatedTile.resolutionState == TileResolutionState.CORRECT
+            )
+        } else {
+            null
         }
     }
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/presentation/TileAssignmentCommit.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/presentation/TileAssignmentCommit.kt
@@ -1,0 +1,9 @@
+package org.cescfe.numpairs.feature.game.presentation
+
+data class TileAssignmentCommit(val tileIndex: Int, val madeTileCorrect: Boolean) {
+    init {
+        require(tileIndex >= 0) {
+            "Tile assignment commits require a non-negative tile index."
+        }
+    }
+}

--- a/app/src/test/java/org/cescfe/numpairs/feature/game/presentation/GameViewModelTileAssignmentCommitTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/game/presentation/GameViewModelTileAssignmentCommitTest.kt
@@ -1,0 +1,83 @@
+package org.cescfe.numpairs.feature.game.presentation
+
+import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.TileResolutionState
+import org.cescfe.numpairs.feature.game.presentation.support.enterStripValue
+import org.cescfe.numpairs.feature.game.presentation.support.incompletePuzzleOneOperatorSelectionAwayFromSolvedCompletion
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GameViewModelTileAssignmentCommitTest {
+    @Test
+    fun `accepted operand change returns one commit after publishing the puzzle change`() {
+        val viewModel = GameViewModel(initialPuzzle = samplePuzzle)
+        viewModel.enterStripValue(index = 0, value = "1")
+
+        viewModel.onTileLeftOperandTapped(index = 0)
+        val commit = viewModel.onTileOperandSelectionConfirmed(stripEntryId = 0)
+
+        assertEquals(
+            Expression.Operand.Known(value = 1, stripEntryId = 0),
+            viewModel.currentPuzzle.value.board.tiles[0].expression.leftOperand
+        )
+        assertEquals(TileAssignmentCommit(tileIndex = 0, madeTileCorrect = false), commit)
+    }
+
+    @Test
+    fun `accepted operator change reports when that action makes its tile correct`() {
+        val viewModel = GameViewModel(
+            initialPuzzle = incompletePuzzleOneOperatorSelectionAwayFromSolvedCompletion()
+        )
+
+        viewModel.onTileOperatorTapped(index = 1)
+        val commit = viewModel.onTileOperatorSelectionConfirmed(operator = Operator.MULTIPLICATION)
+
+        assertEquals(
+            TileResolutionState.CORRECT,
+            viewModel.currentPuzzle.value.board.tiles[1].resolutionState
+        )
+        assertEquals(TileAssignmentCommit(tileIndex = 1, madeTileCorrect = true), commit)
+    }
+
+    @Test
+    fun `invalid unavailable and unchanged selections return no commit`() {
+        val viewModel = GameViewModel(
+            initialPuzzle = incompletePuzzleOneOperatorSelectionAwayFromSolvedCompletion()
+        )
+
+        assertNull(viewModel.onTileOperatorSelectionConfirmed(operator = Operator.ADDITION))
+
+        viewModel.onTileLeftOperandTapped(index = 1)
+        assertNull(viewModel.onTileOperandSelectionConfirmed(stripEntryId = Int.MAX_VALUE))
+
+        viewModel.onTileOperandSelectionDismissed()
+        viewModel.onTileOperatorTapped(index = 0)
+        assertNull(viewModel.onTileOperatorSelectionConfirmed(operator = Operator.ADDITION))
+        assertNull(viewModel.uiState.value.tileOperatorSelectionDialog)
+    }
+
+    @Test
+    fun `a tile can report a new correct transition after it is reset`() {
+        val viewModel = GameViewModel(
+            initialPuzzle = incompletePuzzleOneOperatorSelectionAwayFromSolvedCompletion()
+        )
+        viewModel.onTileOperatorTapped(index = 1)
+        viewModel.onTileOperatorSelectionConfirmed(operator = Operator.MULTIPLICATION)
+        viewModel.onSuccessOverlayDismissed()
+
+        viewModel.onTileResetTapped(index = 1)
+        viewModel.onTileLeftOperandTapped(index = 1)
+        val leftOperandCommit = viewModel.onTileOperandSelectionConfirmed(stripEntryId = 1)
+        viewModel.onTileOperatorTapped(index = 1)
+        val operatorCommit = viewModel.onTileOperatorSelectionConfirmed(operator = Operator.MULTIPLICATION)
+        viewModel.onTileRightOperandTapped(index = 1)
+        val rightOperandCommit = viewModel.onTileOperandSelectionConfirmed(stripEntryId = 0)
+
+        assertEquals(TileAssignmentCommit(tileIndex = 1, madeTileCorrect = false), leftOperandCommit)
+        assertEquals(TileAssignmentCommit(tileIndex = 1, madeTileCorrect = false), operatorCommit)
+        assertEquals(TileAssignmentCommit(tileIndex = 1, madeTileCorrect = true), rightOperandCommit)
+    }
+}


### PR DESCRIPTION
## Related Issue

Resolves #472

## Summary

- Return a typed tile-assignment commit only when an accepted operand or operator selection changes the puzzle.
- Derive the affected tile and newly-correct transition from the immediate before and after resolution states.
- Deliver each commit directly through an opt-in GameRoute callback after publication, without durable or replayable event state.
- Keep selectors, strip input, resets, restoration, Tutorial, onboarding, and generic GameScreen presentation free of new feedback behavior.
- Add unit and route coverage for accepted, rejected, unchanged, newly-correct, reset, recomposition, and reset-key behavior.
- Validate with spotlessApply, testDebugUnitTest, spotlessCheck, compileDebugAndroidTestKotlin, and diff review.