### PR TITLE
[238] Rename mandatory generated hard rules as constraints

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPairsPuzzleGenerator.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPairsPuzzleGenerator.kt
@@ -42,13 +42,13 @@ class GeneratedPairsPuzzleGenerator(private val context: GeneratedPuzzleGenerati
             valuePairSelector = GeneratedPairsValuePairSelector(
                 profile = profile,
                 random = random,
-                hardRules = context.hardRules.valuePairs
+                constraints = context.constraints.valuePairs
             )
         )
         val stripMaskSelector = GeneratedStripMaskSelector(
             profile = profile,
             random = random,
-            hardRule = context.hardRules.stripMask
+            constraint = context.constraints.stripMask
         )
         val puzzleAssembler = GeneratedPairsPuzzleAssembler(profile = profile, random = random)
         val rejections = mutableListOf<GeneratedPairsPuzzleCandidateRejection>()

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleGenerationContext.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleGenerationContext.kt
@@ -1,17 +1,17 @@
 package org.cescfe.numpairs.domain.generated.generation
 
-import org.cescfe.numpairs.domain.generated.generation.internal.GeneratedPuzzleHardRuleSet
+import org.cescfe.numpairs.domain.generated.generation.internal.GeneratedPuzzleConstraintSet
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
 
 class GeneratedPuzzleGenerationContext private constructor(
     val profile: GeneratedPuzzleProfile,
-    internal val hardRules: GeneratedPuzzleHardRuleSet
+    internal val constraints: GeneratedPuzzleConstraintSet
 ) {
     companion object {
         fun forProfile(profile: GeneratedPuzzleProfile): GeneratedPuzzleGenerationContext =
             GeneratedPuzzleGenerationContext(
                 profile = profile,
-                hardRules = GeneratedPuzzleHardRuleSet.from(profile = profile)
+                constraints = GeneratedPuzzleConstraintSet.from(profile = profile)
             )
     }
 }

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsValuePairSelector.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsValuePairSelector.kt
@@ -6,12 +6,12 @@ import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
 internal class GeneratedPairsValuePairSelector(
     private val profile: GeneratedPuzzleProfile,
     private val random: Random,
-    private val hardRules: GeneratedValuePairRuleSet
+    private val constraints: GeneratedValuePairConstraintSet
 ) {
     constructor(profile: GeneratedPuzzleProfile, random: Random) : this(
         profile = profile,
         random = random,
-        hardRules = GeneratedPuzzleHardRuleSet.from(profile = profile).valuePairs
+        constraints = GeneratedPuzzleConstraintSet.from(profile = profile).valuePairs
     )
 
     fun selectValuePairs(variationPlan: GeneratedPairsVariationPlan): List<GeneratedPairsValuePair>? =
@@ -83,7 +83,7 @@ internal class GeneratedPairsValuePairSelector(
             }
         }
 
-        if (!hardRules.canStillSatisfyProductAnchorMix(
+        if (!constraints.canStillSatisfyProductAnchorMix(
                 productAnchorCount = productAnchorCount,
                 remainingPairSlots = profile.size.pairCount - selectedPairs.size
             )
@@ -101,7 +101,7 @@ internal class GeneratedPairsValuePairSelector(
 
         if (selectedPairs.size == profile.size.pairCount) {
             return if (
-                hardRules.isComplete(pairs = selectedPairs) &&
+                constraints.isComplete(pairs = selectedPairs) &&
                 primeProductDecoyDirective.isSatisfiedBy(pairCount = primeProductDecoyCount)
             ) {
                 GeneratedPairsSearchOutcome.Found(selectedPairs)
@@ -130,7 +130,7 @@ internal class GeneratedPairsValuePairSelector(
             }
 
             if (
-                !hardRules.canBeAdded(
+                !constraints.canBeAdded(
                     pair = candidatePair,
                     valueOccurrences = valueOccurrences,
                     usedResults = usedResults
@@ -151,7 +151,8 @@ internal class GeneratedPairsValuePairSelector(
                     selectedPairs = selectedPairs + candidatePair,
                     valueOccurrences = valueOccurrences.with(candidatePair),
                     usedResults = usedResults + candidatePair.resultValues,
-                    productAnchorCount = productAnchorCount + hardRules.productAnchorIncrement(pair = candidatePair),
+                    productAnchorCount = productAnchorCount +
+                        constraints.productAnchorIncrement(pair = candidatePair),
                     primeProductDecoyCount = updatedPrimeProductDecoyCount,
                     primeProductDecoyDirective = primeProductDecoyDirective,
                     searchControl = searchControl
@@ -176,7 +177,7 @@ internal class GeneratedPairsValuePairSelector(
                 )
 
                 if (
-                    hardRules.canBeAdded(
+                    constraints.canBeAdded(
                         pair = candidatePair,
                         valueOccurrences = emptyMap(),
                         usedResults = emptySet()

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPuzzleConstraints.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPuzzleConstraints.kt
@@ -13,23 +13,23 @@ import org.cescfe.numpairs.domain.generated.puzzle.GeneratedPairsPuzzleValidatio
 import org.cescfe.numpairs.domain.puzzle.assignment.StripEntryId
 import org.cescfe.numpairs.domain.puzzle.assignment.UnorderedStripEntryPair
 
-internal data class GeneratedPuzzleHardRuleSet(
-    val valuePairs: GeneratedValuePairRuleSet,
-    val stripValues: GeneratedStripValueRule,
-    val boardResults: GeneratedBoardResultRule,
-    val multiplicationResults: GeneratedMultiplicationResultRule,
-    val stripMask: GeneratedStripMaskRule
+internal data class GeneratedPuzzleConstraintSet(
+    val valuePairs: GeneratedValuePairConstraintSet,
+    val stripValues: GeneratedStripValueConstraint,
+    val boardResults: GeneratedBoardResultConstraint,
+    val multiplicationResults: GeneratedMultiplicationResultConstraint,
+    val stripMask: GeneratedStripMaskConstraint
 ) {
     companion object {
-        fun from(profile: GeneratedPuzzleProfile): GeneratedPuzzleHardRuleSet {
-            val stripValues = GeneratedStripValueRule(policy = profile.stripValuePolicy)
-            val boardResults = GeneratedBoardResultRule(constraints = profile.resultConstraints)
-            val multiplicationResults = GeneratedMultiplicationResultRule(
+        fun from(profile: GeneratedPuzzleProfile): GeneratedPuzzleConstraintSet {
+            val stripValues = GeneratedStripValueConstraint(policy = profile.stripValuePolicy)
+            val boardResults = GeneratedBoardResultConstraint(constraints = profile.resultConstraints)
+            val multiplicationResults = GeneratedMultiplicationResultConstraint(
                 constraints = profile.resultConstraints
             )
 
-            return GeneratedPuzzleHardRuleSet(
-                valuePairs = GeneratedValuePairRuleSet(
+            return GeneratedPuzzleConstraintSet(
+                valuePairs = GeneratedValuePairConstraintSet(
                     pairSpecification = GeneratedPuzzlePairSpecification(
                         stripValuePolicy = profile.stripValuePolicy,
                         resultConstraints = profile.resultConstraints
@@ -42,17 +42,17 @@ internal data class GeneratedPuzzleHardRuleSet(
                 stripValues = stripValues,
                 boardResults = boardResults,
                 multiplicationResults = multiplicationResults,
-                stripMask = GeneratedStripMaskRule(profile = profile)
+                stripMask = GeneratedStripMaskConstraint(profile = profile)
             )
         }
     }
 }
 
-internal class GeneratedValuePairRuleSet(
+internal class GeneratedValuePairConstraintSet(
     private val pairSpecification: GeneratedPuzzlePairSpecification,
-    private val stripValues: GeneratedStripValueRule,
-    private val boardResults: GeneratedBoardResultRule,
-    private val multiplicationResults: GeneratedMultiplicationResultRule,
+    private val stripValues: GeneratedStripValueConstraint,
+    private val boardResults: GeneratedBoardResultConstraint,
+    private val multiplicationResults: GeneratedMultiplicationResultConstraint,
     private val productAnchorMix: ProductAnchorMix?
 ) {
     fun canBeAdded(pair: GeneratedPairsPairValues, valueOccurrences: Map<Int, Int>, usedResults: Set<Int>): Boolean =
@@ -83,7 +83,7 @@ internal class GeneratedValuePairRuleSet(
         if (productAnchorMix?.isAnchor(product = pair.product) == true) 1 else 0
 }
 
-internal class GeneratedStripValueRule(private val policy: StripValuePolicy) {
+internal class GeneratedStripValueConstraint(private val policy: StripValuePolicy) {
     fun violationsFor(values: List<Int>): List<GeneratedPairsPuzzleValidationViolation> = buildList {
         val valuesOutsideRange = values.filterTo(mutableSetOf()) { value -> value !in policy.valueRange }
         if (valuesOutsideRange.isNotEmpty()) {
@@ -109,7 +109,7 @@ internal class GeneratedStripValueRule(private val policy: StripValuePolicy) {
     }
 }
 
-internal class GeneratedBoardResultRule(private val constraints: ResultConstraints) {
+internal class GeneratedBoardResultConstraint(private val constraints: ResultConstraints) {
     fun violationsFor(results: List<Int>): List<GeneratedPairsPuzzleValidationViolation> {
         if (constraints.acceptsBoardResults(results = results.map(Int::toLong))) {
             return emptyList()
@@ -127,7 +127,7 @@ internal class GeneratedBoardResultRule(private val constraints: ResultConstrain
     }
 }
 
-internal class GeneratedMultiplicationResultRule(private val constraints: ResultConstraints) {
+internal class GeneratedMultiplicationResultConstraint(private val constraints: ResultConstraints) {
     fun violationsFor(resultsByIndex: Map<Int, Int>): List<GeneratedPairsPuzzleValidationViolation> = buildList {
         val excessiveResults = resultsByIndex.filterValues { result ->
             result > constraints.maxMultiplicationResult
@@ -155,7 +155,7 @@ internal class GeneratedMultiplicationResultRule(private val constraints: Result
     }
 }
 
-internal class GeneratedStripMaskRule(private val profile: GeneratedPuzzleProfile) {
+internal class GeneratedStripMaskConstraint(private val profile: GeneratedPuzzleProfile) {
     fun isSatisfied(
         knownEntryIds: Set<StripEntryId>,
         hiddenEntryCount: Int,

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedStripMaskSelector.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedStripMaskSelector.kt
@@ -7,12 +7,12 @@ import org.cescfe.numpairs.domain.puzzle.assignment.StripEntryId
 internal class GeneratedStripMaskSelector(
     private val profile: GeneratedPuzzleProfile,
     private val random: Random,
-    private val hardRule: GeneratedStripMaskRule
+    private val constraint: GeneratedStripMaskConstraint
 ) {
     constructor(profile: GeneratedPuzzleProfile, random: Random) : this(
         profile = profile,
         random = random,
-        hardRule = GeneratedPuzzleHardRuleSet.from(profile = profile).stripMask
+        constraint = GeneratedPuzzleConstraintSet.from(profile = profile).stripMask
     )
 
     fun selectKnownEntryIds(
@@ -131,7 +131,7 @@ internal class GeneratedStripMaskSelector(
             }
 
             if (
-                !hardRule.isSatisfied(
+                !constraint.isSatisfied(
                     knownEntryIds = knownEntryIds,
                     hiddenEntryCount = profile.size.stripEntryCount - knownEntryIds.size,
                     solutionPairs = solutionPairs

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/puzzle/internal/GeneratedPairsPuzzleValidator.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/puzzle/internal/GeneratedPairsPuzzleValidator.kt
@@ -14,7 +14,7 @@ import org.cescfe.numpairs.domain.puzzle.model.Tile
 
 internal class GeneratedPairsPuzzleValidator(context: GeneratedPuzzleGenerationContext) {
     private val profile = context.profile
-    private val hardRules = context.hardRules
+    private val constraints = context.constraints
 
     fun validate(initialPuzzle: Puzzle, solvedPuzzle: Puzzle): GeneratedPairsPuzzleValidationReport {
         val solvedAnalysis = solvedPuzzle.analyzeResolvedPuzzle()
@@ -35,7 +35,7 @@ internal class GeneratedPairsPuzzleValidator(context: GeneratedPuzzleGenerationC
 
             val knownEntryIds = initialPuzzle.knownStripEntryIds()
             addAll(
-                hardRules.stripMask.violationsFor(
+                constraints.stripMask.violationsFor(
                     knownEntryIds = knownEntryIds,
                     hiddenEntryCount = initialPuzzle.strip.entries.count { entry ->
                         entry.item == StripItem.Hidden
@@ -66,17 +66,17 @@ internal class GeneratedPairsPuzzleValidator(context: GeneratedPuzzleGenerationC
             addAssignmentViolations(solvedAnalysis = solvedAnalysis)
 
             addAll(
-                hardRules.stripValues.violationsFor(
+                constraints.stripValues.violationsFor(
                     values = solvedAnalysis.knownStripValuesByEntryId.values.toList()
                 )
             )
             addAll(
-                hardRules.boardResults.violationsFor(
+                constraints.boardResults.violationsFor(
                     results = solvedPuzzle.board.tiles.map(Tile::result)
                 )
             )
             addAll(
-                hardRules.multiplicationResults.violationsFor(
+                constraints.multiplicationResults.violationsFor(
                     resultsByIndex = solvedAnalysis.resolvedAssignments
                         .filter { assignment -> assignment.operator == Operator.MULTIPLICATION }
                         .associate { assignment ->


### PR DESCRIPTION
## Related Issue

Resolves #492

## Summary

- Rename mandatory generated-puzzle hard-rule types and collaborators to constraint terminology.
- Keep constraint enforcement separate from the existing soft variety plan.
- Preserve generation logic, ordering, randomness, profiles, and validation behavior.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`