### PR TITLE
[226] Add accepted-assignment haptics to generated games

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedAssignmentHapticsTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedAssignmentHapticsTest.kt
@@ -1,0 +1,176 @@
+package org.cescfe.numpairs.feature.generated
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
+import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
+import org.cescfe.numpairs.data.preferences.FakePersonalizationPreferencesRepository
+import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
+import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.feature.game.GameRoute
+import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
+import org.cescfe.numpairs.feature.menu.ui.MenuScreenTestTags
+import org.cescfe.numpairs.ui.navigation.AppNavigation
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GeneratedAssignmentHapticsTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun generatedAssignmentsRequestConfirmationOnlyWhileThePreferenceIsEnabled() {
+        val hapticFeedback = RecordingHapticFeedback()
+        val preferencesRepository = FakePersonalizationPreferencesRepository()
+        setAppContent(
+            hapticFeedback = hapticFeedback,
+            preferencesRepository = preferencesRepository
+        )
+        navigateToGeneratedMode(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
+
+        assignFirstTileOperator(Operator.ADDITION)
+        assertEquals(listOf(HapticFeedbackType.Confirm), hapticFeedback.requestedTypes)
+
+        runBlocking {
+            preferencesRepository.setGeneratedGameHapticsEnabled(false)
+        }
+        composeTestRule.waitForIdle()
+        assignFirstTileOperator(Operator.MULTIPLICATION)
+        assertEquals(1, hapticFeedback.requestedTypes.size)
+
+        runBlocking {
+            preferencesRepository.setGeneratedGameHapticsEnabled(true)
+        }
+        composeTestRule.waitForIdle()
+        assignFirstTileOperator(Operator.ADDITION)
+        assertEquals(
+            listOf(HapticFeedbackType.Confirm, HapticFeedbackType.Confirm),
+            hapticFeedback.requestedTypes
+        )
+
+        assignFirstTileOperator(Operator.ADDITION)
+        enterFirstStripValue()
+        assertEquals(2, hapticFeedback.requestedTypes.size)
+    }
+
+    @Test
+    fun eightPairsUsesTheSameGeneratedAssignmentHaptic() {
+        val hapticFeedback = RecordingHapticFeedback()
+        setAppContent(hapticFeedback = hapticFeedback)
+        navigateToGeneratedMode(MenuScreenTestTags.EIGHT_PAIRS_BUTTON)
+
+        assignFirstTileOperator(Operator.ADDITION)
+
+        assertEquals(listOf(HapticFeedbackType.Confirm), hapticFeedback.requestedTypes)
+    }
+
+    @Test
+    fun genericGameRouteDoesNotRequestGeneratedAssignmentHaptics() {
+        val hapticFeedback = RecordingHapticFeedback()
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalHapticFeedback provides hapticFeedback) {
+                NumPairsTheme {
+                    GameRoute(
+                        title = "Tutorial",
+                        initialPuzzle = samplePuzzle,
+                        gameSessionKey = "generic-route-haptics"
+                    )
+                }
+            }
+        }
+
+        assignFirstTileOperator(Operator.ADDITION)
+
+        assertEquals(emptyList<HapticFeedbackType>(), hapticFeedback.requestedTypes)
+    }
+
+    private fun setAppContent(
+        hapticFeedback: RecordingHapticFeedback,
+        preferencesRepository: FakePersonalizationPreferencesRepository =
+            FakePersonalizationPreferencesRepository()
+    ) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalHapticFeedback provides hapticFeedback) {
+                NumPairsTheme {
+                    AppNavigation(
+                        onboardingRepository = FakeOnboardingRepository(),
+                        generatedSessionRepository = FakeGeneratedSessionRepository(),
+                        personalizationPreferencesRepository = preferencesRepository,
+                        topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
+                        generatedModeRegistry = GeneratedModes.registry,
+                        generatedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory {
+                            GeneratedPuzzleGenerationUseCase { request ->
+                                GeneratedPuzzleGenerationResult.Generated(
+                                    request = request,
+                                    initialPuzzle = samplePuzzle
+                                )
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    private fun navigateToGeneratedMode(menuButtonTag: String) {
+        composeTestRule
+            .onNodeWithTag(menuButtonTag)
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+    }
+
+    private fun assignFirstTileOperator(operator: Operator) {
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.BOARD)
+            .performScrollTo()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileOperator(0), useUnmergedTree = true)
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileOperatorOption(operator), useUnmergedTree = true)
+            .performClick()
+        composeTestRule.waitForIdle()
+    }
+
+    private fun enterFirstStripValue() {
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.stripItem(0))
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.STRIP_ENTRY_INPUT)
+            .performTextInput("1")
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.STRIP_ENTRY_INPUT)
+            .performImeAction()
+        composeTestRule.waitForIdle()
+    }
+
+    private class RecordingHapticFeedback : HapticFeedback {
+        val requestedTypes = mutableListOf<HapticFeedbackType>()
+
+        override fun performHapticFeedback(hapticFeedbackType: HapticFeedbackType) {
+            requestedTypes += hapticFeedbackType
+        }
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/fourpairs/FourPairsRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/fourpairs/FourPairsRoute.kt
@@ -32,6 +32,7 @@ fun FourPairsRoute(
     generationUseCase: GeneratedPuzzleGenerationUseCase,
     launchIntent: GeneratedModeLaunchIntent = GeneratedModeLaunchIntent.DefaultNewPuzzle,
     mode: GeneratedModeConfiguration = GeneratedModes.FOUR_PAIRS,
+    isGeneratedGameHapticsEnabled: Boolean = true,
     tutorialOverlayMode: TutorialMode? = null,
     onTutorialOverlayClosed: () -> Unit = {},
     onNavigateBack: () -> Unit = {}
@@ -61,6 +62,7 @@ fun FourPairsRoute(
             title = stringResource(R.string.four_pairs_screen_title),
             generationUseCase = generationUseCase,
             generatedSessionRepository = generatedSessionRepository,
+            isGeneratedGameHapticsEnabled = isGeneratedGameHapticsEnabled,
             isRulesHelperEnabled = true,
             isRulesHelperActionDiscoveryDotVisible = actionDiscoveryState?.hasSeenHelpAction == false,
             onRulesHelperActionTapped = {

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
@@ -22,7 +22,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -43,6 +45,7 @@ fun GeneratedModeRoute(
     generationUseCase: GeneratedPuzzleGenerationUseCase,
     generatedSessionRepository: GeneratedSessionRepository,
     modifier: Modifier = Modifier,
+    isGeneratedGameHapticsEnabled: Boolean = true,
     isRulesHelperEnabled: Boolean = false,
     isRulesHelperActionDiscoveryDotVisible: Boolean = false,
     onRulesHelperActionTapped: () -> Unit = {},
@@ -79,6 +82,7 @@ fun GeneratedModeRoute(
                     onRulesHelperActionTapped = onRulesHelperActionTapped,
                     onRulesHelperPlayTutorialRequested = onRulesHelperPlayTutorialRequested,
                     topBarActions = topBarActions,
+                    isGeneratedGameHapticsEnabled = isGeneratedGameHapticsEnabled,
                     onNewPuzzleRequested = viewModel::onNewPuzzleRequested,
                     onPuzzleChanged = viewModel::onPuzzleChanged,
                     onNavigateBack = onNavigateBack,
@@ -96,6 +100,7 @@ fun GeneratedModeRoute(
             onRulesHelperActionTapped = onRulesHelperActionTapped,
             onRulesHelperPlayTutorialRequested = onRulesHelperPlayTutorialRequested,
             topBarActions = topBarActions,
+            isGeneratedGameHapticsEnabled = isGeneratedGameHapticsEnabled,
             onNewPuzzleRequested = viewModel::onNewPuzzleRequested,
             onPuzzleChanged = viewModel::onPuzzleChanged,
             onNavigateBack = onNavigateBack
@@ -112,6 +117,7 @@ fun GeneratedModeRoute(
                     onRulesHelperActionTapped = onRulesHelperActionTapped,
                     onRulesHelperPlayTutorialRequested = onRulesHelperPlayTutorialRequested,
                     topBarActions = topBarActions,
+                    isGeneratedGameHapticsEnabled = isGeneratedGameHapticsEnabled,
                     onNewPuzzleRequested = viewModel::onNewPuzzleRequested,
                     onPuzzleChanged = viewModel::onPuzzleChanged,
                     onNavigateBack = onNavigateBack,
@@ -148,11 +154,14 @@ private fun GeneratedPuzzleGameContent(
     onRulesHelperActionTapped: () -> Unit,
     onRulesHelperPlayTutorialRequested: (() -> Unit)?,
     topBarActions: @Composable RowScope.() -> Unit,
+    isGeneratedGameHapticsEnabled: Boolean,
     onNewPuzzleRequested: () -> Unit,
     onPuzzleChanged: (GeneratedSessionId, Puzzle) -> Unit,
     onNavigateBack: () -> Unit,
     overlay: @Composable () -> Unit = {}
 ) {
+    val hapticFeedback = LocalHapticFeedback.current
+
     Box(modifier = modifier.fillMaxSize()) {
         GameRoute(
             title = title,
@@ -170,6 +179,11 @@ private fun GeneratedPuzzleGameContent(
             topBarActions = topBarActions,
             onPuzzleChanged = { puzzle ->
                 onPuzzleChanged(session.id, puzzle)
+            },
+            onTileAssignmentCommitted = {
+                if (isGeneratedGameHapticsEnabled) {
+                    hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                }
             },
             onNavigateBack = onNavigateBack
         )

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -82,6 +82,7 @@ private fun UnlockedAppNavigation(
     startDestination: AppDestination
 ) {
     val generatedSessionSnapshot by generatedSessionRepository.session.collectAsState(initial = null)
+    val personalizationPreferences by personalizationPreferencesRepository.preferences.collectAsState(initial = null)
     val resumableSession = generatedSessionSnapshot.toResumableGeneratedSessionOrNull(
         modeRegistry = generatedModeRegistry
     )
@@ -197,6 +198,8 @@ private fun UnlockedAppNavigation(
                     generationUseCase = generationUseCase,
                     generatedSessionRepository = generatedSessionRepository,
                     topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
+                    isGeneratedGameHapticsEnabled =
+                    personalizationPreferences?.generatedGameHapticsEnabled == true,
                     onNavigateBack = navigateToMenu
                 )
 
@@ -206,6 +209,8 @@ private fun UnlockedAppNavigation(
                     title = mode.localizedTitle(),
                     generationUseCase = generationUseCase,
                     generatedSessionRepository = generatedSessionRepository,
+                    isGeneratedGameHapticsEnabled =
+                    personalizationPreferences?.generatedGameHapticsEnabled == true,
                     modifier = modifier,
                     onNavigateBack = navigateToMenu
                 )


### PR DESCRIPTION
## Related Issue

Resolves #473

## Summary

- Consume one-shot assignment commits only inside generated-mode content.
- Request the Compose/Android Confirm haptic, which uses platform compatibility fallback and respects system haptic settings without a vibration permission.
- Observe the persisted NumPairs preference in unlocked navigation, suppressing feedback until preferences are loaded and whenever the toggle is disabled.
- Apply the same generated-only behavior to 4 Pairs and 8 Pairs while leaving generic GameRoute, Tutorial, onboarding, and authored practice unchanged.
- Add Compose coverage for enabled and disabled preference changes, unchanged assignments, strip input, both generated modes, and the generic route boundary.
- Validate with spotlessApply, testDebugUnitTest, spotlessCheck, compileDebugAndroidTestKotlin, manifest review, and UI diff review.

## UI Consistency

- Shared components or tokens reused: no visual components or tokens change; the implementation uses the platform action-oriented Confirm haptic through LocalHapticFeedback.
- Intentional deviations from established visual roles: none. The UI tree, layout, colors, typography, shapes, and interaction geometry are unchanged.