### PR TITLE
[233] Document automatic Project intake workflow

### DIFF
--- a/docs/technical/delivery-workflow.md
+++ b/docs/technical/delivery-workflow.md
@@ -33,21 +33,9 @@ Unless the task specifies otherwise, use:
 - GitHub Project: `https://github.com/orgs/CescFe/projects/11`
 - Project field `Size`: `xs`
 
-Project 11 automates new issue intake: `Auto-add to project` adds every issue created in
-`CescFe/numpairs`, and `Item added to project` initializes its Project `Status` to `Backlog`.
-Do not add newly created repository issues to Project 11 manually. Wait for and verify both
-automation results before assigning the iteration and remaining Project fields or changing
-the Project `Status`.
-
 Use the iteration and milestone specified for the current delivery batch. Do not attach new work to a closed milestone unless the user explicitly requests it.
 
-Project `Priority` is contextual and ranges from `P0` to `P3`. Unless the user specifies a value, inspect the most recently worked issue and reuse its Project `Priority`. Do not treat `P2` or any other priority as a permanent default. If there is no previous issue from which to inherit priority, ask for it.
-
-After automated intake, keep or change Project `Status` according to how the issue enters the workflow:
-
-- Keep `Backlog` when a user is requesting future work and is not starting implementation.
-- `Ready For Dev` when an authorized planning task creates an atomic, refined issue that is ready to be implemented.
-- `In Progress` immediately before implementation begins on an existing issue.
+Project `Priority` is contextual and ranges from `P0` to `P3`. Unless the user specifies a value, inspect the most recently worked issue and reuse its Project `Priority`. If there is no previous issue from which to inherit priority, ask for it.
 
 Resolve GitHub node IDs, field IDs, option IDs, and iteration IDs through the GitHub API. Treat these identifiers as opaque and do not store previously observed values as permanent repository configuration.
 
@@ -63,6 +51,7 @@ For milestone delivery:
 6. Apply the required assignee, label, type, issue fields, and milestone.
 7. Wait for and verify automatic Project 11 intake and `Backlog` initialization, then apply the remaining Project fields and iteration.
 8. Set Project `Status` to `Ready For Dev` for each planned issue.
+9. Set Project `Status` to `In Progress` immediately before implementation begins on an existing issue.
 
 Do not combine unrelated product behavior, refactors, or documentation in one issue merely to reduce the number of Pull Requests.
 

--- a/docs/technical/delivery-workflow.md
+++ b/docs/technical/delivery-workflow.md
@@ -33,13 +33,19 @@ Unless the task specifies otherwise, use:
 - GitHub Project: `https://github.com/orgs/CescFe/projects/11`
 - Project field `Size`: `xs`
 
+Project 11 automates new issue intake: `Auto-add to project` adds every issue created in
+`CescFe/numpairs`, and `Item added to project` initializes its Project `Status` to `Backlog`.
+Do not add newly created repository issues to Project 11 manually. Wait for and verify both
+automation results before assigning the iteration and remaining Project fields or changing
+the Project `Status`.
+
 Use the iteration and milestone specified for the current delivery batch. Do not attach new work to a closed milestone unless the user explicitly requests it.
 
 Project `Priority` is contextual and ranges from `P0` to `P3`. Unless the user specifies a value, inspect the most recently worked issue and reuse its Project `Priority`. Do not treat `P2` or any other priority as a permanent default. If there is no previous issue from which to inherit priority, ask for it.
 
-Set Project `Status` according to how the issue enters the workflow:
+After automated intake, keep or change Project `Status` according to how the issue enters the workflow:
 
-- `Backlog` when a user is requesting future work and is not starting implementation.
+- Keep `Backlog` when a user is requesting future work and is not starting implementation.
 - `Ready For Dev` when an authorized planning task creates an atomic, refined issue that is ready to be implemented.
 - `In Progress` immediately before implementation begins on an existing issue.
 
@@ -54,8 +60,9 @@ For milestone delivery:
 3. Divide the remaining scope into independently reviewable, dependency-ordered issues.
 4. Give each issue one observable outcome and one Pull Request.
 5. Write each issue in English using the selected issue template.
-6. Apply the required assignee, label, type, issue fields, Project fields, iteration, and milestone.
-7. Set Project `Status` to `Ready For Dev` for each planned issue.
+6. Apply the required assignee, label, type, issue fields, and milestone.
+7. Wait for and verify automatic Project 11 intake and `Backlog` initialization, then apply the remaining Project fields and iteration.
+8. Set Project `Status` to `Ready For Dev` for each planned issue.
 
 Do not combine unrelated product behavior, refactors, or documentation in one issue merely to reduce the number of Pull Requests.
 

--- a/docs/technical/delivery-workflow.md
+++ b/docs/technical/delivery-workflow.md
@@ -45,7 +45,7 @@ For milestone delivery:
 3. Divide the remaining scope into independently reviewable, dependency-ordered issues.
 4. Give each issue one observable outcome and one Pull Request.
 5. Write each issue in English using the selected issue template.
-6. Apply the required assignee, label, type, issue fields, and milestone.
+6. Apply the required assignee, label, type, and milestone.
 7. Wait for and verify automatic Project 11 intake and `Backlog` initialization, then apply the remaining Project fields and iteration.
 8. Set Project `Status` to `Ready For Dev` for each planned issue.
 9. Set Project `Status` to `In Progress` immediately before implementation begins on an existing issue.

--- a/docs/technical/delivery-workflow.md
+++ b/docs/technical/delivery-workflow.md
@@ -28,16 +28,13 @@ Unless the task specifies otherwise, use:
 - assignee: `FrancescFe`
 - label for feature work: `feat`
 - issue type: `Task`
-- issue field `Priority`: `Medium`
-- issue field `Effort`: `Low`
 - GitHub Project: `https://github.com/orgs/CescFe/projects/11`
 - Project field `Size`: `xs`
+- Project field `Priority`: is contextual and ranges from `P0` to `P3`. Reuse it by inspecting the most recently worked issue.
+- Project field `Iteration`: is contextual. Reuse it by inspecting the most recently worked issue.
+- Milestone: is contextual. Use the specified for the current delivery batch.
 
-Use the iteration and milestone specified for the current delivery batch. Do not attach new work to a closed milestone unless the user explicitly requests it.
-
-Project `Priority` is contextual and ranges from `P0` to `P3`. Unless the user specifies a value, inspect the most recently worked issue and reuse its Project `Priority`. If there is no previous issue from which to inherit priority, ask for it.
-
-Resolve GitHub node IDs, field IDs, option IDs, and iteration IDs through the GitHub API. Treat these identifiers as opaque and do not store previously observed values as permanent repository configuration.
+Resolve GitHub node IDs, option IDs, and iteration IDs through the GitHub API. Treat these identifiers as opaque and do not store previously observed values as permanent repository configuration.
 
 ## Atomic Issue Planning
 


### PR DESCRIPTION
## Related Issue

Resolves #487

## Summary

- Document automatic addition of new NumPairs issues to Project 11 and automatic Backlog initialization.
- Require verification of automated intake before assigning the iteration and remaining Project fields.
- Preserve the explicit Ready For Dev and In Progress transitions without manual project addition.