### PR TITLE
[229] Transition only to safely adopted replacement puzzles

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedReplacementTransitionTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedReplacementTransitionTest.kt
@@ -1,0 +1,220 @@
+package org.cescfe.numpairs.feature.generated
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.CompletableDeferred
+import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
+import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
+import org.cescfe.numpairs.data.preferences.FakePersonalizationPreferencesRepository
+import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
+import org.cescfe.numpairs.data.preferences.PersonalizationPreferences
+import org.cescfe.numpairs.domain.puzzle.assignment.ResolvedOperandAssignment
+import org.cescfe.numpairs.domain.puzzle.assignment.StripEntryId
+import org.cescfe.numpairs.domain.puzzle.construction.resolvedTile
+import org.cescfe.numpairs.domain.puzzle.model.Board
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.Strip
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.cescfe.numpairs.feature.game.ui.screen.GameScreenRobot
+import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
+import org.cescfe.numpairs.feature.menu.ui.MenuScreenTestTags
+import org.cescfe.numpairs.ui.navigation.AppNavigation
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GeneratedReplacementTransitionTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun fourPairsKeepsCompletionUntilTheAdoptedSuccessorTransitionsOnce() {
+        assertSafeReplacementTransition(
+            mode = GeneratedModes.FOUR_PAIRS,
+            menuButtonTag = MenuScreenTestTags.FOUR_PAIRS_BUTTON
+        )
+    }
+
+    @Test
+    fun eightPairsKeepsCompletionUntilTheAdoptedSuccessorTransitionsOnce() {
+        assertSafeReplacementTransition(
+            mode = GeneratedModes.EIGHT_PAIRS,
+            menuButtonTag = MenuScreenTestTags.EIGHT_PAIRS_BUTTON
+        )
+    }
+
+    private fun assertSafeReplacementTransition(mode: GeneratedModeConfiguration, menuButtonTag: String) {
+        val successor = CompletableDeferred<Puzzle>()
+        val puzzleProvider = ControlledReplacementPuzzleProvider(
+            initialPuzzle = oneOperatorAwayFromSolvedReplacementPuzzle(),
+            successor = successor
+        )
+        val useCaseFactory = GeneratedPuzzleGenerationUseCaseFactory { requestedMode ->
+            require(requestedMode == mode)
+            GeneratedPuzzleGenerationUseCase { request ->
+                GeneratedPuzzleGenerationResult.Generated(
+                    request = request,
+                    initialPuzzle = puzzleProvider.nextPuzzle()
+                )
+            }
+        }
+        var recompositionMarker by mutableIntStateOf(0)
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                Box {
+                    AppNavigation(
+                        onboardingRepository = FakeOnboardingRepository(),
+                        generatedSessionRepository = FakeGeneratedSessionRepository(),
+                        personalizationPreferencesRepository = FakePersonalizationPreferencesRepository(
+                            initialPreferences = PersonalizationPreferences(
+                                generatedGameHapticsEnabled = false
+                            )
+                        ),
+                        topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
+                        generatedModeRegistry = GeneratedModes.registry,
+                        generatedPuzzleGenerationUseCaseFactory = useCaseFactory
+                    )
+                    Text(text = recompositionMarker.toString())
+                }
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(menuButtonTag)
+            .performClick()
+        gameRobot()
+            .scrollToBoard()
+            .tapTileOperator(index = 1)
+            .tapOperatorOption(Operator.MULTIPLICATION)
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY_NEW_PUZZLE)
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(GENERATED_PUZZLE_LOADING_TAG)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY_NEW_PUZZLE)
+            .performClick()
+        composeTestRule.runOnIdle {
+            assertEquals(2, puzzleProvider.requestCount)
+        }
+
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.runOnIdle {
+            successor.complete(oneOperatorAwayFromSolvedReplacementPuzzle())
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodesWithTag(GENERATED_PUZZLE_CONTENT_TAG)
+                .fetchSemanticsNodes()
+                .singleOrNull()
+                ?.config
+                ?.contains(GeneratedReplacementTransitionKey) == true
+        }
+
+        composeTestRule
+            .onNodeWithTag(GENERATED_PUZZLE_LOADING_TAG)
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY)
+            .assertDoesNotExist()
+        val transition = composeTestRule
+            .onNodeWithTag(GENERATED_PUZZLE_CONTENT_TAG)
+            .fetchSemanticsNode()
+            .config[GeneratedReplacementTransitionKey]
+        assertNotEquals(transition.predecessorSessionId, transition.successorSessionId)
+
+        composeTestRule.mainClock.advanceTimeBy(500)
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithTag(GENERATED_PUZZLE_CONTENT_TAG)
+            .assert(SemanticsMatcher.keyNotDefined(GeneratedReplacementTransitionKey))
+
+        composeTestRule.runOnIdle {
+            recompositionMarker += 1
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithTag(GENERATED_PUZZLE_CONTENT_TAG)
+            .assert(SemanticsMatcher.keyNotDefined(GeneratedReplacementTransitionKey))
+    }
+
+    private fun gameRobot(): GameScreenRobot = GameScreenRobot(
+        activity = composeTestRule.activity,
+        interactions = composeTestRule
+    )
+}
+
+private class ControlledReplacementPuzzleProvider(
+    private val initialPuzzle: Puzzle,
+    private val successor: CompletableDeferred<Puzzle>
+) {
+    var requestCount = 0
+        private set
+
+    suspend fun nextPuzzle(): Puzzle {
+        requestCount += 1
+
+        return when (requestCount) {
+            1 -> initialPuzzle
+            2 -> successor.await()
+            else -> error("Duplicate replacement request was not deduplicated.")
+        }
+    }
+}
+
+private fun oneOperatorAwayFromSolvedReplacementPuzzle(): Puzzle {
+    val firstOperand = ResolvedOperandAssignment(value = 1, stripEntryId = StripEntryId(0))
+    val secondOperand = ResolvedOperandAssignment(value = 2, stripEntryId = StripEntryId(1))
+    val additionTile = resolvedTile(
+        leftOperand = firstOperand,
+        operator = Operator.ADDITION,
+        rightOperand = secondOperand
+    )
+    val multiplicationTile = resolvedTile(
+        leftOperand = firstOperand,
+        operator = Operator.MULTIPLICATION,
+        rightOperand = secondOperand
+    )
+
+    return Puzzle(
+        board = Board(
+            tiles = listOf(
+                additionTile,
+                multiplicationTile.copy(
+                    expression = multiplicationTile.expression.copy(
+                        operator = Operator.Hidden
+                    )
+                )
+            )
+        ),
+        strip = Strip.fromItems(
+            items = listOf(
+                StripItem.Known(1),
+                StripItem.Known(2)
+            )
+        )
+    )
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
@@ -3,6 +3,9 @@ package org.cescfe.numpairs.feature.generated
 import android.content.Context
 import android.content.ContextWrapper
 import androidx.activity.ComponentActivity
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,11 +20,16 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -65,35 +73,12 @@ fun GeneratedModeRoute(
         onDispose(viewModel::onRouteExited)
     }
 
-    when (val state = uiState) {
-        GeneratedPuzzleGenerationUiState.Idle -> Unit
-        is GeneratedPuzzleGenerationUiState.Restoring -> {
-            GeneratedPuzzleInitialLoadingScreen(modifier = modifier)
-        }
-
-        is GeneratedPuzzleGenerationUiState.Loading -> {
-            state.previousSession?.let { session ->
-                GeneratedPuzzleGameContent(
-                    title = title,
-                    session = session,
-                    modifier = modifier,
-                    isRulesHelperEnabled = isRulesHelperEnabled,
-                    isRulesHelperActionDiscoveryDotVisible = isRulesHelperActionDiscoveryDotVisible,
-                    onRulesHelperActionTapped = onRulesHelperActionTapped,
-                    onRulesHelperPlayTutorialRequested = onRulesHelperPlayTutorialRequested,
-                    topBarActions = topBarActions,
-                    isGeneratedGameHapticsEnabled = isGeneratedGameHapticsEnabled,
-                    onNewPuzzleRequested = viewModel::onNewPuzzleRequested,
-                    onPuzzleChanged = viewModel::onPuzzleChanged,
-                    onNavigateBack = onNavigateBack,
-                    overlay = { GeneratedPuzzleLoadingOverlay() }
-                )
-            } ?: GeneratedPuzzleInitialLoadingScreen(modifier = modifier)
-        }
-
-        is GeneratedPuzzleGenerationUiState.Ready -> GeneratedPuzzleGameContent(
+    val visibleSession = uiState.visibleSession()
+    if (visibleSession != null) {
+        GeneratedPuzzleGameBoundary(
+            state = uiState,
             title = title,
-            session = state.session,
+            session = visibleSession,
             modifier = modifier,
             isRulesHelperEnabled = isRulesHelperEnabled,
             isRulesHelperActionDiscoveryDotVisible = isRulesHelperActionDiscoveryDotVisible,
@@ -103,38 +88,29 @@ fun GeneratedModeRoute(
             isGeneratedGameHapticsEnabled = isGeneratedGameHapticsEnabled,
             onNewPuzzleRequested = viewModel::onNewPuzzleRequested,
             onPuzzleChanged = viewModel::onPuzzleChanged,
+            onReplacementTransitionConsumed = viewModel::onReplacementTransitionConsumed,
+            onRetry = viewModel::retry,
             onNavigateBack = onNavigateBack
         )
+        return
+    }
+
+    when (val state = uiState) {
+        GeneratedPuzzleGenerationUiState.Idle -> Unit
+        is GeneratedPuzzleGenerationUiState.Restoring,
+        is GeneratedPuzzleGenerationUiState.Loading -> {
+            GeneratedPuzzleInitialLoadingScreen(modifier = modifier)
+        }
 
         is GeneratedPuzzleGenerationUiState.Failed -> {
-            state.previousSession?.let { session ->
-                GeneratedPuzzleGameContent(
-                    title = title,
-                    session = session,
-                    modifier = modifier,
-                    isRulesHelperEnabled = isRulesHelperEnabled,
-                    isRulesHelperActionDiscoveryDotVisible = isRulesHelperActionDiscoveryDotVisible,
-                    onRulesHelperActionTapped = onRulesHelperActionTapped,
-                    onRulesHelperPlayTutorialRequested = onRulesHelperPlayTutorialRequested,
-                    topBarActions = topBarActions,
-                    isGeneratedGameHapticsEnabled = isGeneratedGameHapticsEnabled,
-                    onNewPuzzleRequested = viewModel::onNewPuzzleRequested,
-                    onPuzzleChanged = viewModel::onPuzzleChanged,
-                    onNavigateBack = onNavigateBack,
-                    overlay = {
-                        GeneratedPuzzleFailureDialog(
-                            onRetry = viewModel::retry,
-                            onNavigateBack = onNavigateBack
-                        )
-                    }
-                )
-            } ?: GeneratedPuzzleInitialFailureScreen(
+            GeneratedPuzzleInitialFailureScreen(
                 modifier = modifier,
                 onRetry = viewModel::retry,
                 onNavigateBack = onNavigateBack
             )
         }
 
+        is GeneratedPuzzleGenerationUiState.Ready -> Unit
         is GeneratedPuzzleGenerationUiState.ResumeUnavailable -> {
             GeneratedSessionResumeUnavailableScreen(
                 modifier = modifier,
@@ -142,6 +118,114 @@ fun GeneratedModeRoute(
             )
         }
     }
+}
+
+@Composable
+private fun GeneratedPuzzleGameBoundary(
+    state: GeneratedPuzzleGenerationUiState,
+    title: String,
+    session: GeneratedModeGameSession,
+    modifier: Modifier,
+    isRulesHelperEnabled: Boolean,
+    isRulesHelperActionDiscoveryDotVisible: Boolean,
+    onRulesHelperActionTapped: () -> Unit,
+    onRulesHelperPlayTutorialRequested: (() -> Unit)?,
+    topBarActions: @Composable RowScope.() -> Unit,
+    isGeneratedGameHapticsEnabled: Boolean,
+    onNewPuzzleRequested: () -> Unit,
+    onPuzzleChanged: (GeneratedSessionId, Puzzle) -> Unit,
+    onReplacementTransitionConsumed: (GeneratedPuzzleReplacementTransition) -> Unit,
+    onRetry: () -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    val replacementTransition = (state as? GeneratedPuzzleGenerationUiState.Ready)?.replacementTransition
+    val entranceProgress = remember { Animatable(1f) }
+    var presentedSessionId by remember { mutableStateOf(session.id) }
+    var activeReplacementTransition by remember {
+        mutableStateOf<GeneratedPuzzleReplacementTransition?>(null)
+    }
+    val currentSession by rememberUpdatedState(session)
+    val transitionToStart = replacementTransition?.takeIf { transition ->
+        transition.predecessorSessionId == presentedSessionId &&
+            transition.successorSessionId == session.id &&
+            activeReplacementTransition == null
+    }
+    val visibleTransition = activeReplacementTransition ?: transitionToStart
+    val visibleProgress = if (transitionToStart != null && activeReplacementTransition == null) {
+        0f
+    } else {
+        entranceProgress.value
+    }
+
+    LaunchedEffect(replacementTransition, session.id) {
+        replacementTransition ?: return@LaunchedEffect
+        if (transitionToStart != null) {
+            entranceProgress.snapTo(0f)
+            activeReplacementTransition = transitionToStart
+            presentedSessionId = session.id
+        }
+        onReplacementTransitionConsumed(replacementTransition)
+    }
+
+    LaunchedEffect(activeReplacementTransition) {
+        if (activeReplacementTransition != null) {
+            entranceProgress.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(
+                    durationMillis = REPLACEMENT_TRANSITION_DURATION_MILLIS,
+                    easing = FastOutSlowInEasing
+                )
+            )
+            presentedSessionId = currentSession.id
+            activeReplacementTransition = null
+        }
+    }
+
+    LaunchedEffect(session) {
+        if (activeReplacementTransition == null && replacementTransition == null) {
+            presentedSessionId = session.id
+            entranceProgress.snapTo(1f)
+        }
+    }
+
+    GeneratedPuzzleGameContent(
+        title = title,
+        session = session,
+        modifier = modifier
+            .graphicsLayer {
+                val scale = REPLACEMENT_TRANSITION_INITIAL_SCALE +
+                    ((1f - REPLACEMENT_TRANSITION_INITIAL_SCALE) * visibleProgress)
+                scaleX = scale
+                scaleY = scale
+                alpha = REPLACEMENT_TRANSITION_INITIAL_ALPHA +
+                    ((1f - REPLACEMENT_TRANSITION_INITIAL_ALPHA) * visibleProgress)
+            }
+            .testTag(GENERATED_PUZZLE_CONTENT_TAG)
+            .generatedReplacementTransitionSemantics(visibleTransition),
+        isRulesHelperEnabled = isRulesHelperEnabled,
+        isRulesHelperActionDiscoveryDotVisible = isRulesHelperActionDiscoveryDotVisible,
+        onRulesHelperActionTapped = onRulesHelperActionTapped,
+        onRulesHelperPlayTutorialRequested = onRulesHelperPlayTutorialRequested,
+        topBarActions = topBarActions,
+        isGeneratedGameHapticsEnabled = isGeneratedGameHapticsEnabled,
+        onNewPuzzleRequested = onNewPuzzleRequested,
+        onPuzzleChanged = onPuzzleChanged,
+        onNavigateBack = onNavigateBack,
+        overlay = {
+            when (state) {
+                is GeneratedPuzzleGenerationUiState.Loading -> GeneratedPuzzleLoadingOverlay()
+                is GeneratedPuzzleGenerationUiState.Failed -> GeneratedPuzzleFailureDialog(
+                    onRetry = onRetry,
+                    onNavigateBack = onNavigateBack
+                )
+
+                GeneratedPuzzleGenerationUiState.Idle,
+                is GeneratedPuzzleGenerationUiState.Restoring,
+                is GeneratedPuzzleGenerationUiState.Ready,
+                is GeneratedPuzzleGenerationUiState.ResumeUnavailable -> Unit
+            }
+        }
+    )
 }
 
 @Composable
@@ -191,6 +275,15 @@ private fun GeneratedPuzzleGameContent(
         )
         overlay()
     }
+}
+
+private fun GeneratedPuzzleGenerationUiState.visibleSession(): GeneratedModeGameSession? = when (this) {
+    is GeneratedPuzzleGenerationUiState.Ready -> session
+    is GeneratedPuzzleGenerationUiState.Loading -> previousSession
+    is GeneratedPuzzleGenerationUiState.Failed -> previousSession
+    GeneratedPuzzleGenerationUiState.Idle,
+    is GeneratedPuzzleGenerationUiState.Restoring,
+    is GeneratedPuzzleGenerationUiState.ResumeUnavailable -> null
 }
 
 @Composable
@@ -385,3 +478,7 @@ private tailrec fun Context.findComponentActivity(): ComponentActivity? = when (
 internal const val GENERATED_PUZZLE_LOADING_TAG = "generatedPuzzleLoading"
 internal const val GENERATED_PUZZLE_FAILURE_TAG = "generatedPuzzleFailure"
 internal const val GENERATED_SESSION_RESUME_UNAVAILABLE_TAG = "generatedSessionResumeUnavailable"
+internal const val GENERATED_PUZZLE_CONTENT_TAG = "generatedPuzzleContent"
+internal const val REPLACEMENT_TRANSITION_INITIAL_ALPHA = 0.82f
+internal const val REPLACEMENT_TRANSITION_INITIAL_SCALE = 0.985f
+internal const val REPLACEMENT_TRANSITION_DURATION_MILLIS = 260

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModel.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModel.kt
@@ -48,7 +48,16 @@ internal sealed interface GeneratedPuzzleGenerationUiState {
     data class Loading(val request: GeneratedPuzzleGenerationRequest, val previousSession: GeneratedModeGameSession?) :
         GeneratedPuzzleGenerationUiState
 
-    data class Ready(val session: GeneratedModeGameSession) : GeneratedPuzzleGenerationUiState
+    data class Ready(
+        val session: GeneratedModeGameSession,
+        val replacementTransition: GeneratedPuzzleReplacementTransition? = null
+    ) : GeneratedPuzzleGenerationUiState {
+        init {
+            require(replacementTransition == null || replacementTransition.successorSessionId == session.id) {
+                "A replacement transition must target the ready session."
+            }
+        }
+    }
 
     data class Failed(
         val request: GeneratedPuzzleGenerationRequest,
@@ -139,6 +148,16 @@ internal class GeneratedPuzzleViewModel(
             request = nextRequest(),
             previousSession = state.session
         )
+    }
+
+    fun onReplacementTransitionConsumed(transition: GeneratedPuzzleReplacementTransition) {
+        val state = _uiState.value as? GeneratedPuzzleGenerationUiState.Ready ?: return
+        if (
+            state.session.id == transition.successorSessionId &&
+            state.replacementTransition == transition
+        ) {
+            _uiState.value = state.copy(replacementTransition = null)
+        }
     }
 
     fun onPuzzleChanged(expectedSessionId: GeneratedSessionId, puzzle: Puzzle) {
@@ -294,11 +313,18 @@ internal class GeneratedPuzzleViewModel(
 
         return try {
             generatedSessionRepository.replace(snapshot)
+            val session = GeneratedModeGameSession(
+                snapshot = snapshot,
+                request = outcome.request
+            )
             GeneratedPuzzleGenerationUiState.Ready(
-                session = GeneratedModeGameSession(
-                    snapshot = snapshot,
-                    request = outcome.request
-                )
+                session = session,
+                replacementTransition = previousSession?.let { predecessor ->
+                    GeneratedPuzzleReplacementTransition(
+                        predecessorSessionId = predecessor.id,
+                        successorSessionId = session.id
+                    )
+                }
             )
         } catch (_: IOException) {
             GeneratedPuzzleGenerationUiState.Failed(
@@ -313,6 +339,17 @@ internal class GeneratedPuzzleViewModel(
         profile = mode.profile,
         seed = seedSource.nextSeed()
     )
+}
+
+internal data class GeneratedPuzzleReplacementTransition(
+    val predecessorSessionId: GeneratedSessionId,
+    val successorSessionId: GeneratedSessionId
+) {
+    init {
+        require(predecessorSessionId != successorSessionId) {
+            "A replacement transition requires distinct predecessor and successor sessions."
+        }
+    }
 }
 
 internal data class GeneratedModeGameSession(

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedReplacementTransitionSemantics.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedReplacementTransitionSemantics.kt
@@ -1,0 +1,20 @@
+package org.cescfe.numpairs.feature.generated
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.semantics
+
+internal val GeneratedReplacementTransitionKey =
+    SemanticsPropertyKey<GeneratedPuzzleReplacementTransition>("GeneratedReplacementTransition")
+internal var SemanticsPropertyReceiver.generatedReplacementTransition by GeneratedReplacementTransitionKey
+
+internal fun Modifier.generatedReplacementTransitionSemantics(
+    transition: GeneratedPuzzleReplacementTransition?
+): Modifier = if (transition != null) {
+    semantics {
+        generatedReplacementTransition = transition
+    }
+} else {
+    this
+}

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModelTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModelTest.kt
@@ -24,6 +24,7 @@ import org.cescfe.numpairs.feature.game.presentation.support.solvedPuzzleWithKno
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -73,6 +74,7 @@ class GeneratedPuzzleViewModelTest {
         val ready = viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready
         assertEquals(attemptedSnapshot, repository.session.value)
         assertEquals(attemptedSnapshot, ready.session.snapshot)
+        assertNull(ready.replacementTransition)
     }
 
     @Test
@@ -121,6 +123,87 @@ class GeneratedPuzzleViewModelTest {
         assertEquals(listOf(11, 22, 33), useCase.requests.map(GeneratedPuzzleGenerationRequest::seed))
         assertEquals(2, repository.replaceAttempts.size)
         assertEquals(ready.session.snapshot, repository.session.value)
+        assertEquals(
+            GeneratedPuzzleReplacementTransition(
+                predecessorSessionId = initialSession.id,
+                successorSessionId = ready.session.id
+            ),
+            ready.replacementTransition
+        )
+        viewModel.onReplacementTransitionConsumed(requireNotNull(ready.replacementTransition))
+        assertNull(
+            (viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready).replacementTransition
+        )
+    }
+
+    @Test
+    fun replacement_readiness_and_transition_metadata_wait_for_successful_adoption() {
+        val replacementWriteGate = CompletableDeferred<Unit>()
+        val repository = RecordingGeneratedSessionRepository()
+        val viewModel = GeneratedPuzzleViewModel(
+            mode = GeneratedModes.FOUR_PAIRS,
+            generationUseCase = QueueGeneratedPuzzleUseCase(
+                CompletableDeferred(samplePuzzle),
+                CompletableDeferred(samplePuzzle)
+            ),
+            generatedSessionRepository = repository,
+            seedSource = QueueGeneratedPuzzleSeedSource(101, 202),
+            sessionIdSource = QueueGeneratedSessionIdSource("previous", "successor")
+        )
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.advanceUntilIdle()
+        val previousSession = (viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready).session
+        repository.nextReplaceGate = replacementWriteGate
+
+        viewModel.onNewPuzzleRequested()
+        dispatcher.scheduler.runCurrent()
+
+        val loading = viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Loading
+        assertEquals(previousSession, loading.previousSession)
+        assertEquals(previousSession.snapshot, repository.session.value)
+        assertEquals(GeneratedSessionId("successor"), repository.replaceAttempts.last().sessionId)
+
+        replacementWriteGate.complete(Unit)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val ready = viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready
+        assertEquals(GeneratedSessionId("successor"), ready.session.id)
+        assertEquals(ready.session.snapshot, repository.session.value)
+        assertEquals(
+            GeneratedPuzzleReplacementTransition(
+                predecessorSessionId = previousSession.id,
+                successorSessionId = ready.session.id
+            ),
+            ready.replacementTransition
+        )
+    }
+
+    @Test
+    fun replacement_transition_requires_distinct_ids_and_the_ready_successor() {
+        val readySnapshot = generatedSessionSnapshot(sessionId = "ready")
+        val readySession = GeneratedModeGameSession(
+            snapshot = readySnapshot,
+            request = GeneratedPuzzleGenerationRequest(
+                profile = GeneratedModes.FOUR_PAIRS.profile,
+                seed = readySnapshot.seed
+            )
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedPuzzleReplacementTransition(
+                predecessorSessionId = readySession.id,
+                successorSessionId = readySession.id
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedPuzzleGenerationUiState.Ready(
+                session = readySession,
+                replacementTransition = GeneratedPuzzleReplacementTransition(
+                    predecessorSessionId = GeneratedSessionId("previous"),
+                    successorSessionId = GeneratedSessionId("different-successor")
+                )
+            )
+        }
     }
 
     @Test
@@ -202,6 +285,7 @@ class GeneratedPuzzleViewModelTest {
         assertEquals(snapshot.profileId, ready.session.request.profileId.value)
         assertEquals(0, generationUseCase.requestCount)
         assertTrue(repository.replaceAttempts.isEmpty())
+        assertNull(ready.replacementTransition)
     }
 
     @Test
@@ -347,6 +431,13 @@ class GeneratedPuzzleViewModelTest {
 
         assertEquals(GeneratedSessionId("replacement"), replacementSession.id)
         assertEquals(replacementSession.snapshot, repository.session.value)
+        assertEquals(
+            GeneratedPuzzleReplacementTransition(
+                predecessorSessionId = previousSession.id,
+                successorSessionId = replacementSession.id
+            ),
+            (viewModel.uiState.value as GeneratedPuzzleGenerationUiState.Ready).replacementTransition
+        )
         assertTrue(repository.updateAttempts.isEmpty())
         assertTrue(repository.clearAttempts.isEmpty())
     }
@@ -464,7 +555,7 @@ private class QueueGeneratedSessionIdSource(vararg ids: String) : GeneratedSessi
 
 private class RecordingGeneratedSessionRepository(
     initialSession: GeneratedSessionSnapshot? = null,
-    private val writeGate: CompletableDeferred<Unit>? = null,
+    writeGate: CompletableDeferred<Unit>? = null,
     private val replaceFailure: IOException? = null,
     firstUpdateGate: CompletableDeferred<Unit>? = null
 ) : GeneratedSessionRepository {
@@ -474,10 +565,14 @@ private class RecordingGeneratedSessionRepository(
     val replaceAttempts = mutableListOf<GeneratedSessionSnapshot>()
     val updateAttempts = mutableListOf<Puzzle>()
     val clearAttempts = mutableListOf<GeneratedSessionId>()
+    var nextReplaceGate: CompletableDeferred<Unit>? = writeGate
 
     override suspend fun replace(snapshot: GeneratedSessionSnapshot) {
         replaceAttempts += snapshot
-        writeGate?.await()
+        nextReplaceGate?.let { gate ->
+            nextReplaceGate = null
+            gate.await()
+        }
         replaceFailure?.let { failure ->
             throw failure
         }


### PR DESCRIPTION
## Related Issue

Resolves #478

## Summary

- Publish identity-checked replacement metadata only after the generated successor is successfully adopted and stored.
- Keep the current game and completion surface mounted through generation, persistence, failure, and retry.
- Consume the transient event while a brief generated-content entrance runs, preventing replay after recomposition or composition recreation.
- Preserve request deduplication, cancellation, stale-session guards, initial generation, and resume behavior.
- Cover readiness timing, identity invariants, failure/retry, cancellation, stale callbacks, duplicate UI requests, and one-shot playback in 4 Pairs and 8 Pairs.
- Validate formatting, unit tests, instrumented-test compilation, UI diff, and stage lint (0 errors; 8 pre-existing warnings).

## UI Consistency

- Shared components or tokens reused: the existing generated game tree, completion surface, loading/failure UI, theme colors, geometry, and interactions remain unchanged.
- Intentional deviations from established visual roles: feature-local replacement motion enters adopted content from 82% alpha and 98.5% scale over 260 ms; one graphics layer preserves layout, touch targets, semantics, and the final state.