### PR TITLE
[236] Document the generated challenge domain and difficulty profiles

### DIFF
--- a/docs/product/prd/prd-v8.md
+++ b/docs/product/prd/prd-v8.md
@@ -270,7 +270,9 @@ selection, and session documentation is delivered.
 - Keep generation deterministic for tests and bounded on failure.
 - Protect the documented profile and population-variety expectations with automated tests.
 
-The supporting generation reference owns the exact profile constraints and assessment thresholds.
+The supporting generation reference owns the exact profile constraints and assessment acceptance
+semantics. Numerical assessment bands may be locked only after deterministic baseline
+characterization; v8 must not invent unevidenced score thresholds before the evaluator exists.
 
 ### `8 Pairs Hard`
 
@@ -283,7 +285,9 @@ The supporting generation reference owns the exact profile constraints and asses
   supported envelope.
 - Keep generation deterministic for tests and bounded on failure at sixteen-entry scale.
 
-The supporting generation reference owns the exact profile constraints and assessment thresholds.
+The supporting generation reference owns the exact profile constraints and assessment acceptance
+semantics. Numerical assessment bands may be locked only after deterministic baseline
+characterization; v8 must not invent unevidenced score thresholds before the evaluator exists.
 
 ### Persistent Mode Defaults
 

--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -4,10 +4,13 @@
 
 - Status: product reference for generated puzzle construction
 - Implemented profiles: generated `4 Pairs Low` and `8 Pairs Medium`
+- v8 target profiles: generated `4 Pairs Medium` and `8 Pairs Hard`
 - Related references:
   - `docs/product/prd/prd-v5.md`
   - `docs/product/prd/prd-v7.md`
+  - `docs/product/prd/prd-v8.md`
   - `docs/technical/generated-session-persistence.md`
+  - `docs/technical/adr/adr-005-model-sparse-generated-challenges.md`
   - `docs/game-rules.md`
   - `docs/ubiquitous-language.md`
 
@@ -35,9 +38,27 @@ The solved puzzle is the generator's source of truth. The initial puzzle is the 
 
 ---
 
-## Difficulty Profiles
+## Generated Challenges And Difficulty Profiles
 
-Generated puzzle profiles define size, value constraints, result constraints, masking, and validation expectations for each generated mode.
+A generated mode is the stable puzzle-size family. A difficulty tier classifies intended
+deductive challenge independently from size. A generated challenge binds one supported mode,
+difficulty tier, and validated generated puzzle profile.
+
+Profiles define size, difficulty, value constraints, result constraints, masking, variety,
+assessment policy, and validation expectations for one challenge. Absolute profile values remain
+calibrated per challenge: Medium has shared product meaning, but `4 Pairs Medium` does not copy raw
+sixteen-entry counts from `8 Pairs Medium`.
+
+The supported v8 catalog is sparse:
+
+| Generated mode | Low | Medium | Hard |
+| --- | --- | --- | --- |
+| `4 Pairs` | Supported | Supported | Unsupported |
+| `8 Pairs` | Unsupported | Supported | Supported |
+
+Unsupported combinations are absent rather than synthesized. The durable configuration decision
+is recorded in
+[ADR-005](../technical/adr/adr-005-model-sparse-generated-challenges.md).
 
 Profile definitions are not usable directly. They must be created through the generated-profile factory, which derives board, strip, and hidden-entry counts from puzzle size and returns either a validated profile or a non-empty set of typed compatibility violations.
 
@@ -45,13 +66,90 @@ The profile factory owns deterministic validation limits for eligible-pair catal
 
 Profile concerns are separated as follows:
 
-- hard rules cover strip values, arithmetic results, product anchors, initial mask shape, required anchors, hidden runs, and distribution
+- mandatory constraints cover strip values, arithmetic results, product anchors, initial mask shape, required anchors, hidden runs, and distribution
 - soft variety policy covers high-value masking frequencies and prime-product decoy frequencies
+- difficulty-assessment policy defines bounded acceptance semantics over an already valid candidate
 - generation execution concerns such as attempt limits and deterministic entropy are supplied to the generator rather than stored as passive profile flags
 
 Soft targets that are structurally unreachable for the profile are rejected during profile creation. Bounded fallback remains available for a sampled plan that is infeasible only for the candidates explored during that generation run.
 
-The application composition resolves a stable generated-mode identifier to one profile and creates one immutable hard-rule context for that profile. Candidate selection and final generated-puzzle validation receive that same context. Final validation returns a report with stable rule identifiers and context for every failed rule; it does not stop at the first failure.
+The application resolves stable mode and profile identities to one configured challenge and creates
+one immutable mandatory-constraint context for its profile. Candidate selection and final
+generated-puzzle validation receive that same context. Final validation returns a report with
+stable rule identifiers and context for every failed rule; it does not stop at the first failure.
+
+## Difficulty Assessment
+
+Difficulty assessment is a platform-independent analysis of a valid generated initial puzzle. It
+does not drive Compose UI, reveal answers to the player, or change shared completion validation.
+Its purpose is to reject content that is unsatisfiable, trivial for its intended tier, or beyond a
+bounded supported ambiguity envelope.
+
+The evaluator reasons in canonical domain facts:
+
+- one pair fact associates an unordered pair of strip entries with one sum result and one product
+  result
+- swapping left and right operands does not create a new candidate or solution
+- committing the same facts in a different UI or board order does not create a new solution
+- stable strip-entry identity remains authoritative for usage and pairing constraints
+- solution counts collapse cases related only by a global permutation of equal-valued strip-entry
+  identities, because that permutation exposes the same arithmetic deductions
+
+The last rule affects assessment metrics only. During play, repeated strip entries remain distinct
+game elements and any completed puzzle satisfying shared entry-usage and sum/product pairing rules
+is valid.
+
+Assessment reports:
+
+- initial plausible pair/result candidate count
+- initial and total forced-deduction counts
+- first forced-deduction depth, measured as the minimum number of chained propagation layers needed
+  to prove the first fact without a speculative commitment
+- maximum branching factor observed during bounded search
+- ambiguous states explored
+- bounded valid-solution equivalence count
+- known-entry count and longest hidden run
+- known-strip and unambiguous-result anchor counts
+- repeated-value group count
+- plausible decoy count, where a locally arithmetic-compatible candidate is eliminated only by
+  cross-pair or global usage constraints
+
+A forced deduction is a canonical fact present in every remaining valid solution equivalence
+class. The bounded solution count distinguishes none, one, and multiple up to its configured cap;
+it is not a unique-solution requirement.
+
+Assessment returns typed assessed, unsatisfiable, cancelled, and work-limit outcomes. The same
+puzzle and execution policy must produce the same metrics. Candidate expansions and cancellation
+checks are bounded independently from generation search.
+
+Every new v8 profile requires:
+
+- a completed assessment within its work policy
+- at least one valid solution equivalence class
+- at least one opening fact derivable by constraint propagation without committing a speculative
+  branch
+- profile-specific structural and decoy observations described below
+
+Numerical score bands for branching, depth, and ambiguous-state metrics must be based on the
+deterministic characterization of existing profiles. Characterization may tighten a profile's
+documented assessment policy before that profile is implemented, but v8 does not assign arbitrary
+weights or unevidenced global score thresholds in advance.
+
+## Population Variety Semantics
+
+Configured percentages describe the intended frequency of a trait in the final generated-puzzle
+population, not only the probability of preferring that trait during search.
+
+- One deterministic variation plan is sampled per generated puzzle.
+- For every configured target, the plan requests the included or excluded outcome explicitly.
+- Candidate selection treats the complete plan as strict during bounded search and returns a
+  matching puzzle whenever a compatible candidate is found.
+- Mandatory validity constraints always take precedence.
+- If a plan is infeasible for the candidates explored within the execution policy, generation may
+  relax the soft plan and return a mandatory-valid puzzle instead of failing or searching without
+  a bound.
+- Built-in profile frequencies are characterized over deterministic seed corpus `1..500`.
+- Each observed target remains within `±5` percentage points of its configured percentage.
 
 ## Generation Execution And Recovery
 
@@ -61,7 +159,11 @@ Value-pair and strip-mask searches share the same budget and observe cancellatio
 
 The application executes generation on an injected non-main dispatcher. The generated-mode presentation owner exposes loading, ready, restoration, resume-unavailable, and recoverable-failure states. Replay keeps the completed session visible until a replacement is stored and ready, and duplicate replay requests are ignored.
 
-Successful generation persists the exact initial puzzle before publishing it as playable. Generated play keeps one application-wide versioned session slot shared by `4 Pairs Low` and `8 Pairs Medium`. The slot stores the exact initial and current puzzles plus stable session, mode, profile, and seed metadata. Process-death restoration reads that snapshot directly; it never regenerates historical content from the seed.
+Successful generation persists the exact initial puzzle before publishing it as playable.
+Generated play keeps one application-wide versioned session slot shared by all configured
+challenges. The slot stores the exact initial and current puzzles plus stable session, mode,
+profile, and seed metadata. Mode/profile identity resolves the exact challenge. Process-death
+restoration reads that snapshot directly; it never regenerates historical content from the seed.
 
 Committed puzzle changes update the current snapshot through the stable session id, solved puzzles clear resumability, and stale callbacks cannot mutate a replacement. Generation, storage failure, or cancellation leaves the previous unfinished slot intact. See `docs/technical/generated-session-persistence.md` for the storage, ordering, validation, and backup contract.
 
@@ -117,6 +219,75 @@ These constraints keep the first generated mode approachable, reduce arithmetic 
 
 ---
 
+### `4 Pairs Medium`
+
+Status: specified for v8; not implemented.
+
+Shape:
+
+- 4 solution pairs
+- 8 strip entries
+- 8 board tiles
+
+Strip values:
+
+- range: `1..40`
+- occurrence limit: no value may appear more than twice
+- repeated-value groups: at most 1 distinct value may repeat
+- repeated-value population target: around 35% of generated puzzles should contain exactly 1
+  repeated-value group
+- `1`: allowed
+
+Result constraints:
+
+- multiplication result limit: `400`
+- board result duplicates: not allowed
+- product anchor mix: 1 to 2 multiplication results should be greater than `80`, the maximum sum
+  of two allowed strip values
+
+Initial masking:
+
+- tile expressions: all hidden
+- known strip entries: 3
+- hidden strip entries: 5
+- required fixed anchors: none
+- pair distribution: known entries must belong to at least 2 distinct solution pairs
+- hidden run limit: no more than 3 consecutive hidden strip entries
+- high-value mask bias:
+  - last strip entry hidden target: 25%
+  - second-last strip entry hidden target: 40%
+
+Generation expectations:
+
+- deterministic generation support for tests: required
+- bounded attempts, search work, failure, and cancellation: required
+- board tile shuffling: enabled
+- prime-product decoy target: around 30% of generated puzzles should include exactly 1 solution
+  pair made of `1` and a prime number
+- shared population-variety semantics apply to repetition, high-value masking, and prime-product
+  decoys
+
+Assessment expectations:
+
+- assessment must complete within the configured Medium work policy
+- at least 1 valid solution equivalence class must exist; uniqueness is not required
+- at least 1 opening fact must be derivable without speculative commitment
+- at least 1 locally plausible decoy must remain after direct arithmetic filtering
+- the first forced fact must require at least 1 propagation layer
+- characterization must demonstrate more opening ambiguity than `4 Pairs Low` without exceeding the
+  bounded Medium envelope
+
+Solving-tip implications:
+
+- prime results are no longer guaranteed addition tiles because `1` is allowed
+- the highest strip value is no longer guaranteed visible
+- one repeated-value group can make arithmetic values interchangeable while stable entry identity
+  remains authoritative
+- longer hidden runs require more use of sorted-neighbor and cross-pair constraints
+- v8 intentionally does not revise the current Low-specific solving-tips surface
+
+---
+
 ### `8 Pairs Medium`
 
 Status: implemented.
@@ -158,22 +329,16 @@ Generation expectations:
 - bounded attempts / failure handling: required
 - board tile shuffling: enabled
 - prime-product decoy target: around 30% of generated puzzles should include one solution pair made of `1` and a prime number
-- probabilistic targets should guide generation variety without making the generator hang when other hard constraints cannot satisfy them
+- probabilistic targets should guide generation variety without making the generator hang when other mandatory constraints cannot satisfy them
 
-Probabilistic target semantics:
-
-- Percentages describe the intended frequency of the trait in the final generated-puzzle population, not only the probability of preferring that trait during search.
-- One variation plan is sampled per generated puzzle. For every configured target, the plan explicitly requests both outcomes: inclusion or exclusion of a prime-product decoy, and hidden or known visibility for each targeted high-value strip entry.
-- Candidate selection treats the complete variation plan as strict during bounded search and returns a matching puzzle whenever a compatible candidate is found.
-- Hard validity constraints always take precedence. If a variation plan is infeasible, generation may relax the soft plan and return a hard-valid puzzle instead of failing or retrying without a bound.
-- The built-in profile is characterized over the deterministic seed corpus `1..500`. Each observed target frequency must remain within `±5` percentage points of its configured percentage.
+The shared population-variety semantics apply to high-value masking and prime-product decoys.
 
 Validation expectations:
 
 - the solved puzzle must satisfy all `8 Pairs Medium` value and result constraints
 - the initial puzzle must follow the `8 Pairs Medium` masking policy
 - the solved puzzle must be accepted by shared NumPairs completion validation
-- unique-solution guarantees remain out of scope unless explicitly added to this profile
+- one or more valid completions may exist; uniqueness is not required
 
 Solving-tip implications:
 
@@ -181,6 +346,72 @@ Solving-tip implications:
 - repeated values make strip-entry identity more important than numeric value alone
 - product factor checks still apply, but the larger value range and product limit make them less beginner-oriented
 - `8 Pairs Medium` may need separate player-facing tips if solving tips are exposed for this mode
+
+---
+
+### `8 Pairs Hard`
+
+Status: specified for v8; not implemented.
+
+Shape:
+
+- 8 solution pairs
+- 16 strip entries
+- 16 board tiles
+
+Strip values:
+
+- range: `1..99`
+- occurrence limit: no value may appear more than twice
+- repeated-value groups: 1 to 2 distinct values must repeat
+- `1`: allowed
+
+Result constraints:
+
+- multiplication result limit: `1000`
+- board result duplicates: not allowed
+- product anchor mix: 0 to 1 multiplication results may be greater than `198`, the maximum sum of
+  two allowed strip values
+
+Initial masking:
+
+- tile expressions: all hidden
+- known strip entries: 4 to 5
+- hidden strip entries: 11 to 12
+- required fixed anchors: none
+- pair distribution: known entries must belong to at least 3 distinct solution pairs
+- hidden run limit: no more than 5 consecutive hidden strip entries
+- high-value mask bias:
+  - last strip entry hidden target: 60%
+  - second-last strip entry hidden target: 70%
+  - third-last strip entry hidden target: 70%
+
+Generation expectations:
+
+- deterministic generation support for tests: required
+- bounded attempts, search work, failure, and cancellation at sixteen-entry scale: required
+- board tile shuffling: enabled
+- prime-product decoy target: around 60% of generated puzzles should include exactly 1 solution
+  pair made of `1` and a prime number
+- shared population-variety semantics apply to high-value masking and prime-product decoys
+
+Assessment expectations:
+
+- assessment must complete within the configured Hard work policy
+- at least 1 valid solution equivalence class must exist; uniqueness is not required
+- at least 1 opening fact must be derivable without speculative commitment
+- at least 3 locally plausible decoys must remain after direct arithmetic filtering
+- the first forced fact must require at least 2 chained propagation layers
+- at least 1 ambiguous state must remain after direct local filtering
+- characterization must demonstrate greater deductive depth and ambiguity than `8 Pairs Medium`
+  without exceeding the bounded Hard envelope
+
+Solving implications:
+
+- very few results are guaranteed products solely because they exceed the maximum possible sum
+- repeated values and deliberately hidden high values weaken direct strip anchors
+- longer hidden runs increase reliance on cross-pair, global usage, and sorted-strip propagation
+- decoys should be eliminated through deductions rather than blind trial-and-error
 
 ---
 
@@ -196,7 +427,9 @@ Validation should confirm that:
 - the initial puzzle follows the selected profile's strip masking policy
 - the generated puzzle satisfies shared NumPairs rules
 
-Guaranteed unique solutions are not required unless explicitly added to a future profile. Generated puzzles should never be shown if they fail internal consistency validation.
+Generated puzzles may have more than one valid completion. Every completion satisfying shared
+NumPairs rules remains valid, and generated puzzles should never be shown if they fail internal
+consistency validation or their selected profile's assessment acceptance policy.
 
 ---
 
@@ -205,5 +438,7 @@ Guaranteed unique solutions are not required unless explicitly added to a future
 - `docs/game-rules.md` owns core NumPairs rules shared by handcrafted and generated puzzles.
 - `docs/product/prd/prd-v5.md` owns v5 product scope.
 - `docs/product/prd/prd-v7.md` owns the reliable-session and replay-control product contract.
+- `docs/product/prd/prd-v8.md` owns the difficulty-selection and challenge-expansion product contract.
 - `docs/technical/generated-session-persistence.md` owns the implemented session storage and coordination boundary.
+- `docs/technical/adr/adr-005-model-sparse-generated-challenges.md` owns the durable sparse challenge-catalog decision.
 - `docs/ubiquitous-language.md` owns shared terminology.

--- a/docs/technical/adr/adr-005-model-sparse-generated-challenges.md
+++ b/docs/technical/adr/adr-005-model-sparse-generated-challenges.md
@@ -1,0 +1,114 @@
+# ADR-005: Model A Sparse Catalog Of Generated Challenges
+
+## Context
+
+Generated NumPairs play currently exposes two stable modes:
+
+- `4 Pairs`, which resolves to `4 Pairs Low`
+- `8 Pairs`, which resolves to `8 Pairs Medium`
+
+The application models each generated mode as one stable mode id plus exactly one generated
+puzzle profile. Navigation, generation composition, retained presentation state, and generated
+session restoration consequently assume a one-to-one mode/profile relationship.
+
+v8 keeps generated mode as the puzzle-size family and introduces Low, Medium, and Hard as an
+independent difficulty dimension. The supported content matrix is intentionally incomplete:
+
+| Generated mode | Low | Medium | Hard |
+| --- | --- | --- | --- |
+| `4 Pairs` | Supported | Supported | Unsupported |
+| `8 Pairs` | Unsupported | Supported | Supported |
+
+The architecture needs to represent those four supported combinations without making Android
+presentation state part of the puzzle profile, duplicating a mode for every difficulty, or
+manufacturing unsupported combinations.
+
+## Options Considered
+
+### Keep One Profile Per Generated Mode
+
+Add a new generated mode id for each difficulty, such as `four-pairs-medium`, while keeping the
+existing configuration shape.
+
+This preserves the current registry but changes the meaning of generated mode from the stable
+size family to one complete challenge. Menu selection, mode-specific preferences, titles, and
+session presentation would have to recover the shared `4 Pairs` or `8 Pairs` family by parsing or
+duplicating metadata. It also keeps size and difficulty coupled under a different name.
+
+### Generate The Full Size/Difficulty Product
+
+Model puzzle size and difficulty independently and construct every combination automatically.
+
+This expresses the dimensions directly but implies support for `4 Pairs Hard` and `8 Pairs Low`,
+which v8 does not define. Filtering those combinations later would create a second source of truth
+for supported content and allow invalid profiles to reach application composition.
+
+### Configure A Sparse Generated Challenge Catalog
+
+Keep generated mode as the stable size family, define difficulty tier independently, and register
+only supported generated challenges. Each challenge binds exactly one mode, difficulty tier, and
+validated generated puzzle profile.
+
+The mode owns stable family identity and puzzle size. The profile owns calibrated generation and
+assessment policy. The challenge is the application configuration that establishes their
+supported relationship.
+
+## Decision
+
+NumPairs will use a validated sparse catalog of generated challenges.
+
+- `GeneratedMode` identifies the replayable puzzle-size family.
+- `GeneratedPuzzleSize` owns pair, strip-entry, and board-tile counts.
+- `DifficultyTier` classifies intended deductive challenge as Low, Medium, or Hard.
+- `GeneratedPuzzleProfile` owns the calibrated mandatory constraints, soft variety policy, and
+  difficulty-assessment policy for one supported challenge.
+- `GeneratedChallenge` binds one mode, one difficulty tier, and one validated profile.
+- A generated mode exposes one or more explicitly configured challenges.
+- Unsupported mode/difficulty combinations do not exist in the catalog.
+
+Catalog validation must reject:
+
+- duplicate mode identities
+- duplicate challenge or profile identities
+- more than one challenge with the same difficulty inside one mode
+- a profile whose puzzle size differs from its mode
+- a profile whose declared difficulty differs from its challenge
+
+Android strings, selection state, persisted player preference, navigation destinations, and
+challenge-specific learning capabilities remain outside the domain profile.
+
+Generated session snapshots continue storing stable mode and profile ids. Their combination
+resolves the exact configured challenge, so difficulty does not become a redundant persisted
+field. Existing `4 Pairs Low` and `8 Pairs Medium` snapshots remain representable without a schema
+change.
+
+## Consequences
+
+### Positive
+
+- Puzzle size and difficulty have explicit, independent meanings.
+- The application can add `4 Pairs Medium` and `8 Pairs Hard` without duplicating modes.
+- Unsupported combinations are unrepresentable through normal catalog resolution.
+- Mode-specific selection preferences can use stable mode and difficulty identities.
+- Generation, ViewModel ownership, resume, replacement, and replay can resolve one exact challenge.
+- Profiles remain independent from Android and player-specific state.
+- A future custom mode can use a separate product concept without adding `CUSTOM` to the closed
+  difficulty tiers.
+
+### Negative
+
+- Application composition becomes more explicit than the current one-profile mode registry.
+- Callers that previously accepted only a generated mode must distinguish family selection from a
+  playable challenge.
+- Registry and restoration tests must cover mismatched and unsupported mode/profile combinations.
+- Presentation keys must include challenge identity so two difficulties in one mode cannot share
+  retained gameplay state accidentally.
+
+## Future Considerations
+
+If a future milestone supports every difficulty for every size, it may generate catalog entries
+from validated definitions, but the resulting supported challenges should remain explicit.
+
+Custom generation settings should be modeled as their own configuration boundary rather than as a
+fourth difficulty tier. Any future snapshot change should preserve one authoritative challenge
+identity and avoid persisting derivable size or difficulty values redundantly.

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -6,20 +6,55 @@ A complete game instance containing a board and a strip of available numbers.
 ## Generated Puzzle
 A puzzle produced by a generator rather than authored by hand.
 
-Generated puzzles are used by generated gameplay modes. A mode selects one difficulty profile and presents its player-facing initial puzzle.
+Generated puzzles are used by generated challenges. A challenge selects one validated generated
+puzzle profile and presents its player-facing initial puzzle.
 
 ## Generated Mode
-A replayable gameplay configuration identified by a stable generated-mode identity.
+A replayable generated-puzzle family identified by a stable generated-mode identity and puzzle
+size.
 
-A generated mode resolves to one difficulty profile in the application layer. The mode identity is used for profile selection, navigation, and game-session identity; Android strings and mode-specific learning capabilities remain outside the profile.
+`4 Pairs` and `8 Pairs` are generated modes. A mode exposes one or more explicitly supported
+generated challenges. Its identity is used for family selection, mode-specific preference, and
+generated-session identity; it does not imply one difficulty.
+
+## Difficulty Tier
+The intended deductive challenge classification independent from generated puzzle size.
+
+Supported tiers are:
+
+- low
+- medium
+- hard
+
+A tier has shared product meaning but does not own identical absolute profile constants for every
+size. Each supported challenge calibrates the tier for its mode.
+
+## Generated Challenge
+One supported playable combination of generated mode, difficulty tier, and generated puzzle
+profile.
+
+Generated challenges are registered explicitly. Unsupported size and difficulty combinations are
+absent rather than synthesized. Challenge identity owns application profile selection,
+generation, retained presentation state, navigation, and exact session resolution.
+
+## Generated Puzzle Profile
+The validated, immutable generation and difficulty-assessment configuration for one generated
+challenge.
+
+A profile owns puzzle size, value and result constraints, initial masking, variety targets, and
+assessment policy. Android strings, player preference, lock state, navigation, and
+challenge-specific learning capabilities remain outside the profile.
 
 ## Generated Session
 A playable generated-puzzle lifecycle identified by a stable session identity.
 
-NumPairs owns at most one generated session slot for the application, shared by all generated modes. A generated session carries its mode, profile, seed metadata, exact initial puzzle, and exact current puzzle.
+NumPairs owns at most one generated session slot for the application, shared by all generated
+challenges. A generated session carries the mode and profile identities that resolve its exact
+challenge, seed metadata, exact initial puzzle, and exact current puzzle.
 
 ## Resumable Generated Session
-The generated session currently stored in the application-wide slot when its current puzzle is valid, belongs to a configured mode/profile, and is not solved.
+The generated session currently stored in the application-wide slot when its current puzzle is
+valid, resolves to a configured challenge through its mode/profile identities, and is not solved.
 
 An opened but untouched generated puzzle is resumable. A solved, stale, mismatched, corrupt, unsupported, or missing snapshot is not resumable.
 


### PR DESCRIPTION
## Related Issue

Resolves #490

## Summary

- Record the sparse generated-challenge catalog decision in ADR-005.
- Define generated mode, difficulty tier, challenge, and profile ownership in the ubiquitous language.
- Specify bounded difficulty-assessment semantics and population-variety behavior.
- Document the initial 4 Pairs Medium and 8 Pairs Hard profiles without requiring unique player solutions.