### PR TITLE
[237] Document v8 difficulty selection and session behavior

### DIFF
--- a/docs/technical/generated-session-persistence.md
+++ b/docs/technical/generated-session-persistence.md
@@ -2,9 +2,10 @@
 
 ## Document Status
 
-- Status: implemented technical reference for v7
-- Product contract: `docs/product/prd/prd-v7.md`
+- Status: implemented v7 persistence boundary with the v8 multi-profile contract documented
+- Product contracts: `docs/product/prd/prd-v7.md` and `docs/product/prd/prd-v8.md`
 - Related generation reference: `docs/product/puzzle-generation.md`
+- Related domain decision: `docs/technical/adr/adr-005-model-sparse-generated-challenges.md`
 
 This document owns the persistence and coordination boundary for the single resumable generated puzzle. It does not redefine puzzle rules, generation profiles, or menu copy.
 
@@ -12,15 +13,43 @@ This document owns the persistence and coordination boundary for the single resu
 
 ## Scope And Ownership
 
-NumPairs stores at most one generated session for the whole application. The slot may belong to `4 Pairs Low` or `8 Pairs Medium`; there is no independent save per mode, history, account sync, or manual save management.
+NumPairs stores at most one generated session for the whole application. The slot may belong to
+any challenge in the supported generated-challenge catalog: `4 Pairs Low`, `4 Pairs Medium`,
+`8 Pairs Medium`, or `8 Pairs Hard` in v8. There is no independent save per mode, history,
+account sync, or manual save management.
 
-`MainActivity` creates one application-scoped `GeneratedSessionRepository` from application-private storage and passes it only through generated-play and unlocked-navigation composition. Tutorial and onboarding do not receive generated-session persistence callbacks and cannot replace the slot.
+`MainActivity` creates one application-scoped `GeneratedSessionRepository` from
+application-private storage and passes it only through generated-play and unlocked-navigation
+composition. Tutorial and onboarding do not receive generated-session persistence callbacks and
+cannot replace the slot.
+
+The remembered difficulty selections are a separate preference aggregate, not generated-session
+state. Session creation and restoration may read a challenge choice supplied by navigation, but
+the generated-session repository never owns or mutates selector defaults.
+
+---
+
+## Remembered Difficulty Selection
+
+The application keeps one stable difficulty id for each generated mode in local preference
+storage. The preference boundary exposes an observable effective selection per mode and accepts
+only mode/difficulty pairs present in the supported challenge catalog.
+
+The effective fallback is `Low` for `4 Pairs` and `Medium` for `8 Pairs`. Missing, corrupt,
+unknown, and no-longer-supported stored values resolve to that fallback without writing it back.
+The only operation that writes a selector default is an explicit supported option choice made by
+the player in that mode's difficulty selector.
+
+Opening the selector, showing a fallback, pressing Play, resuming or restoring a session, replacing
+a session, completing a puzzle, and using `Play another` do not write this preference. The two mode
+values remain independent, and neither completion nor any other v8 behavior stores progression,
+locks, completion counts, rewards, or statistics.
 
 ---
 
 ## Versioned Snapshot
 
-Schema version `1` stores:
+Schema version `1` continues to store:
 
 - stable generated-session id
 - generated-mode id
@@ -29,7 +58,14 @@ Schema version `1` stores:
 - exact initial `Puzzle`
 - exact current `Puzzle`
 
-The seed is diagnostic and generation metadata. Restoration never reruns the generator because a generator or profile implementation may change after the session was created.
+The seed is diagnostic and generation metadata. Restoration never reruns the generator because a
+generator or profile implementation may change after the session was created.
+
+The stored mode/profile pair resolves one exact supported `GeneratedChallenge`; v8 does not assume
+that a mode has only one profile. The existing `4 Pairs Low` and `8 Pairs Medium` ids retain their
+meaning, so valid schema-1 snapshots for those challenges remain compatible. An unknown mode,
+unknown profile, unsupported pair, or profile whose declared mode differs from the stored mode is
+invalid session data and is exposed as an empty slot.
 
 The initial and current puzzles preserve:
 
@@ -61,7 +97,8 @@ Generated gameplay forwards only committed domain `Puzzle` changes. Draft text, 
 
 ### Create And Replace
 
-1. Generate and validate a puzzle through the bounded generation pipeline.
+1. Resolve the requested supported challenge and generate and validate a puzzle through its
+   bounded generation pipeline.
 2. Build a new versioned snapshot with identical initial and current puzzles.
 3. Store the snapshot.
 4. Publish the playable successor.
@@ -70,7 +107,10 @@ The previous slot remains intact while generation or storage is pending. Failure
 
 ### Restore
 
-Resume identifies the expected stable session id. Restoration reads the slot and requires matching session, mode, and profile ids plus an unsolved current puzzle. It then presents the exact current puzzle without invoking generation or mutating the repository.
+Resume identifies the expected stable session id. Restoration reads the slot and requires matching
+session id plus a mode/profile pair that still resolves the exact stored challenge, and an unsolved
+current puzzle. It then presents the exact current puzzle without invoking generation, consulting
+the remembered selector default, or mutating either repository.
 
 Missing, stale, mismatched, solved, corrupt, or unsupported sessions are not presented as resumable gameplay. The route offers a safe return to the menu.
 
@@ -78,7 +118,9 @@ Missing, stale, mismatched, solved, corrupt, or unsupported sessions are not pre
 
 Committed strip values, operand assignments, operator assignments, and tile resets replace `currentPuzzle` for the active id. When the puzzle becomes solved, the same identity guard clears the slot. The solved game remains visible in memory for its completion actions, but the normal menu no longer exposes `Resume`.
 
-`Play another` uses the create-and-replace pipeline. A late clear from the solved session cannot clear the successor because their stable ids differ.
+`Play another` uses the create-and-replace pipeline with the completed session's exact mode and
+profile. It does not consult or update the remembered selector default. A late clear from the
+solved session cannot clear the successor because their stable ids differ.
 
 ---
 

--- a/docs/ui-behavior.md
+++ b/docs/ui-behavior.md
@@ -2,8 +2,9 @@
 
 ## Overview
 
-This document defines the current menu, personalization, generated-session routing,
-generated-game feedback, completion, and in-puzzle interaction model for NumPairs.
+This document defines the current menu, generated difficulty selection, personalization,
+generated-session routing, generated-game feedback, completion, and in-puzzle interaction model
+for NumPairs.
 
 It complements the game rules described in [game-rules.md](./game-rules.md) and focuses on:
 
@@ -11,8 +12,9 @@ It complements the game rules described in [game-rules.md](./game-rules.md) and 
 2. Result grid behavior
 3. Contextual editing flows
 4. Gameplay top bar helper behavior
-5. Generated-session menu, replacement, and completion behavior
-6. Persistent color personalization and generated-only feedback
+5. Generated difficulty selection and remembered defaults
+6. Generated-session menu, replacement, and completion behavior
+7. Persistent color personalization and generated-only feedback
 
 This is the interaction baseline shared where applicable by Tutorial, generated `4 Pairs`, and generated `8 Pairs` gameplay.
 
@@ -20,6 +22,9 @@ Required-onboarding behavior is documented in
 [PRD v6](./product/prd/prd-v6.md). The reliable-session product contract is documented in
 [PRD v7](./product/prd/prd-v7.md), and its storage boundary is documented in
 [generated-session-persistence.md](./technical/generated-session-persistence.md).
+Generated difficulty selection and challenge expansion are documented in
+[PRD v8](./product/prd/prd-v8.md), and the sparse challenge catalog is recorded in
+[ADR-005](./technical/adr/adr-005-model-sparse-generated-challenges.md).
 Personalization and generated-game feedback are documented in
 [PRD v9](./product/prd/prd-v9.md); the platform-branding boundary is recorded in
 [ADR-004](./technical/adr/adr-004-keep-v9-platform-branding-static.md).
@@ -37,6 +42,8 @@ Personalization and generated-game feedback are documented in
 - **Entry dialog**: the dialog used to enter or edit a number in the strip
 - **Rules helper**: an informational dialog opened from the game top app bar to explain core game rules
 - **Usage indicator**: a compact `+` or `×` marker that shows whether a visible strip entry is already used by that operator family
+- **Difficulty selector**: the mode-specific destination used to choose one supported generated
+  challenge before starting it
 
 In this document, strip items are rendered as chips.
 
@@ -53,7 +60,7 @@ In this document, strip items are rendered as chips.
 
 ---
 
-## Normal Menu And Generated Session Routing
+## Normal Menu, Difficulty Selection, And Generated Session Routing
 
 The unlocked normal menu renders actions in this order:
 
@@ -65,18 +72,57 @@ The unlocked normal menu renders actions in this order:
 
 `Resume` and both generated-mode actions use the primary CTA treatment. `How to play` and
 `Personalization` use the lower-emphasis secondary treatment. The localized `Resume`
-accessibility description identifies whether the saved puzzle belongs to 4 or 8 Pairs.
+accessibility description identifies the saved mode and difficulty, for example
+`Resume 4 Pairs · Medium puzzle`.
 
 The application derives menu resumability from the one global generated-session slot. Missing, solved, unknown-mode, mode/profile-mismatched, corrupt, and unsupported snapshots do not expose `Resume`.
 
 Selecting `Resume` opens the saved mode and exact current puzzle without generation.
 
-Selecting either generated-mode action while a resumable session exists opens the same modal choice:
+Selecting `Play 4 Pairs` or `Play 8 Pairs` always opens that mode's dedicated difficulty
+selector. Entering the selector does not generate a puzzle, replace a session, or persist a
+difficulty.
+
+### Difficulty Selector
+
+The selector shows only challenges present in the supported generated-challenge catalog:
+
+- `4 Pairs` shows `Low` and `Medium`
+- `8 Pairs` shows `Medium` and `Hard`
+
+All shown options are enabled from the beginning. The selector has no locked option, progress
+indicator, completion requirement, reward, or explanation of how to unlock content. Selection is
+communicated through label and control state rather than color alone, and every option and action
+keeps the established minimum touch target and readable text-scaling behavior.
+
+On entry, the selected option is the last supported difficulty the player explicitly chose for
+that mode. The two modes remember their choices independently. A missing, corrupt, unknown, or
+unsupported stored value is presented using `Low` for `4 Pairs` and `Medium` for `8 Pairs` without
+rewriting storage.
+
+Tapping a supported difficulty makes it the current option and immediately persists that explicit
+choice for the selected mode. Merely entering the selector, displaying a fallback, or leaving by
+system back or the visible back action does not write a preference. The back actions return to the
+normal menu without starting a puzzle or changing the generated-session slot.
+
+The primary action identifies the exact requested challenge, for example
+`Play 4 Pairs · Medium`. Activating it starts the existing resume-or-replace routing for that
+challenge. Difficulty is fixed once play begins; generated gameplay and completion do not expose a
+change-difficulty action.
+
+### Resume Or Replace
+
+Activating the selector's primary action while a resumable session exists opens the same modal
+choice:
 
 - primary: `Resume`
-- secondary: start a new puzzle for the mode the player selected
+- secondary: start a new puzzle for the mode and difficulty the player selected
 
-Both same-mode and different-mode selections use one concise supporting message: `You have an unfinished <saved mode> puzzle.` The message uses the larger body text treatment. The secondary label always identifies the requested replacement mode as `New <selected mode>`.
+Same-challenge, same-mode/different-difficulty, and different-mode selections use one concise
+supporting message: `You have an unfinished <saved mode> · <saved difficulty> puzzle.` The message
+uses the larger body text treatment. The secondary label always identifies the requested
+replacement challenge as `New <selected mode> · <selected difficulty>`. The primary action's
+accessibility description identifies the saved challenge.
 
 The primary action uses the shared primary CTA treatment and established button shape.
 
@@ -108,7 +154,8 @@ and hidden states remain shared.
 The screen also exposes one `Game haptics` preference. It defaults to enabled, persists
 independently from onboarding and generated sessions, and controls only accepted-assignment
 haptics in generated games. Android's system touch-feedback setting remains authoritative.
-There are no sound, error-haptic, typography, shape, motion, or difficulty controls.
+There are no sound, error-haptic, typography, shape, motion, or difficulty controls on the
+Personalization screen. Generated difficulty is selected only through the mode-specific selector.
 
 In-app NumPairs branding follows the selected appearance palette. The system splash and
 launcher stay static and Warm. The packaged monochrome icon remains available for Android
@@ -126,13 +173,17 @@ and the completion surface enters once. Recomposition, restoration, preview stat
 already-solved initial puzzle do not replay the celebration. Completion actions remain
 usable throughout the final visual state.
 
-`Play another` runs the existing bounded generation and safe-replacement pipeline. The
-solved puzzle remains visible while its successor is generating, validating, or being
+`Play another` runs the existing bounded generation and safe-replacement pipeline for the exact
+mode and difficulty of the completed session. It does not consult or rewrite either remembered
+selector default. The solved puzzle remains visible while its successor is generating, validating,
+or being
 stored. Failure or cancellation keeps the completion surface available. Only after a
 successor is safely stored and adopted does a brief entrance transition introduce it; the
 transition is transient and is not persisted.
 
-Solving clears menu resumability before `Back to menu` returns to the menu. There is no `Change difficulty`, restart, timer, or additional completion action.
+Solving clears menu resumability before `Back to menu` returns to the menu. Completion does not
+record progression or completion counts. There is no `Change difficulty`, restart, timer, or
+additional completion action.
 
 ---
 
@@ -167,12 +218,17 @@ final state when system animation duration is disabled.
 Gameplay screens should show:
 
 - a back navigation action
-- the current mode title
+- the current generated challenge title, such as `4 Pairs · Low` or `8 Pairs · Hard`; Tutorial
+  retains its authored title
 - an optional rules helper action
 
 The rules helper action should be available in generated `4 Pairs` for v3. It should not be shown in Tutorial because Tutorial has its own guided instructional surface. It is intentionally not part of the menu screen in the first implementation.
 
 Reliable sessions do not add a new-puzzle, restart, resume, or overflow action to the gameplay TopAppBar. Session choices remain in the normal menu and completion surface.
+
+The existing Low-specific rules helper and solving tips may remain available in `4 Pairs Medium`
+for v8. Aligning that learning content with Medium is a separate follow-up and does not alter the
+challenge identity or generated puzzle rules.
 
 ### Rules Helper Behavior
 
@@ -433,6 +489,9 @@ motion contracts remain stable.
 
 The following behaviors are intentionally left for future tickets:
 
+- Difficulty changes during an active generated puzzle
+- Difficulty locks, player progression, completion tracking, rewards, and statistics
+- Revising Low-specific solving tips for `4 Pairs Medium`
 - Advanced validation while entering or selecting values
 - Context-aware filtering of operand slot options
 - Automatic prevention of invalid operator or operand choices


### PR DESCRIPTION
## Related Issue

Resolves #491

## Summary

- Define the mode-specific difficulty selector, supported options, fallbacks, and explicit-write preference behavior.
- Make generated titles, Resume, replacement, and replay behavior challenge-aware.
- Preserve schema-1 session compatibility while resolving each stored mode/profile pair through the sparse challenge catalog.