### PR TITLE
[227] Animate newly correct generated tiles

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/CorrectTileMotionTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/CorrectTileMotionTest.kt
@@ -1,0 +1,192 @@
+package org.cescfe.numpairs.feature.generated
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
+import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
+import org.cescfe.numpairs.data.preferences.FakePersonalizationPreferencesRepository
+import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
+import org.cescfe.numpairs.data.preferences.PersonalizationPreferences
+import org.cescfe.numpairs.domain.puzzle.model.Board
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.Strip
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.cescfe.numpairs.domain.puzzle.model.Tile
+import org.cescfe.numpairs.feature.game.GameRoute
+import org.cescfe.numpairs.feature.game.ui.screen.GameScreenRobot
+import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
+import org.cescfe.numpairs.feature.game.ui.semantics.CorrectTileFeedbackIdKey
+import org.cescfe.numpairs.feature.menu.ui.MenuScreenTestTags
+import org.cescfe.numpairs.ui.navigation.AppNavigation
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CorrectTileMotionTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun enabledRouteTargetsOneTileOnceAndAllowsANewResponseAfterReset() {
+        var recompositionMarker by mutableStateOf(0)
+        var puzzleResetKey by mutableStateOf(0)
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                Column {
+                    Text(text = recompositionMarker.toString())
+                    GameRoute(
+                        title = "4 pairs",
+                        initialPuzzle = oneOperatorAwayPuzzle(),
+                        gameSessionKey = "correct-tile-motion",
+                        puzzleResetKey = puzzleResetKey,
+                        isCorrectTileMotionEnabled = true
+                    )
+                }
+            }
+        }
+        val game = gameRobot()
+
+        game.scrollToBoard()
+            .tapTileOperator(index = 0)
+            .tapOperatorOption(Operator.ADDITION)
+        assertTileFeedback(tileIndex = 0, feedbackId = 1L)
+        assertNoTileFeedback(tileIndex = 1)
+
+        composeTestRule.runOnIdle {
+            recompositionMarker += 1
+        }
+        composeTestRule.waitForIdle()
+        assertTileFeedback(tileIndex = 0, feedbackId = 1L)
+
+        game.tapTileReset(index = 0)
+        assertNoTileFeedback(tileIndex = 0)
+        game.tapTileLeftOperand(index = 0)
+            .tapOperandOption(entryId = 0)
+            .tapTileOperator(index = 0)
+            .tapOperatorOption(Operator.ADDITION)
+            .tapTileRightOperand(index = 0)
+            .tapOperandOption(entryId = 1)
+        assertTileFeedback(tileIndex = 0, feedbackId = 2L)
+
+        composeTestRule.runOnIdle {
+            puzzleResetKey += 1
+        }
+        composeTestRule.waitForIdle()
+        assertNoTileFeedback(tileIndex = 0)
+    }
+
+    @Test
+    fun generatedRouteEnablesCorrectTileMotion() {
+        composeTestRule.setContent {
+            NumPairsTheme {
+                AppNavigation(
+                    onboardingRepository = FakeOnboardingRepository(),
+                    generatedSessionRepository = FakeGeneratedSessionRepository(),
+                    personalizationPreferencesRepository = FakePersonalizationPreferencesRepository(
+                        initialPreferences = PersonalizationPreferences(
+                            generatedGameHapticsEnabled = false
+                        )
+                    ),
+                    topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
+                    generatedModeRegistry = GeneratedModes.registry,
+                    generatedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory {
+                        GeneratedPuzzleGenerationUseCase { request ->
+                            GeneratedPuzzleGenerationResult.Generated(
+                                request = request,
+                                initialPuzzle = oneOperatorAwayPuzzle()
+                            )
+                        }
+                    }
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
+            .performClick()
+        gameRobot()
+            .scrollToBoard()
+            .tapTileOperator(index = 0)
+            .tapOperatorOption(Operator.ADDITION)
+
+        assertTileFeedback(tileIndex = 0, feedbackId = 1L)
+    }
+
+    @Test
+    fun genericGameRouteKeepsCorrectTileMotionDisabledByDefault() {
+        composeTestRule.setContent {
+            NumPairsTheme {
+                GameRoute(
+                    title = "Tutorial",
+                    initialPuzzle = oneOperatorAwayPuzzle(),
+                    gameSessionKey = "generic-correct-tile-motion"
+                )
+            }
+        }
+
+        gameRobot()
+            .scrollToBoard()
+            .tapTileOperator(index = 0)
+            .tapOperatorOption(Operator.ADDITION)
+
+        assertNoTileFeedback(tileIndex = 0)
+    }
+
+    private fun gameRobot(): GameScreenRobot = GameScreenRobot(
+        activity = composeTestRule.activity,
+        interactions = composeTestRule
+    )
+
+    private fun assertTileFeedback(tileIndex: Int, feedbackId: Long) {
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tile(tileIndex), useUnmergedTree = true)
+            .assert(SemanticsMatcher.expectValue(CorrectTileFeedbackIdKey, feedbackId))
+    }
+
+    private fun assertNoTileFeedback(tileIndex: Int) {
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tile(tileIndex), useUnmergedTree = true)
+            .assert(SemanticsMatcher.keyNotDefined(CorrectTileFeedbackIdKey))
+    }
+}
+
+private fun oneOperatorAwayPuzzle(): Puzzle = Puzzle(
+    board = Board(
+        tiles = listOf(
+            Tile(
+                expression = Expression(
+                    leftOperand = Expression.Operand.Known(value = 1, stripEntryId = 0),
+                    operator = Operator.Hidden,
+                    rightOperand = Expression.Operand.Known(value = 2, stripEntryId = 1)
+                ),
+                result = 3
+            ),
+            Tile(
+                expression = Expression(
+                    leftOperand = Expression.Operand.Hidden,
+                    operator = Operator.Hidden,
+                    rightOperand = Expression.Operand.Hidden
+                ),
+                result = 7
+            )
+        )
+    ),
+    strip = Strip.fromItems(
+        items = listOf(1, 2, 3, 4).map(StripItem::Known)
+    )
+)

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/GameRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/GameRoute.kt
@@ -9,8 +9,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModel
@@ -34,6 +37,7 @@ fun GameRoute(
     onRulesHelperActionTapped: () -> Unit = {},
     onRulesHelperPlayTutorialRequested: (() -> Unit)? = null,
     isSuccessOverlayEnabled: Boolean = true,
+    isCorrectTileMotionEnabled: Boolean = false,
     interactionPolicy: GameInteractionPolicy = GameInteractionPolicy.AllowAll,
     highlightState: GameHighlightState = GameHighlightState.None,
     topBarActions: @Composable RowScope.() -> Unit = {},
@@ -51,6 +55,20 @@ fun GameRoute(
     val currentOnGameUiStateChanged by rememberUpdatedState(onGameUiStateChanged)
     val currentOnPuzzleChanged by rememberUpdatedState(onPuzzleChanged)
     val currentOnTileAssignmentCommitted by rememberUpdatedState(onTileAssignmentCommitted)
+    var nextCorrectTileFeedbackId by remember(gameViewModel) { mutableLongStateOf(0L) }
+    var correctTileFeedbackIdsByIndex by remember(gameViewModel, puzzleResetKey) {
+        mutableStateOf(emptyMap<Int, Long>())
+    }
+
+    fun handleTileAssignmentCommit(commit: TileAssignmentCommit) {
+        currentOnTileAssignmentCommitted(commit)
+
+        if (isCorrectTileMotionEnabled && commit.madeTileCorrect) {
+            nextCorrectTileFeedbackId += 1
+            correctTileFeedbackIdsByIndex = correctTileFeedbackIdsByIndex +
+                (commit.tileIndex to nextCorrectTileFeedbackId)
+        }
+    }
 
     LaunchedEffect(gameViewModel, puzzleResetKey) {
         gameViewModel.reset(initialPuzzle = initialPuzzle)
@@ -112,7 +130,7 @@ fun GameRoute(
 
             if (interactionPolicy.canConfirmTileOperand(dialog.tileIndex, dialog.slot, stripEntryId)) {
                 gameViewModel.onTileOperandSelectionConfirmed(stripEntryId)
-                    ?.let(currentOnTileAssignmentCommitted)
+                    ?.let(::handleTileAssignmentCommit)
             }
         },
         onTileOperatorTapped = { index ->
@@ -123,6 +141,7 @@ fun GameRoute(
         onTileResetTapped = { index ->
             if (interactionPolicy.canTapTileReset(index) && resolveActiveStripItemEntryInputIfAllowed()) {
                 gameViewModel.onTileResetTapped(index)
+                correctTileFeedbackIdsByIndex = correctTileFeedbackIdsByIndex - index
             }
         },
         onTileOperatorSelectionDismissed = gameViewModel::onTileOperatorSelectionDismissed,
@@ -131,7 +150,7 @@ fun GameRoute(
 
             if (interactionPolicy.canConfirmTileOperator(tileIndex, operator)) {
                 gameViewModel.onTileOperatorSelectionConfirmed(operator)
-                    ?.let(currentOnTileAssignmentCommitted)
+                    ?.let(::handleTileAssignmentCommit)
             }
         },
         onSuccessOverlayDismissed = gameViewModel::onSuccessOverlayDismissed,
@@ -143,6 +162,7 @@ fun GameRoute(
         isSuccessOverlayEnabled = isSuccessOverlayEnabled,
         interactionPolicy = interactionPolicy,
         highlightState = highlightState,
+        correctTileFeedbackIdsByIndex = correctTileFeedbackIdsByIndex,
         topBarActions = topBarActions,
         contentBeforePuzzle = contentBeforePuzzle
     )

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/tile/PuzzleTile.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/tile/PuzzleTile.kt
@@ -1,5 +1,8 @@
 package org.cescfe.numpairs.feature.game.ui.components.tile
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -15,8 +18,11 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -28,6 +34,7 @@ import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
 import org.cescfe.numpairs.feature.game.presentation.GameUiState
 import org.cescfe.numpairs.feature.game.presentation.TileUiState
 import org.cescfe.numpairs.feature.game.presentation.TileVisualState
+import org.cescfe.numpairs.feature.game.ui.semantics.correctTileFeedbackSemantics
 import org.cescfe.numpairs.feature.game.ui.semantics.gameHighlightSemantics
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 import org.cescfe.numpairs.ui.theme.NumPairsTextStyles
@@ -39,6 +46,7 @@ fun PuzzleTile(
     tile: TileUiState,
     modifier: Modifier = Modifier,
     isHighlighted: Boolean = false,
+    correctFeedbackId: Long? = null,
     leftOperandModifier: Modifier = Modifier,
     isLeftOperandHighlighted: Boolean = false,
     leftOperandContentDescription: String? = null,
@@ -55,6 +63,7 @@ fun PuzzleTile(
     resetModifier: Modifier = Modifier,
     onResetClick: (() -> Unit)? = null
 ) {
+    val correctFeedbackScale = remember { Animatable(1f) }
     val statePalette = tileStatePalette(tile.visualState)
     val semanticColors = MaterialTheme.numPairsSemanticColors
     val tileBorder = if (isHighlighted) {
@@ -69,14 +78,39 @@ fun PuzzleTile(
         TileVisualState.NORMAL -> null
     }
 
+    LaunchedEffect(correctFeedbackId) {
+        correctFeedbackScale.snapTo(1f)
+        if (correctFeedbackId != null) {
+            correctFeedbackScale.animateTo(
+                targetValue = CORRECT_TILE_FEEDBACK_SCALE,
+                animationSpec = tween(
+                    durationMillis = CORRECT_TILE_FEEDBACK_SCALE_UP_DURATION_MILLIS,
+                    easing = FastOutSlowInEasing
+                )
+            )
+            correctFeedbackScale.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(
+                    durationMillis = CORRECT_TILE_FEEDBACK_SCALE_DOWN_DURATION_MILLIS,
+                    easing = FastOutSlowInEasing
+                )
+            )
+        }
+    }
+
     Box(
         modifier = modifier
+            .graphicsLayer {
+                scaleX = correctFeedbackScale.value
+                scaleY = correctFeedbackScale.value
+            }
             .semantics {
                 if (tileStateDescription != null) {
                     stateDescription = tileStateDescription
                 }
             }
             .gameHighlightSemantics(isHighlighted)
+            .correctTileFeedbackSemantics(correctFeedbackId)
     ) {
         Card(
             modifier = Modifier,

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/tile/PuzzleTileDefaults.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/components/tile/PuzzleTileDefaults.kt
@@ -26,6 +26,9 @@ internal const val LARGE_OPERAND_CHARACTER_COUNT = 3
 internal val HIGHLIGHTED_TILE_BORDER_WIDTH = 3.dp
 internal val HIGHLIGHTED_TILE_EXPRESSION_SLOT_BORDER_WIDTH = 2.dp
 internal val HIGHLIGHTED_TILE_EXPRESSION_SLOT_CORNER_RADIUS = 8.dp
+internal const val CORRECT_TILE_FEEDBACK_SCALE = 1.04f
+internal const val CORRECT_TILE_FEEDBACK_SCALE_UP_DURATION_MILLIS = 90
+internal const val CORRECT_TILE_FEEDBACK_SCALE_DOWN_DURATION_MILLIS = 130
 
 @Composable
 internal fun tileStatePalette(visualState: TileVisualState): TileStatePalette {

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreen.kt
@@ -73,6 +73,7 @@ fun GameScreen(
     isSuccessOverlayEnabled: Boolean = true,
     interactionPolicy: GameInteractionPolicy = GameInteractionPolicy.AllowAll,
     highlightState: GameHighlightState = GameHighlightState.None,
+    correctTileFeedbackIdsByIndex: Map<Int, Long> = emptyMap(),
     topBarActions: @Composable RowScope.() -> Unit = {},
     contentBeforePuzzle: @Composable ColumnScope.() -> Unit = {}
 ) {
@@ -150,6 +151,7 @@ fun GameScreen(
                     onTileOperatorSelectionConfirmed = onTileOperatorSelectionConfirmed,
                     interactionPolicy = interactionPolicy,
                     highlightState = highlightState,
+                    correctTileFeedbackIdsByIndex = correctTileFeedbackIdsByIndex,
                     modifier = Modifier.fillMaxWidth()
                 )
             }

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenSections.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenSections.kt
@@ -58,7 +58,8 @@ internal fun BoardSection(
     onTileOperatorSelectionDismissed: () -> Unit,
     onTileOperatorSelectionConfirmed: (Operator) -> Unit,
     interactionPolicy: GameInteractionPolicy = GameInteractionPolicy.AllowAll,
-    highlightState: GameHighlightState = GameHighlightState.None
+    highlightState: GameHighlightState = GameHighlightState.None,
+    correctTileFeedbackIdsByIndex: Map<Int, Long> = emptyMap()
 ) {
     val boardContentDescription = stringResource(R.string.board_content_description)
 
@@ -96,6 +97,7 @@ internal fun BoardSection(
                             PuzzleTile(
                                 tile = tile,
                                 isHighlighted = highlightState.isTileHighlighted(tileIndex),
+                                correctFeedbackId = correctTileFeedbackIdsByIndex[tileIndex],
                                 modifier = Modifier
                                     .testTag(GameScreenTestTags.tile(tileIndex))
                                     .width(tileWidth)

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/semantics/GameHighlightSemantics.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/semantics/GameHighlightSemantics.kt
@@ -16,6 +16,9 @@ var SemanticsPropertyReceiver.operandSelectorUsageHintVisualState by OperandSele
 val StripEntryInputInvalidKey = SemanticsPropertyKey<Boolean>("StripEntryInputInvalid")
 var SemanticsPropertyReceiver.stripEntryInputInvalid by StripEntryInputInvalidKey
 
+val CorrectTileFeedbackIdKey = SemanticsPropertyKey<Long>("CorrectTileFeedbackId")
+var SemanticsPropertyReceiver.correctTileFeedbackId by CorrectTileFeedbackIdKey
+
 object OperandSelectorUsageHintVisualStateValues {
     const val AVAILABLE = "available"
     const val USED_WITH_PAIRING_AVAILABLE = "used_with_pairing_available"
@@ -26,6 +29,14 @@ object OperandSelectorUsageHintVisualStateValues {
 internal fun Modifier.gameHighlightSemantics(isHighlighted: Boolean): Modifier = if (isHighlighted) {
     semantics {
         gameHighlighted = true
+    }
+} else {
+    this
+}
+
+internal fun Modifier.correctTileFeedbackSemantics(feedbackId: Long?): Modifier = if (feedbackId != null) {
+    semantics {
+        correctTileFeedbackId = feedbackId
     }
 } else {
     this

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
@@ -176,6 +176,7 @@ private fun GeneratedPuzzleGameContent(
             isRulesHelperActionDiscoveryDotVisible = isRulesHelperActionDiscoveryDotVisible,
             onRulesHelperActionTapped = onRulesHelperActionTapped,
             onRulesHelperPlayTutorialRequested = onRulesHelperPlayTutorialRequested,
+            isCorrectTileMotionEnabled = true,
             topBarActions = topBarActions,
             onPuzzleChanged = { puzzle ->
                 onPuzzleChanged(session.id, puzzle)


### PR DESCRIPTION
## Related Issue

Resolves #474

## Summary

- Animate only the generated-game tile made correct by a one-shot accepted assignment commit.
- Keep transient feedback out of saved state so recomposition and restoration cannot replay it, while allowing a new response after reset.
- Cover direct targeting, reset behavior, generated-mode opt-in, and generic-route opt-out with Compose tests.
- Validate formatting, unit tests, instrumented-test compilation, UI diff, and lint (0 errors; 8 pre-existing warnings).

## UI Consistency

- Shared components or tokens reused: the existing PuzzleTile component, existing correctness visuals, and Material motion easing.
- Intentional deviations from established visual roles: feature-local 1.04 scale and 90 ms/130 ms durations define the first tile-feedback motion role; graphics-layer scaling leaves layout, touch targets, labels, and final state unchanged.