### PR TITLE
[235] Clarify end-to-end delivery merge authorization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,8 @@ Follow the selected template and replace its prompts with task-specific content.
 - Keep each implementation limited to one atomic issue, one branch, and one Pull Request.
 - Preserve unrelated and user-authored work already present in the worktree.
 - Verify the associated issue's acceptance criteria and mark only fulfilled criteria complete before merge.
-- Do not merge without explicit authorization or while a required check is not successful.
+- Treat a user request to complete an issue, delivery batch, or milestone end to end as merge authorization for every in-scope Pull Request; no per-PR confirmation is required.
+- Outside that authorized scope, or when the user requests review, Pull Request creation, or no merge, do not merge. Never merge while a required check is not successful.
 - Compile instrumented tests when required, but do not start an emulator or run connected-device tasks.
 - Resolve current GitHub Project field and option identifiers dynamically; do not treat opaque IDs as permanent configuration.
 - Do not introduce an architectural pattern, dependency, or refactor solely to satisfy a generic best practice.

--- a/docs/technical/delivery-workflow.md
+++ b/docs/technical/delivery-workflow.md
@@ -118,13 +118,23 @@ Pull Request title format:
 [{reference}] {Relevant sentence-case message}
 ```
 
-When a merge is authorized, use squash and merge with this squash commit title:
+A user request to complete an issue, delivery batch, or milestone end to end authorizes every
+in-scope merge in that delivery cycle. No additional per-Pull-Request merge confirmation is
+required. This authorization remains limited to the requested delivery scope and does not extend
+to unrelated future work.
+
+A request limited to implementation, Pull Request creation, or review does not authorize merge.
+An explicit review-first or no-merge instruction overrides a broader workflow request.
+
+For every authorized merge, use squash and merge with this squash commit title:
 
 ```text
 [{reference}] {Relevant sentence-case message}
 ```
 
-Do not merge while a required check is pending, unexpectedly skipped, cancelled, or failing. Merge only when the user requested an end-to-end merge cycle. If the user asks to review the Pull Request first or explicitly says not to merge, stop after creating and reporting the Pull Request.
+Do not merge while a required check is pending, unexpectedly skipped, cancelled, or failing. If
+the delivery is not authorized end to end, or the user asks to review the Pull Request first or
+explicitly says not to merge, stop after creating and reporting the Pull Request.
 
 Before any authorized merge:
 
@@ -150,7 +160,7 @@ For each authorized issue:
 9. Open and configure the Pull Request.
 10. Wait for required GitHub checks when a merge is part of the requested cycle.
 11. Review the associated issue's acceptance criteria and mark only fulfilled criteria complete.
-12. If checks pass, every required criterion is fulfilled, and merge is authorized, squash and merge with the required title.
+12. If checks pass, every required criterion is fulfilled, and the delivery scope authorizes merging, squash and merge with the required title without requesting per-Pull-Request confirmation.
 13. Update local `main` before starting the next issue.
 
 Do not start dependent implementation from an unmerged branch when the requested workflow requires sequential integration into `main`.


### PR DESCRIPTION
## Related Issue

Resolves #501

## Summary

- Treat an end-to-end issue, delivery batch, or milestone request as merge authorization for every in-scope Pull Request.
- Remove per-Pull-Request confirmation from an already authorized delivery cycle.
- Preserve acceptance-criteria, required-check, review-first, and no-merge safeguards.