### PR TITLE
[230] Add v9 cross-theme previews and regression coverage

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/PersonalizationThemeProviderTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/PersonalizationThemeProviderTest.kt
@@ -20,11 +20,18 @@ class PersonalizationThemeProviderTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun changingPreferenceUpdatesThemeWithoutForgettingChildState() {
+    fun everyPreferenceThemeUpdatesColorsWithoutForgettingChildState() {
         val repository = FakePersonalizationPreferencesRepository()
         var firstRememberedValue: Any? = null
         var latestRememberedValue: Any? = null
         var latestPrimary = Color.Unspecified
+        val expectedPrimaryByTheme = linkedMapOf(
+            PersonalizationTheme.WARM to Color(0xFF9CBD7B),
+            PersonalizationTheme.FROST to Color(0xFF215EA8),
+            PersonalizationTheme.OBSIDIAN to Color(0xFFD7A66A),
+            PersonalizationTheme.TERMINAL to Color(0xFF65D46E),
+            PersonalizationTheme.EMBER to Color(0xFFA33A00)
+        )
 
         composeTestRule.setContent {
             PersonalizationThemeProvider(repository) {
@@ -38,16 +45,14 @@ class PersonalizationThemeProviderTest {
             }
         }
 
-        composeTestRule.runOnIdle {
-            assertEquals(Color(0xFF9CBD7B), latestPrimary)
-            repository.state.value = PersonalizationPreferences(
-                selectedTheme = PersonalizationTheme.FROST
-            )
-        }
-
-        composeTestRule.runOnIdle {
-            assertEquals(Color(0xFF215EA8), latestPrimary)
-            assertSame(firstRememberedValue, latestRememberedValue)
+        expectedPrimaryByTheme.forEach { (theme, expectedPrimary) ->
+            composeTestRule.runOnIdle {
+                repository.state.value = PersonalizationPreferences(selectedTheme = theme)
+            }
+            composeTestRule.runOnIdle {
+                assertEquals(expectedPrimary, latestPrimary)
+                assertSame(firstRememberedValue, latestRememberedValue)
+            }
         }
     }
 

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/CorrectTileMotionTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/CorrectTileMotionTest.kt
@@ -91,7 +91,20 @@ class CorrectTileMotionTest {
     }
 
     @Test
-    fun generatedRouteEnablesCorrectTileMotion() {
+    fun fourPairsRouteEnablesCorrectTileMotion() {
+        assertGeneratedRouteEnablesCorrectTileMotion(
+            menuButtonTag = MenuScreenTestTags.FOUR_PAIRS_BUTTON
+        )
+    }
+
+    @Test
+    fun eightPairsRouteEnablesCorrectTileMotion() {
+        assertGeneratedRouteEnablesCorrectTileMotion(
+            menuButtonTag = MenuScreenTestTags.EIGHT_PAIRS_BUTTON
+        )
+    }
+
+    private fun assertGeneratedRouteEnablesCorrectTileMotion(menuButtonTag: String) {
         composeTestRule.setContent {
             NumPairsTheme {
                 AppNavigation(
@@ -117,7 +130,7 @@ class CorrectTileMotionTest {
         }
 
         composeTestRule
-            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
+            .onNodeWithTag(menuButtonTag)
             .performClick()
         gameRobot()
             .scrollToBoard()

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedCompletionCelebrationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedCompletionCelebrationTest.kt
@@ -109,7 +109,20 @@ class GeneratedCompletionCelebrationTest {
     }
 
     @Test
-    fun generatedModeOptsInToCompletionCelebration() {
+    fun fourPairsOptsInToCompletionCelebration() {
+        assertGeneratedModeOptsInToCompletionCelebration(
+            menuButtonTag = MenuScreenTestTags.FOUR_PAIRS_BUTTON
+        )
+    }
+
+    @Test
+    fun eightPairsOptsInToCompletionCelebration() {
+        assertGeneratedModeOptsInToCompletionCelebration(
+            menuButtonTag = MenuScreenTestTags.EIGHT_PAIRS_BUTTON
+        )
+    }
+
+    private fun assertGeneratedModeOptsInToCompletionCelebration(menuButtonTag: String) {
         composeTestRule.setContent {
             NumPairsTheme {
                 AppNavigation(
@@ -135,7 +148,7 @@ class GeneratedCompletionCelebrationTest {
         }
 
         composeTestRule
-            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
+            .onNodeWithTag(menuButtonTag)
             .performClick()
         gameRobot()
             .scrollToBoard()

--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/PersonalizationNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/PersonalizationNavigationTest.kt
@@ -81,19 +81,25 @@ class PersonalizationNavigationTest {
         composeTestRule
             .onNodeWithTag(PersonalizationScreenTestTags.SCREEN)
             .assertIsDisplayed()
-        composeTestRule
-            .onNodeWithTag(PersonalizationScreenTestTags.themeOption(PersonalizationTheme.FROST))
-            .performScrollTo()
-            .performClick()
+        PersonalizationTheme.entries.forEach { theme ->
+            composeTestRule
+                .onNodeWithTag(PersonalizationScreenTestTags.themeOption(theme))
+                .performScrollTo()
+                .performClick()
+            composeTestRule.runOnIdle {
+                assertEquals(theme, personalizationRepository.state.value.selectedTheme)
+                assertEquals(snapshot, generatedSessionRepository.session.value)
+            }
+        }
         composeTestRule
             .onNodeWithTag(PersonalizationScreenTestTags.HAPTICS_TOGGLE)
             .performScrollTo()
             .performClick()
 
         composeTestRule.runOnIdle {
-            assertEquals(PersonalizationTheme.FROST, personalizationRepository.state.value.selectedTheme)
+            assertEquals(PersonalizationTheme.EMBER, personalizationRepository.state.value.selectedTheme)
             assertEquals(false, personalizationRepository.state.value.generatedGameHapticsEnabled)
-            assertEquals(Color(0xFF215EA8), latestPrimary)
+            assertEquals(Color(0xFFA33A00), latestPrimary)
             assertEquals(snapshot, generatedSessionRepository.session.value)
         }
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreen.kt
@@ -27,7 +27,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.preferences.PersonalizationTheme
 import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
 import org.cescfe.numpairs.domain.puzzle.model.OperandSlot
 import org.cescfe.numpairs.domain.puzzle.model.Operator
@@ -45,6 +47,7 @@ import org.cescfe.numpairs.feature.game.ui.actions.RulesHelperAction
 import org.cescfe.numpairs.feature.game.ui.help.RulesHelperDialog
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.cescfe.numpairs.ui.theme.NumPairsThemePreviewParameterProvider
 
 @Composable
 fun GameScreen(
@@ -283,8 +286,10 @@ private fun GameScreenTopBar(
 
 @Preview(showBackground = true)
 @Composable
-private fun GameScreenPreview() {
-    NumPairsTheme {
+private fun GameScreenPreview(
+    @PreviewParameter(NumPairsThemePreviewParameterProvider::class) theme: PersonalizationTheme
+) {
+    NumPairsTheme(theme = theme) {
         GameScreen(
             title = stringResource(R.string.tutorial_screen_title),
             uiState = GameUiState.from(samplePuzzle)
@@ -294,8 +299,10 @@ private fun GameScreenPreview() {
 
 @Preview(showBackground = true)
 @Composable
-private fun GameScreenWithTopBarActionPreview() {
-    NumPairsTheme {
+private fun GameScreenWithTopBarActionPreview(
+    @PreviewParameter(NumPairsThemePreviewParameterProvider::class) theme: PersonalizationTheme
+) {
+    NumPairsTheme(theme = theme) {
         GameScreen(
             title = stringResource(R.string.tutorial_screen_title),
             uiState = GameUiState.from(samplePuzzle),

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreen.kt
@@ -28,11 +28,14 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.preferences.PersonalizationTheme
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.cescfe.numpairs.ui.theme.NumPairsThemePreviewParameterProvider
 
 @Composable
 fun MenuScreen(
@@ -171,8 +174,10 @@ private fun MenuButtonText(text: String) {
 
 @Preview(showBackground = true)
 @Composable
-private fun MenuScreenPreview() {
-    NumPairsTheme {
+private fun MenuScreenPreview(
+    @PreviewParameter(NumPairsThemePreviewParameterProvider::class) theme: PersonalizationTheme
+) {
+    NumPairsTheme(theme = theme) {
         MenuScreen()
     }
 }

--- a/app/src/main/java/org/cescfe/numpairs/feature/personalization/ui/PersonalizationScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/personalization/ui/PersonalizationScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import org.cescfe.numpairs.R
 import org.cescfe.numpairs.data.preferences.PersonalizationPreferences
@@ -46,6 +47,7 @@ import org.cescfe.numpairs.data.preferences.PersonalizationTheme
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
 import org.cescfe.numpairs.ui.theme.NumPairsThemePreviewColors
+import org.cescfe.numpairs.ui.theme.NumPairsThemePreviewParameterProvider
 import org.cescfe.numpairs.ui.theme.numPairsSemanticColors
 import org.cescfe.numpairs.ui.theme.previewColors
 
@@ -315,10 +317,12 @@ private fun PersonalizationTheme.localizedName(): String = stringResource(
 
 @Preview(showBackground = true)
 @Composable
-private fun PersonalizationScreenPreview() {
-    NumPairsTheme {
+private fun PersonalizationScreenPreview(
+    @PreviewParameter(NumPairsThemePreviewParameterProvider::class) theme: PersonalizationTheme
+) {
+    NumPairsTheme(theme = theme) {
         PersonalizationScreen(
-            preferences = PersonalizationPreferences(),
+            preferences = PersonalizationPreferences(selectedTheme = theme),
             onThemeSelected = {},
             onGeneratedGameHapticsEnabledChanged = {},
             onNavigateBack = {}

--- a/app/src/main/java/org/cescfe/numpairs/ui/theme/NumPairsThemePreviewParameterProvider.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/theme/NumPairsThemePreviewParameterProvider.kt
@@ -1,0 +1,9 @@
+package org.cescfe.numpairs.ui.theme
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import org.cescfe.numpairs.data.preferences.PersonalizationTheme
+
+internal class NumPairsThemePreviewParameterProvider : PreviewParameterProvider<PersonalizationTheme> {
+    override val values: Sequence<PersonalizationTheme>
+        get() = PersonalizationTheme.entries.asSequence()
+}

--- a/app/src/test/java/org/cescfe/numpairs/ui/theme/NumPairsThemePreviewParameterProviderTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/ui/theme/NumPairsThemePreviewParameterProviderTest.kt
@@ -1,0 +1,15 @@
+package org.cescfe.numpairs.ui.theme
+
+import org.cescfe.numpairs.data.preferences.PersonalizationTheme
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NumPairsThemePreviewParameterProviderTest {
+    @Test
+    fun `preview parameters contain every personalization theme exactly once`() {
+        val themes = NumPairsThemePreviewParameterProvider().values.toList()
+
+        assertEquals(PersonalizationTheme.entries, themes)
+        assertEquals(themes.size, themes.distinct().size)
+    }
+}


### PR DESCRIPTION
## Related Issue

Resolves #481

## Summary

- Drive Menu, Game, and Personalization previews from one exhaustive five-theme parameter provider.
- Verify every root theme applies without replacing remembered child state.
- Exercise every Personalization theme while proving the generated-session snapshot remains unchanged.
- Add explicit correct-tile and completion-celebration parity coverage for both 4 Pairs and 8 Pairs.
- Preserve existing generic/Tutorial opt-out and onboarding coverage without changing runtime behavior.
- Validate formatting, unit tests, instrumented-test compilation, and UI diff.

## UI Consistency

- Shared components or tokens reused: previews render the existing MenuScreen, GameScreen, PersonalizationScreen, NumPairsTheme definitions, typography, shapes, spacing, elevation, and semantic states unchanged.
- Intentional deviations from established visual roles: none; this PR changes preview inputs and regression coverage only.