### PR TITLE
[239] Model supported generated challenges independently from mode

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
@@ -113,7 +113,7 @@ class AppNavigationLearningFlowTest {
                     generatedSessionRepository = FakeGeneratedSessionRepository(),
                     personalizationPreferencesRepository = FakePersonalizationPreferencesRepository(),
                     topAppBarActionDiscoveryRepository = actionDiscoveryRepository,
-                    generatedModeRegistry = GeneratedModes.registry,
+                    generatedChallengeCatalog = GeneratedModes.catalog,
                     generatedPuzzleGenerationUseCaseFactory = fourPairsProviderFactory(puzzleProvider = puzzleProvider)
                 )
             }
@@ -238,8 +238,8 @@ class AppNavigationLearningFlowTest {
 
     private fun fourPairsProviderFactory(
         puzzleProvider: QueueGeneratedPuzzleProvider
-    ): GeneratedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory { mode ->
-        require(mode == GeneratedModes.FOUR_PAIRS)
+    ): GeneratedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory { challenge ->
+        require(challenge == GeneratedModes.FOUR_PAIRS_LOW)
         GeneratedPuzzleGenerationUseCase { request ->
             GeneratedPuzzleGenerationResult.Generated(
                 request = request,

--- a/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
@@ -164,7 +164,7 @@ class RequiredOnboardingNavigationTest {
                     generatedSessionRepository = FakeGeneratedSessionRepository(),
                     personalizationPreferencesRepository = FakePersonalizationPreferencesRepository(),
                     topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
-                    generatedModeRegistry = GeneratedModes.registry,
+                    generatedChallengeCatalog = GeneratedModes.catalog,
                     generatedPuzzleGenerationUseCaseFactory = generatedPuzzleFactory()
                 )
             }

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/eightpairs/EightPairsModeTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/eightpairs/EightPairsModeTest.kt
@@ -117,7 +117,7 @@ class EightPairsModeTest {
                     generatedSessionRepository = FakeGeneratedSessionRepository(),
                     personalizationPreferencesRepository = FakePersonalizationPreferencesRepository(),
                     topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
-                    generatedModeRegistry = GeneratedModes.registry,
+                    generatedChallengeCatalog = GeneratedModes.catalog,
                     generatedPuzzleGenerationUseCaseFactory = eightPairsProviderFactory(puzzleProvider = puzzleProvider)
                 )
             }
@@ -159,8 +159,8 @@ class EightPairsModeTest {
 
     private fun eightPairsProviderFactory(
         puzzleProvider: RecordingGeneratedPuzzleProvider
-    ): GeneratedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory { mode ->
-        require(mode == GeneratedModes.EIGHT_PAIRS)
+    ): GeneratedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory { challenge ->
+        require(challenge == GeneratedModes.EIGHT_PAIRS_MEDIUM)
         GeneratedPuzzleGenerationUseCase { request ->
             GeneratedPuzzleGenerationResult.Generated(
                 request = request,

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/fourpairs/FourPairsCompletionActionsTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/fourpairs/FourPairsCompletionActionsTest.kt
@@ -213,7 +213,7 @@ class FourPairsCompletionActionsTest {
                     generatedSessionRepository = generatedSessionRepository,
                     personalizationPreferencesRepository = FakePersonalizationPreferencesRepository(),
                     topAppBarActionDiscoveryRepository = actionDiscoveryRepository,
-                    generatedModeRegistry = GeneratedModes.registry,
+                    generatedChallengeCatalog = GeneratedModes.catalog,
                     generatedPuzzleGenerationUseCaseFactory = fourPairsProviderFactory(puzzleProvider = puzzleProvider)
                 )
             }
@@ -327,8 +327,8 @@ class FourPairsCompletionActionsTest {
 
     private fun fourPairsProviderFactory(
         puzzleProvider: QueueGeneratedPuzzleProvider
-    ): GeneratedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory { mode ->
-        require(mode == GeneratedModes.FOUR_PAIRS)
+    ): GeneratedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory { challenge ->
+        require(challenge == GeneratedModes.FOUR_PAIRS_LOW)
         GeneratedPuzzleGenerationUseCase { request ->
             GeneratedPuzzleGenerationResult.Generated(
                 request = request,

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/CorrectTileMotionTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/CorrectTileMotionTest.kt
@@ -116,7 +116,7 @@ class CorrectTileMotionTest {
                         )
                     ),
                     topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
-                    generatedModeRegistry = GeneratedModes.registry,
+                    generatedChallengeCatalog = GeneratedModes.catalog,
                     generatedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory {
                         GeneratedPuzzleGenerationUseCase { request ->
                             GeneratedPuzzleGenerationResult.Generated(

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedAssignmentHapticsTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedAssignmentHapticsTest.kt
@@ -115,7 +115,7 @@ class GeneratedAssignmentHapticsTest {
                         generatedSessionRepository = FakeGeneratedSessionRepository(),
                         personalizationPreferencesRepository = preferencesRepository,
                         topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
-                        generatedModeRegistry = GeneratedModes.registry,
+                        generatedChallengeCatalog = GeneratedModes.catalog,
                         generatedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory {
                             GeneratedPuzzleGenerationUseCase { request ->
                                 GeneratedPuzzleGenerationResult.Generated(

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedCompletionCelebrationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedCompletionCelebrationTest.kt
@@ -134,7 +134,7 @@ class GeneratedCompletionCelebrationTest {
                         )
                     ),
                     topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
-                    generatedModeRegistry = GeneratedModes.registry,
+                    generatedChallengeCatalog = GeneratedModes.catalog,
                     generatedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory {
                         GeneratedPuzzleGenerationUseCase { request ->
                             GeneratedPuzzleGenerationResult.Generated(

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleGenerationRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleGenerationRouteTest.kt
@@ -47,7 +47,7 @@ class GeneratedPuzzleGenerationRouteTest {
         composeTestRule.setContent {
             NumPairsTheme {
                 GeneratedModeRoute(
-                    mode = GeneratedModes.FOUR_PAIRS,
+                    challenge = GeneratedModes.FOUR_PAIRS_LOW,
                     title = "4 pairs",
                     generationUseCase = useCase,
                     generatedSessionRepository = FakeGeneratedSessionRepository()
@@ -104,7 +104,7 @@ class GeneratedPuzzleGenerationRouteTest {
         composeTestRule.setContent {
             NumPairsTheme {
                 GeneratedModeRoute(
-                    mode = GeneratedModes.FOUR_PAIRS,
+                    challenge = GeneratedModes.FOUR_PAIRS_LOW,
                     launchIntent = GeneratedModeLaunchIntent.ResumeSession(snapshot.sessionId),
                     title = "4 pairs",
                     generationUseCase = useCase,
@@ -133,7 +133,7 @@ class GeneratedPuzzleGenerationRouteTest {
         composeTestRule.setContent {
             NumPairsTheme {
                 GeneratedModeRoute(
-                    mode = GeneratedModes.FOUR_PAIRS,
+                    challenge = GeneratedModes.FOUR_PAIRS_LOW,
                     launchIntent = GeneratedModeLaunchIntent.ResumeSession(
                         expectedSessionId = GeneratedSessionId("missing")
                     ),
@@ -166,7 +166,7 @@ class GeneratedPuzzleGenerationRouteTest {
         composeTestRule.setContent {
             NumPairsTheme {
                 GeneratedModeRoute(
-                    mode = GeneratedModes.FOUR_PAIRS,
+                    challenge = GeneratedModes.FOUR_PAIRS_LOW,
                     title = "4 pairs",
                     generationUseCase = CountingGeneratedPuzzleUseCase(),
                     generatedSessionRepository = repository
@@ -254,7 +254,7 @@ private class CountingGeneratedPuzzleUseCase : GeneratedPuzzleGenerationUseCase 
 private fun generatedSessionSnapshot(currentPuzzle: Puzzle) = GeneratedSessionSnapshot(
     sessionId = GeneratedSessionId("resume-session"),
     modeId = GeneratedModes.FOUR_PAIRS.id.value,
-    profileId = GeneratedModes.FOUR_PAIRS.profile.id.value,
+    profileId = GeneratedModes.FOUR_PAIRS_LOW.profile.id.value,
     seed = 211,
     initialPuzzle = samplePuzzle,
     currentPuzzle = currentPuzzle

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedReplacementTransitionTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/GeneratedReplacementTransitionTest.kt
@@ -47,7 +47,7 @@ class GeneratedReplacementTransitionTest {
     @Test
     fun fourPairsKeepsCompletionUntilTheAdoptedSuccessorTransitionsOnce() {
         assertSafeReplacementTransition(
-            mode = GeneratedModes.FOUR_PAIRS,
+            challenge = GeneratedModes.FOUR_PAIRS_LOW,
             menuButtonTag = MenuScreenTestTags.FOUR_PAIRS_BUTTON
         )
     }
@@ -55,19 +55,19 @@ class GeneratedReplacementTransitionTest {
     @Test
     fun eightPairsKeepsCompletionUntilTheAdoptedSuccessorTransitionsOnce() {
         assertSafeReplacementTransition(
-            mode = GeneratedModes.EIGHT_PAIRS,
+            challenge = GeneratedModes.EIGHT_PAIRS_MEDIUM,
             menuButtonTag = MenuScreenTestTags.EIGHT_PAIRS_BUTTON
         )
     }
 
-    private fun assertSafeReplacementTransition(mode: GeneratedModeConfiguration, menuButtonTag: String) {
+    private fun assertSafeReplacementTransition(challenge: GeneratedChallenge, menuButtonTag: String) {
         val successor = CompletableDeferred<Puzzle>()
         val puzzleProvider = ControlledReplacementPuzzleProvider(
             initialPuzzle = oneOperatorAwayFromSolvedReplacementPuzzle(),
             successor = successor
         )
-        val useCaseFactory = GeneratedPuzzleGenerationUseCaseFactory { requestedMode ->
-            require(requestedMode == mode)
+        val useCaseFactory = GeneratedPuzzleGenerationUseCaseFactory { requestedChallenge ->
+            require(requestedChallenge == challenge)
             GeneratedPuzzleGenerationUseCase { request ->
                 GeneratedPuzzleGenerationResult.Generated(
                     request = request,
@@ -89,7 +89,7 @@ class GeneratedReplacementTransitionTest {
                             )
                         ),
                         topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
-                        generatedModeRegistry = GeneratedModes.registry,
+                        generatedChallengeCatalog = GeneratedModes.catalog,
                         generatedPuzzleGenerationUseCaseFactory = useCaseFactory
                     )
                     Text(text = recompositionMarker.toString())

--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceNavigationTest.kt
@@ -28,7 +28,7 @@ import org.cescfe.numpairs.domain.puzzle.model.Strip
 import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.cescfe.numpairs.domain.puzzle.model.Tile
 import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
-import org.cescfe.numpairs.feature.generated.GeneratedModeConfiguration
+import org.cescfe.numpairs.feature.generated.GeneratedChallenge
 import org.cescfe.numpairs.feature.generated.GeneratedModeId
 import org.cescfe.numpairs.feature.generated.GeneratedModes
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationResult
@@ -219,13 +219,13 @@ class GeneratedSessionChoiceNavigationTest {
                     generatedSessionRepository = repository,
                     personalizationPreferencesRepository = FakePersonalizationPreferencesRepository(),
                     topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
-                    generatedModeRegistry = GeneratedModes.registry,
-                    generatedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory { mode ->
+                    generatedChallengeCatalog = GeneratedModes.catalog,
+                    generatedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory { challenge ->
                         GeneratedPuzzleGenerationUseCase { request ->
-                            recorder.generatedModes += mode.id
+                            recorder.generatedModes += challenge.modeId
                             GeneratedPuzzleGenerationResult.Generated(
                                 request = request,
-                                initialPuzzle = initialPuzzleFor(mode)
+                                initialPuzzle = initialPuzzleFor(challenge)
                             )
                         }
                     }
@@ -235,10 +235,10 @@ class GeneratedSessionChoiceNavigationTest {
         return recorder
     }
 
-    private fun initialPuzzleFor(mode: GeneratedModeConfiguration): Puzzle = when (mode.id) {
+    private fun initialPuzzleFor(challenge: GeneratedChallenge): Puzzle = when (challenge.modeId) {
         GeneratedModes.FOUR_PAIRS.id -> samplePuzzle
         GeneratedModes.EIGHT_PAIRS.id -> eightPairsPuzzle()
-        else -> error("Unsupported test mode ${mode.id.value}.")
+        else -> error("Unsupported test mode ${challenge.modeId.value}.")
     }
 
     private fun eightPairsPuzzle(): Puzzle = Puzzle(
@@ -276,7 +276,7 @@ class GeneratedSessionChoiceNavigationTest {
 private fun resumableFourPairsSnapshot(): GeneratedSessionSnapshot = GeneratedSessionSnapshot(
     sessionId = GeneratedSessionId("session-choice"),
     modeId = GeneratedModes.FOUR_PAIRS.id.value,
-    profileId = GeneratedModes.FOUR_PAIRS.profile.id.value,
+    profileId = GeneratedModes.FOUR_PAIRS_LOW.profile.id.value,
     seed = 214,
     initialPuzzle = samplePuzzle,
     currentPuzzle = samplePuzzle

--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionResumeNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionResumeNavigationTest.kt
@@ -51,7 +51,7 @@ class GeneratedSessionResumeNavigationTest {
         val snapshot = GeneratedSessionSnapshot(
             sessionId = GeneratedSessionId("resume-from-menu"),
             modeId = GeneratedModes.FOUR_PAIRS.id.value,
-            profileId = GeneratedModes.FOUR_PAIRS.profile.id.value,
+            profileId = GeneratedModes.FOUR_PAIRS_LOW.profile.id.value,
             seed = 213,
             initialPuzzle = samplePuzzle,
             currentPuzzle = currentPuzzle
@@ -123,7 +123,7 @@ class GeneratedSessionResumeNavigationTest {
                     generatedSessionRepository = repository,
                     personalizationPreferencesRepository = FakePersonalizationPreferencesRepository(),
                     topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
-                    generatedModeRegistry = GeneratedModes.registry,
+                    generatedChallengeCatalog = GeneratedModes.catalog,
                     generatedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory {
                         GeneratedPuzzleGenerationUseCase { request ->
                             generationCounter.count++

--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/PersonalizationNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/PersonalizationNavigationTest.kt
@@ -41,7 +41,7 @@ class PersonalizationNavigationTest {
         val snapshot = GeneratedSessionSnapshot(
             sessionId = GeneratedSessionId("personalization-session"),
             modeId = GeneratedModes.FOUR_PAIRS.id.value,
-            profileId = GeneratedModes.FOUR_PAIRS.profile.id.value,
+            profileId = GeneratedModes.FOUR_PAIRS_LOW.profile.id.value,
             seed = 919,
             initialPuzzle = samplePuzzle,
             currentPuzzle = samplePuzzle
@@ -61,7 +61,7 @@ class PersonalizationNavigationTest {
                     generatedSessionRepository = generatedSessionRepository,
                     personalizationPreferencesRepository = personalizationRepository,
                     topAppBarActionDiscoveryRepository = FakeTopAppBarActionDiscoveryRepository(),
-                    generatedModeRegistry = GeneratedModes.registry,
+                    generatedChallengeCatalog = GeneratedModes.catalog,
                     generatedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory {
                         GeneratedPuzzleGenerationUseCase { request ->
                             GeneratedPuzzleGenerationResult.Generated(

--- a/app/src/main/java/org/cescfe/numpairs/MainActivity.kt
+++ b/app/src/main/java/org/cescfe/numpairs/MainActivity.kt
@@ -34,9 +34,9 @@ class MainActivity : ComponentActivity() {
         val generatedSessionRepository = createGeneratedSessionRepository(applicationContext)
         val personalizationPreferencesRepository = createPersonalizationPreferencesRepository(applicationContext)
         val topAppBarActionDiscoveryRepository = createTopAppBarActionDiscoveryRepository(applicationContext)
-        val generatedModeRegistry = GeneratedModes.registry
+        val generatedChallengeCatalog = GeneratedModes.catalog
         val generatedPuzzleGenerationUseCaseFactory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
-            modeRegistry = generatedModeRegistry
+            challengeCatalog = generatedChallengeCatalog
         )
         lifecycleScope.launch {
             onboardingRuntime.initializer.initialize()
@@ -56,7 +56,7 @@ class MainActivity : ComponentActivity() {
                     generatedSessionRepository = generatedSessionRepository,
                     personalizationPreferencesRepository = personalizationPreferencesRepository,
                     topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
-                    generatedModeRegistry = generatedModeRegistry,
+                    generatedChallengeCatalog = generatedChallengeCatalog,
                     generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory
                 )
             }

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/DifficultyTier.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/DifficultyTier.kt
@@ -1,0 +1,7 @@
+package org.cescfe.numpairs.domain.generated.profile
+
+enum class DifficultyTier {
+    LOW,
+    MEDIUM,
+    HARD
+}

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfile.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfile.kt
@@ -10,6 +10,7 @@ data class GeneratedPuzzleProfileId(val value: String) {
 
 data class GeneratedPuzzleProfileDefinition(
     val id: GeneratedPuzzleProfileId,
+    val difficulty: DifficultyTier,
     val size: GeneratedPuzzleSize,
     val stripValuePolicy: StripValuePolicy,
     val resultConstraints: ResultConstraints,
@@ -20,6 +21,7 @@ data class GeneratedPuzzleProfileDefinition(
 
 class GeneratedPuzzleProfile private constructor(definition: GeneratedPuzzleProfileDefinition) {
     val id: GeneratedPuzzleProfileId = definition.id
+    val difficulty: DifficultyTier = definition.difficulty
     val size: GeneratedPuzzleSize = definition.size
     val stripValuePolicy: StripValuePolicy = definition.stripValuePolicy
     val resultConstraints: ResultConstraints = definition.resultConstraints

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfiles.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfiles.kt
@@ -11,6 +11,7 @@ object GeneratedPuzzleProfiles {
         return GeneratedPuzzleProfile.create(
             definition = GeneratedPuzzleProfileDefinition(
                 id = GeneratedPuzzleProfileId("4-pairs-low"),
+                difficulty = DifficultyTier.LOW,
                 size = size,
                 stripValuePolicy = StripValuePolicy(
                     valueRange = 2..20,
@@ -39,6 +40,7 @@ object GeneratedPuzzleProfiles {
         return GeneratedPuzzleProfile.create(
             definition = GeneratedPuzzleProfileDefinition(
                 id = GeneratedPuzzleProfileId("8-pairs-medium"),
+                difficulty = DifficultyTier.MEDIUM,
                 size = size,
                 stripValuePolicy = StripValuePolicy(
                     valueRange = 1..99,

--- a/app/src/main/java/org/cescfe/numpairs/feature/fourpairs/FourPairsRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/fourpairs/FourPairsRoute.kt
@@ -16,7 +16,7 @@ import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryState
 import org.cescfe.numpairs.feature.game.ui.actions.HintAction
 import org.cescfe.numpairs.feature.game.ui.help.SolvingTipsDialog
-import org.cescfe.numpairs.feature.generated.GeneratedModeConfiguration
+import org.cescfe.numpairs.feature.generated.GeneratedChallenge
 import org.cescfe.numpairs.feature.generated.GeneratedModeLaunchIntent
 import org.cescfe.numpairs.feature.generated.GeneratedModeRoute
 import org.cescfe.numpairs.feature.generated.GeneratedModes
@@ -31,7 +31,7 @@ fun FourPairsRoute(
     modifier: Modifier = Modifier,
     generationUseCase: GeneratedPuzzleGenerationUseCase,
     launchIntent: GeneratedModeLaunchIntent = GeneratedModeLaunchIntent.DefaultNewPuzzle,
-    mode: GeneratedModeConfiguration = GeneratedModes.FOUR_PAIRS,
+    challenge: GeneratedChallenge = GeneratedModes.FOUR_PAIRS_LOW,
     isGeneratedGameHapticsEnabled: Boolean = true,
     tutorialOverlayMode: TutorialMode? = null,
     onTutorialOverlayClosed: () -> Unit = {},
@@ -57,7 +57,7 @@ fun FourPairsRoute(
         modifier = modifier
     ) {
         GeneratedModeRoute(
-            mode = mode,
+            challenge = challenge,
             launchIntent = launchIntent,
             title = stringResource(R.string.four_pairs_screen_title),
             generationUseCase = generationUseCase,

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeConfiguration.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeConfiguration.kt
@@ -1,7 +1,10 @@
 package org.cescfe.numpairs.feature.generated
 
+import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileId
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfiles
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleSize
 
 @JvmInline
 value class GeneratedModeId(val value: String) {
@@ -12,13 +15,70 @@ value class GeneratedModeId(val value: String) {
     }
 }
 
-data class GeneratedModeConfiguration(val id: GeneratedModeId, val profile: GeneratedPuzzleProfile)
+@JvmInline
+value class GeneratedChallengeId(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "Generated challenge id must not be blank."
+        }
+    }
+}
 
-class GeneratedModeRegistry(configurations: Collection<GeneratedModeConfiguration>) {
+data class GeneratedChallenge(
+    val id: GeneratedChallengeId,
+    val modeId: GeneratedModeId,
+    val difficulty: DifficultyTier,
+    val profile: GeneratedPuzzleProfile
+) {
+    init {
+        require(profile.difficulty == difficulty) {
+            "Generated challenge ${id.value} difficulty must match profile ${profile.id.value}."
+        }
+    }
+}
+
+class GeneratedModeConfiguration(
+    val id: GeneratedModeId,
+    val size: GeneratedPuzzleSize,
+    challenges: Collection<GeneratedChallenge>
+) {
+    val challenges: List<GeneratedChallenge> = challenges.toList()
+
+    init {
+        require(this.challenges.isNotEmpty()) {
+            "Generated mode ${id.value} must expose at least one challenge."
+        }
+        require(this.challenges.all { challenge -> challenge.modeId == id }) {
+            "Every generated challenge must belong to mode ${id.value}."
+        }
+        require(this.challenges.all { challenge -> challenge.profile.size == size }) {
+            "Every generated challenge in mode ${id.value} must use the mode puzzle size."
+        }
+        require(this.challenges.map(GeneratedChallenge::id).distinct().size == this.challenges.size) {
+            "Generated challenge ids must be unique within mode ${id.value}."
+        }
+        require(this.challenges.map(GeneratedChallenge::difficulty).distinct().size == this.challenges.size) {
+            "Generated difficulties must be unique within mode ${id.value}."
+        }
+        require(this.challenges.map { challenge -> challenge.profile.id }.distinct().size == this.challenges.size) {
+            "Generated profile ids must be unique within mode ${id.value}."
+        }
+    }
+}
+
+class GeneratedChallengeCatalog(configurations: Collection<GeneratedModeConfiguration>) {
     val all: List<GeneratedModeConfiguration> = configurations.toList()
+    val allChallenges: List<GeneratedChallenge> = all.flatMap(GeneratedModeConfiguration::challenges)
     private val configurationsById: Map<GeneratedModeId, GeneratedModeConfiguration> = all.associateBy(
         GeneratedModeConfiguration::id
     )
+    private val challengesById: Map<GeneratedChallengeId, GeneratedChallenge> = allChallenges.associateBy(
+        GeneratedChallenge::id
+    )
+    private val challengesByModeAndDifficulty: Map<Pair<GeneratedModeId, DifficultyTier>, GeneratedChallenge> =
+        allChallenges.associateBy { challenge -> challenge.modeId to challenge.difficulty }
+    private val challengesByModeAndProfile: Map<Pair<GeneratedModeId, GeneratedPuzzleProfileId>, GeneratedChallenge> =
+        allChallenges.associateBy { challenge -> challenge.modeId to challenge.profile.id }
 
     init {
         require(all.isNotEmpty()) {
@@ -27,26 +87,78 @@ class GeneratedModeRegistry(configurations: Collection<GeneratedModeConfiguratio
         require(configurationsById.size == all.size) {
             "Generated mode ids must be unique."
         }
-        require(all.map(GeneratedModeConfiguration::profile).distinct().size == all.size) {
-            "A generated profile can only belong to one generated mode."
+        require(challengesById.size == allChallenges.size) {
+            "Generated challenge ids must be unique."
+        }
+        require(challengesByModeAndDifficulty.size == allChallenges.size) {
+            "A generated mode can expose only one challenge per difficulty."
+        }
+        require(challengesByModeAndProfile.size == allChallenges.size) {
+            "A generated profile can belong to only one challenge in a mode."
+        }
+        require(allChallenges.map { challenge -> challenge.profile.id }.distinct().size == allChallenges.size) {
+            "A generated profile can belong to only one configured challenge."
         }
     }
 
     fun resolve(id: GeneratedModeId): GeneratedModeConfiguration = requireNotNull(configurationsById[id]) {
         "No generated mode is configured for id ${id.value}."
     }
+
+    fun resolveChallenge(id: GeneratedChallengeId): GeneratedChallenge = requireNotNull(challengesById[id]) {
+        "No generated challenge is configured for id ${id.value}."
+    }
+
+    fun resolveChallenge(modeId: GeneratedModeId, difficulty: DifficultyTier): GeneratedChallenge =
+        requireNotNull(challengesByModeAndDifficulty[modeId to difficulty]) {
+            "No generated challenge is configured for mode ${modeId.value} and difficulty ${difficulty.name}."
+        }
+
+    fun resolveChallenge(modeId: GeneratedModeId, profileId: GeneratedPuzzleProfileId): GeneratedChallenge =
+        requireNotNull(challengesByModeAndProfile[modeId to profileId]) {
+            "No generated challenge is configured for mode ${modeId.value} and profile ${profileId.value}."
+        }
+
+    fun resolveChallengeOrNull(modeId: String, profileId: String): GeneratedChallenge? =
+        allChallenges.singleOrNull { challenge ->
+            challenge.modeId.value == modeId && challenge.profile.id.value == profileId
+        }
+
+    fun modeFor(challenge: GeneratedChallenge): GeneratedModeConfiguration {
+        require(resolveChallenge(id = challenge.id) == challenge) {
+            "Generated challenge ${challenge.id.value} is not configured by this catalog."
+        }
+        return resolve(id = challenge.modeId)
+    }
 }
 
 object GeneratedModes {
-    val FOUR_PAIRS: GeneratedModeConfiguration = GeneratedModeConfiguration(
-        id = GeneratedModeId("four-pairs"),
+    private val fourPairsId = GeneratedModeId("four-pairs")
+    private val eightPairsId = GeneratedModeId("eight-pairs")
+
+    val FOUR_PAIRS_LOW: GeneratedChallenge = GeneratedChallenge(
+        id = GeneratedChallengeId("four-pairs-low"),
+        modeId = fourPairsId,
+        difficulty = DifficultyTier.LOW,
         profile = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW
     )
-    val EIGHT_PAIRS: GeneratedModeConfiguration = GeneratedModeConfiguration(
-        id = GeneratedModeId("eight-pairs"),
+    val EIGHT_PAIRS_MEDIUM: GeneratedChallenge = GeneratedChallenge(
+        id = GeneratedChallengeId("eight-pairs-medium"),
+        modeId = eightPairsId,
+        difficulty = DifficultyTier.MEDIUM,
         profile = GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM
     )
-    val registry: GeneratedModeRegistry = GeneratedModeRegistry(
+    val FOUR_PAIRS: GeneratedModeConfiguration = GeneratedModeConfiguration(
+        id = fourPairsId,
+        size = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW.size,
+        challenges = listOf(FOUR_PAIRS_LOW)
+    )
+    val EIGHT_PAIRS: GeneratedModeConfiguration = GeneratedModeConfiguration(
+        id = eightPairsId,
+        size = GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM.size,
+        challenges = listOf(EIGHT_PAIRS_MEDIUM)
+    )
+    val catalog: GeneratedChallengeCatalog = GeneratedChallengeCatalog(
         configurations = listOf(FOUR_PAIRS, EIGHT_PAIRS)
     )
 }

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeRoute.kt
@@ -47,7 +47,7 @@ import org.cescfe.numpairs.ui.theme.NumPairsComponents
 
 @Composable
 fun GeneratedModeRoute(
-    mode: GeneratedModeConfiguration,
+    challenge: GeneratedChallenge,
     launchIntent: GeneratedModeLaunchIntent = GeneratedModeLaunchIntent.DefaultNewPuzzle,
     title: String,
     generationUseCase: GeneratedPuzzleGenerationUseCase,
@@ -62,7 +62,7 @@ fun GeneratedModeRoute(
     onNavigateBack: () -> Unit = {}
 ) {
     val viewModel = rememberGeneratedPuzzleViewModel(
-        mode = mode,
+        challenge = challenge,
         generationUseCase = generationUseCase,
         generatedSessionRepository = generatedSessionRepository
     )
@@ -428,27 +428,29 @@ private fun GeneratedPuzzleFailureDialog(onRetry: () -> Unit, onNavigateBack: ()
 
 @Composable
 private fun rememberGeneratedPuzzleViewModel(
-    mode: GeneratedModeConfiguration,
+    challenge: GeneratedChallenge,
     generationUseCase: GeneratedPuzzleGenerationUseCase,
     generatedSessionRepository: GeneratedSessionRepository
 ): GeneratedPuzzleViewModel {
     val activity = LocalContext.current.findComponentActivity()
         ?: error("GeneratedModeRoute requires a ComponentActivity host.")
 
-    return remember(activity, mode.id, generationUseCase, generatedSessionRepository) {
+    return remember(activity, challenge.id, generationUseCase, generatedSessionRepository) {
         ViewModelProvider(
             activity,
             GeneratedPuzzleViewModelFactory(
-                mode = mode,
+                challenge = challenge,
                 generationUseCase = generationUseCase,
                 generatedSessionRepository = generatedSessionRepository
             )
-        )["generated-puzzle-${mode.id.value}", GeneratedPuzzleViewModel::class.java]
+        )[challenge.generatedPuzzleViewModelKey(), GeneratedPuzzleViewModel::class.java]
     }
 }
 
+internal fun GeneratedChallenge.generatedPuzzleViewModelKey(): String = "generated-puzzle-${id.value}"
+
 private class GeneratedPuzzleViewModelFactory(
-    private val mode: GeneratedModeConfiguration,
+    private val challenge: GeneratedChallenge,
     private val generationUseCase: GeneratedPuzzleGenerationUseCase,
     private val generatedSessionRepository: GeneratedSessionRepository
 ) : ViewModelProvider.Factory {
@@ -460,7 +462,7 @@ private class GeneratedPuzzleViewModelFactory(
         return requireNotNull(
             modelClass.cast(
                 GeneratedPuzzleViewModel(
-                    mode = mode,
+                    challenge = challenge,
                     generationUseCase = generationUseCase,
                     generatedSessionRepository = generatedSessionRepository
                 )

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleGenerationUseCase.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleGenerationUseCase.kt
@@ -29,38 +29,39 @@ sealed interface GeneratedPuzzleGenerationResult {
 }
 
 fun interface GeneratedPuzzleGenerationUseCaseFactory {
-    fun create(mode: GeneratedModeConfiguration): GeneratedPuzzleGenerationUseCase
+    fun create(challenge: GeneratedChallenge): GeneratedPuzzleGenerationUseCase
 }
 
 class ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
-    private val modeRegistry: GeneratedModeRegistry = GeneratedModes.registry,
+    private val challengeCatalog: GeneratedChallengeCatalog = GeneratedModes.catalog,
     private val generationDispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : GeneratedPuzzleGenerationUseCaseFactory {
-    private val contextByModeId: Map<GeneratedModeId, GeneratedPuzzleGenerationContext> =
-        modeRegistry.all.associate { mode ->
-            mode.id to GeneratedPuzzleGenerationContext.forProfile(profile = mode.profile)
+    private val contextByChallengeId: Map<GeneratedChallengeId, GeneratedPuzzleGenerationContext> =
+        challengeCatalog.allChallenges.associate { challenge ->
+            challenge.id to GeneratedPuzzleGenerationContext.forProfile(profile = challenge.profile)
         }
 
-    override fun create(mode: GeneratedModeConfiguration): GeneratedPuzzleGenerationUseCase {
-        val context = contextFor(mode = mode)
+    override fun create(challenge: GeneratedChallenge): GeneratedPuzzleGenerationUseCase {
+        val context = contextFor(challenge = challenge)
 
         return DispatcherGeneratedPuzzleGenerationUseCase(
             generationDispatcher = generationDispatcher,
             generatorFactory = { request ->
-                require(request.profileId == mode.profile.id) {
-                    "Generation request profile ${request.profileId.value} does not match mode ${mode.id.value}."
+                require(request.profileId == challenge.profile.id) {
+                    "Generation request profile ${request.profileId.value} does not match challenge " +
+                        "${challenge.id.value}."
                 }
                 GeneratedPairsPuzzleGenerator(context = context)
             }
         )
     }
 
-    internal fun contextFor(mode: GeneratedModeConfiguration): GeneratedPuzzleGenerationContext {
-        require(modeRegistry.resolve(id = mode.id) == mode) {
-            "Generated mode ${mode.id.value} is not configured by this generation use-case factory."
+    internal fun contextFor(challenge: GeneratedChallenge): GeneratedPuzzleGenerationContext {
+        require(challengeCatalog.resolveChallenge(id = challenge.id) == challenge) {
+            "Generated challenge ${challenge.id.value} is not configured by this generation use-case factory."
         }
 
-        return contextByModeId.getValue(mode.id)
+        return contextByChallengeId.getValue(challenge.id)
     }
 }
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModel.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModel.kt
@@ -69,7 +69,7 @@ internal sealed interface GeneratedPuzzleGenerationUiState {
 }
 
 internal class GeneratedPuzzleViewModel(
-    private val mode: GeneratedModeConfiguration,
+    private val challenge: GeneratedChallenge,
     private val generationUseCase: GeneratedPuzzleGenerationUseCase,
     private val generatedSessionRepository: GeneratedSessionRepository,
     private val seedSource: GeneratedPuzzleSeedSource = ThreadLocalGeneratedPuzzleSeedSource,
@@ -227,8 +227,8 @@ internal class GeneratedPuzzleViewModel(
             val snapshot = generatedSessionRepository.session.first()
                 ?.takeIf { storedSnapshot ->
                     storedSnapshot.sessionId == launchIntent.expectedSessionId &&
-                        storedSnapshot.modeId == mode.id.value &&
-                        storedSnapshot.profileId == mode.profile.id.value &&
+                        storedSnapshot.modeId == challenge.modeId.value &&
+                        storedSnapshot.profileId == challenge.profile.id.value &&
                         !storedSnapshot.currentPuzzle.isSolved
                 }
             if (token != generationToken) {
@@ -241,7 +241,7 @@ internal class GeneratedPuzzleViewModel(
                     session = GeneratedModeGameSession(
                         snapshot = resumableSnapshot,
                         request = GeneratedPuzzleGenerationRequest(
-                            profile = mode.profile,
+                            profile = challenge.profile,
                             seed = resumableSnapshot.seed
                         )
                     )
@@ -304,7 +304,7 @@ internal class GeneratedPuzzleViewModel(
         val sessionId = sessionIdSource.nextId()
         val snapshot = GeneratedSessionSnapshot(
             sessionId = sessionId,
-            modeId = mode.id.value,
+            modeId = challenge.modeId.value,
             profileId = outcome.request.profileId.value,
             seed = outcome.request.seed,
             initialPuzzle = outcome.initialPuzzle,
@@ -336,7 +336,7 @@ internal class GeneratedPuzzleViewModel(
     }
 
     private fun nextRequest(): GeneratedPuzzleGenerationRequest = GeneratedPuzzleGenerationRequest(
-        profile = mode.profile,
+        profile = challenge.profile,
         seed = seedSource.nextSeed()
     )
 }

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -15,10 +15,11 @@ import org.cescfe.numpairs.data.onboarding.OnboardingState
 import org.cescfe.numpairs.data.preferences.PersonalizationPreferencesRepository
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.feature.fourpairs.FourPairsRoute
+import org.cescfe.numpairs.feature.generated.GeneratedChallenge
+import org.cescfe.numpairs.feature.generated.GeneratedChallengeCatalog
+import org.cescfe.numpairs.feature.generated.GeneratedChallengeId
 import org.cescfe.numpairs.feature.generated.GeneratedModeConfiguration
-import org.cescfe.numpairs.feature.generated.GeneratedModeId
 import org.cescfe.numpairs.feature.generated.GeneratedModeLaunchIntent
-import org.cescfe.numpairs.feature.generated.GeneratedModeRegistry
 import org.cescfe.numpairs.feature.generated.GeneratedModeRoute
 import org.cescfe.numpairs.feature.generated.GeneratedModes
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
@@ -33,8 +34,8 @@ sealed interface AppDestination {
     data object Menu : AppDestination
     data object Tutorial : AppDestination
     data object Personalization : AppDestination
-    data class GeneratedMode(
-        val modeId: GeneratedModeId,
+    data class GeneratedChallenge(
+        val challengeId: GeneratedChallengeId,
         val launchIntent: GeneratedModeLaunchIntent = GeneratedModeLaunchIntent.newPuzzle()
     ) : AppDestination
 }
@@ -45,7 +46,7 @@ fun AppNavigation(
     generatedSessionRepository: GeneratedSessionRepository,
     personalizationPreferencesRepository: PersonalizationPreferencesRepository,
     topAppBarActionDiscoveryRepository: TopAppBarActionDiscoveryRepository,
-    generatedModeRegistry: GeneratedModeRegistry,
+    generatedChallengeCatalog: GeneratedChallengeCatalog,
     generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory,
     modifier: Modifier = Modifier,
     startDestination: AppDestination = AppDestination.Menu
@@ -63,7 +64,7 @@ fun AppNavigation(
             generatedSessionRepository = generatedSessionRepository,
             personalizationPreferencesRepository = personalizationPreferencesRepository,
             topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
-            generatedModeRegistry = generatedModeRegistry,
+            generatedChallengeCatalog = generatedChallengeCatalog,
             generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory,
             modifier = modifier,
             startDestination = startDestination
@@ -76,7 +77,7 @@ private fun UnlockedAppNavigation(
     generatedSessionRepository: GeneratedSessionRepository,
     personalizationPreferencesRepository: PersonalizationPreferencesRepository,
     topAppBarActionDiscoveryRepository: TopAppBarActionDiscoveryRepository,
-    generatedModeRegistry: GeneratedModeRegistry,
+    generatedChallengeCatalog: GeneratedChallengeCatalog,
     generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory,
     modifier: Modifier,
     startDestination: AppDestination
@@ -84,29 +85,29 @@ private fun UnlockedAppNavigation(
     val generatedSessionSnapshot by generatedSessionRepository.session.collectAsState(initial = null)
     val personalizationPreferences by personalizationPreferencesRepository.preferences.collectAsState(initial = null)
     val resumableSession = generatedSessionSnapshot.toResumableGeneratedSessionOrNull(
-        modeRegistry = generatedModeRegistry
+        challengeCatalog = generatedChallengeCatalog
     )
-    var pendingGeneratedModeChoice by remember {
-        mutableStateOf<GeneratedModeConfiguration?>(null)
+    var pendingGeneratedChallengeChoice by remember {
+        mutableStateOf<GeneratedChallenge?>(null)
     }
     var currentDestination by remember(startDestination) {
         mutableStateOf(startDestination)
     }
     val navigateToMenu: () -> Unit = {
-        pendingGeneratedModeChoice = null
+        pendingGeneratedChallengeChoice = null
         currentDestination = AppDestination.Menu
     }
-    val navigateToNewGeneratedPuzzle: (GeneratedModeConfiguration) -> Unit = { mode ->
-        currentDestination = AppDestination.GeneratedMode(
-            modeId = mode.id,
+    val navigateToNewGeneratedPuzzle: (GeneratedChallenge) -> Unit = { challenge ->
+        currentDestination = AppDestination.GeneratedChallenge(
+            challengeId = challenge.id,
             launchIntent = GeneratedModeLaunchIntent.newPuzzle()
         )
     }
-    val onGeneratedModeSelected: (GeneratedModeConfiguration) -> Unit = { selectedMode ->
+    val onGeneratedChallengeSelected: (GeneratedChallenge) -> Unit = { selectedChallenge ->
         if (resumableSession == null) {
-            navigateToNewGeneratedPuzzle(selectedMode)
+            navigateToNewGeneratedPuzzle(selectedChallenge)
         } else {
-            pendingGeneratedModeChoice = selectedMode
+            pendingGeneratedChallengeChoice = selectedChallenge
         }
     }
 
@@ -118,11 +119,13 @@ private fun UnlockedAppNavigation(
         AppDestination.Menu -> {
             MenuRoute(
                 modifier = modifier,
-                resumeModeName = resumableSession?.mode?.localizedTitle(),
+                resumeModeName = resumableSession?.challenge?.let { challenge ->
+                    generatedChallengeCatalog.modeFor(challenge).localizedTitle()
+                },
                 onResumeSelected = {
                     resumableSession?.let { session ->
-                        currentDestination = AppDestination.GeneratedMode(
-                            modeId = session.mode.id,
+                        currentDestination = AppDestination.GeneratedChallenge(
+                            challengeId = session.challenge.id,
                             launchIntent = GeneratedModeLaunchIntent.ResumeSession(
                                 expectedSessionId = session.sessionId
                             )
@@ -136,25 +139,25 @@ private fun UnlockedAppNavigation(
                     currentDestination = AppDestination.Personalization
                 },
                 onFourPairsSelected = {
-                    onGeneratedModeSelected(GeneratedModes.FOUR_PAIRS)
+                    onGeneratedChallengeSelected(GeneratedModes.FOUR_PAIRS_LOW)
                 },
                 onEightPairsSelected = {
-                    onGeneratedModeSelected(GeneratedModes.EIGHT_PAIRS)
+                    onGeneratedChallengeSelected(GeneratedModes.EIGHT_PAIRS_MEDIUM)
                 }
             )
-            val selectedMode = pendingGeneratedModeChoice
-            if (selectedMode != null && resumableSession != null) {
-                val actionGuard = remember(selectedMode.id, resumableSession.sessionId) {
+            val selectedChallenge = pendingGeneratedChallengeChoice
+            if (selectedChallenge != null && resumableSession != null) {
+                val actionGuard = remember(selectedChallenge.id, resumableSession.sessionId) {
                     GeneratedSessionChoiceActionGuard()
                 }
                 GeneratedSessionChoiceDialog(
-                    savedModeName = resumableSession.mode.localizedTitle(),
-                    selectedModeName = selectedMode.localizedTitle(),
+                    savedModeName = generatedChallengeCatalog.modeFor(resumableSession.challenge).localizedTitle(),
+                    selectedModeName = generatedChallengeCatalog.modeFor(selectedChallenge).localizedTitle(),
                     onResume = {
                         actionGuard.handle {
-                            pendingGeneratedModeChoice = null
-                            currentDestination = AppDestination.GeneratedMode(
-                                modeId = resumableSession.mode.id,
+                            pendingGeneratedChallengeChoice = null
+                            currentDestination = AppDestination.GeneratedChallenge(
+                                challengeId = resumableSession.challenge.id,
                                 launchIntent = GeneratedModeLaunchIntent.ResumeSession(
                                     expectedSessionId = resumableSession.sessionId
                                 )
@@ -163,13 +166,13 @@ private fun UnlockedAppNavigation(
                     },
                     onNewPuzzle = {
                         actionGuard.handle {
-                            pendingGeneratedModeChoice = null
-                            navigateToNewGeneratedPuzzle(selectedMode)
+                            pendingGeneratedChallengeChoice = null
+                            navigateToNewGeneratedPuzzle(selectedChallenge)
                         }
                     },
                     onDismiss = {
                         if (!actionGuard.isHandled) {
-                            pendingGeneratedModeChoice = null
+                            pendingGeneratedChallengeChoice = null
                         }
                     }
                 )
@@ -184,16 +187,17 @@ private fun UnlockedAppNavigation(
             onNavigateBack = navigateToMenu,
             modifier = modifier
         )
-        is AppDestination.GeneratedMode -> {
-            val mode = generatedModeRegistry.resolve(id = destination.modeId)
-            val generationUseCase = remember(generatedPuzzleGenerationUseCaseFactory, mode.id) {
-                generatedPuzzleGenerationUseCaseFactory.create(mode = mode)
+        is AppDestination.GeneratedChallenge -> {
+            val challenge = generatedChallengeCatalog.resolveChallenge(id = destination.challengeId)
+            val mode = generatedChallengeCatalog.modeFor(challenge)
+            val generationUseCase = remember(generatedPuzzleGenerationUseCaseFactory, challenge.id) {
+                generatedPuzzleGenerationUseCaseFactory.create(challenge = challenge)
             }
 
             when (mode.id) {
                 GeneratedModes.FOUR_PAIRS.id -> FourPairsRoute(
                     modifier = modifier,
-                    mode = mode,
+                    challenge = challenge,
                     launchIntent = destination.launchIntent,
                     generationUseCase = generationUseCase,
                     generatedSessionRepository = generatedSessionRepository,
@@ -204,7 +208,7 @@ private fun UnlockedAppNavigation(
                 )
 
                 else -> GeneratedModeRoute(
-                    mode = mode,
+                    challenge = challenge,
                     launchIntent = destination.launchIntent,
                     title = mode.localizedTitle(),
                     generationUseCase = generationUseCase,

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/ResumableGeneratedSession.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/ResumableGeneratedSession.kt
@@ -2,28 +2,26 @@ package org.cescfe.numpairs.ui.navigation
 
 import org.cescfe.numpairs.data.generated.session.GeneratedSessionId
 import org.cescfe.numpairs.data.generated.session.GeneratedSessionSnapshot
-import org.cescfe.numpairs.feature.generated.GeneratedModeConfiguration
-import org.cescfe.numpairs.feature.generated.GeneratedModeRegistry
+import org.cescfe.numpairs.feature.generated.GeneratedChallenge
+import org.cescfe.numpairs.feature.generated.GeneratedChallengeCatalog
 
-internal data class ResumableGeneratedSession(val sessionId: GeneratedSessionId, val mode: GeneratedModeConfiguration)
+internal data class ResumableGeneratedSession(val sessionId: GeneratedSessionId, val challenge: GeneratedChallenge)
 
 internal fun GeneratedSessionSnapshot?.toResumableGeneratedSessionOrNull(
-    modeRegistry: GeneratedModeRegistry
+    challengeCatalog: GeneratedChallengeCatalog
 ): ResumableGeneratedSession? {
     val snapshot = this ?: return null
     if (snapshot.currentPuzzle.isSolved) {
         return null
     }
 
-    val mode = modeRegistry.all.singleOrNull { configuration ->
-        configuration.id.value == snapshot.modeId
-    } ?: return null
-    if (mode.profile.id.value != snapshot.profileId) {
-        return null
-    }
+    val challenge = challengeCatalog.resolveChallengeOrNull(
+        modeId = snapshot.modeId,
+        profileId = snapshot.profileId
+    ) ?: return null
 
     return ResumableGeneratedSession(
         sessionId = snapshot.sessionId,
-        mode = mode
+        challenge = challenge
     )
 }

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPairsPuzzleGeneratorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPairsPuzzleGeneratorTest.kt
@@ -3,6 +3,7 @@ package org.cescfe.numpairs.domain.generated.generation
 import kotlin.random.Random
 import org.cescfe.numpairs.domain.generated.generation.internal.GeneratedPairsStripEntryVisibilityDirective
 import org.cescfe.numpairs.domain.generated.generation.internal.GeneratedPairsVariationPlanSelector
+import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileDefinition
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileId
@@ -91,6 +92,7 @@ class GeneratedPairsPuzzleGeneratorTest {
         val profile = GeneratedPuzzleProfile.create(
             definition = GeneratedPuzzleProfileDefinition(
                 id = GeneratedPuzzleProfileId("joint-soft-mask-fallback"),
+                difficulty = DifficultyTier.LOW,
                 size = size,
                 stripValuePolicy = StripValuePolicy(
                     valueRange = 2..5,

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsValuePairSelectorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsValuePairSelectorTest.kt
@@ -1,6 +1,7 @@
 package org.cescfe.numpairs.domain.generated.generation.internal
 
 import kotlin.random.Random
+import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileDefinition
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileId
@@ -102,6 +103,7 @@ private fun singlePairProfile(id: String, valueRange: IntRange, maxMultiplicatio
     return GeneratedPuzzleProfile.create(
         definition = GeneratedPuzzleProfileDefinition(
             id = GeneratedPuzzleProfileId(id),
+            difficulty = DifficultyTier.LOW,
             size = size,
             stripValuePolicy = StripValuePolicy(
                 valueRange = valueRange,

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsVariationPlanSelectorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsVariationPlanSelectorTest.kt
@@ -113,6 +113,7 @@ private fun GeneratedPuzzleProfile.withTargetProbabilities(percentage: Int): Gen
     GeneratedPuzzleProfile.create(
         definition = GeneratedPuzzleProfileDefinition(
             id = id,
+            difficulty = difficulty,
             size = size,
             stripValuePolicy = stripValuePolicy,
             resultConstraints = resultConstraints,

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileTest.kt
@@ -529,6 +529,7 @@ private fun GeneratedPuzzleProfileCreation.Rejected.singleLimitViolation():
 
 private fun smallestBoundedDefinition(): GeneratedPuzzleProfileDefinition = GeneratedPuzzleProfileDefinition(
     id = GeneratedPuzzleProfileId("smallest-bounded-profile"),
+    difficulty = DifficultyTier.LOW,
     size = GeneratedPuzzleSize(pairCount = 1),
     stripValuePolicy = StripValuePolicy(
         valueRange = 2..3,
@@ -549,6 +550,7 @@ private fun smallestBoundedDefinition(): GeneratedPuzzleProfileDefinition = Gene
 
 private fun validDefinition(): GeneratedPuzzleProfileDefinition = GeneratedPuzzleProfileDefinition(
     id = GeneratedPuzzleProfileId("valid-test-profile"),
+    difficulty = DifficultyTier.LOW,
     size = GeneratedPuzzleSize(pairCount = 2),
     stripValuePolicy = StripValuePolicy(
         valueRange = 2..10,

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/ConfiguredGeneratedPuzzleGenerationUseCaseFactoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/ConfiguredGeneratedPuzzleGenerationUseCaseFactoryTest.kt
@@ -3,6 +3,7 @@ package org.cescfe.numpairs.feature.generated
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.cescfe.numpairs.domain.generated.generation.GeneratedPuzzleGenerationRequest
+import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileDefinition
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileId
@@ -22,74 +23,98 @@ import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.cescfe.numpairs.domain.puzzle.model.Tile
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ConfiguredGeneratedPuzzleGenerationUseCaseFactoryTest {
     @Test
-    fun every_registered_mode_uses_its_configured_profile_and_a_shared_context() = runBlocking {
+    fun every_registered_challenge_uses_its_profile_and_a_shared_context() = runBlocking {
         val factory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
             generationDispatcher = Dispatchers.Unconfined
         )
 
-        GeneratedModes.registry.all.forEach { mode ->
-            val outcome = factory.create(mode = mode).generate(
-                GeneratedPuzzleGenerationRequest(profile = mode.profile, seed = 2026)
+        GeneratedModes.catalog.allChallenges.forEach { challenge ->
+            val outcome = factory.create(challenge = challenge).generate(
+                GeneratedPuzzleGenerationRequest(profile = challenge.profile, seed = 2026)
             )
             val puzzle = (outcome as GeneratedPuzzleGenerationResult.Generated).initialPuzzle
 
-            assertEquals(mode.profile.size.boardTileCount, puzzle.board.tiles.size)
-            assertEquals(mode.profile.size.stripEntryCount, puzzle.strip.entries.size)
+            assertEquals(challenge.profile.size.boardTileCount, puzzle.board.tiles.size)
+            assertEquals(challenge.profile.size.stripEntryCount, puzzle.strip.entries.size)
             assertEquals(PuzzleCompletionState.INCOMPLETE, puzzle.completionState)
             assertTrue(puzzle.board.tiles.all(Tile::hasHiddenExpression))
             assertTrue(
                 puzzle.strip.entries.count { entry -> entry.item is StripItem.Known } in
-                    mode.profile.initialStripMaskPolicy.knownEntryCountRange
+                    challenge.profile.initialStripMaskPolicy.knownEntryCountRange
             )
             assertTrue(
                 puzzle.strip.entries.count { entry -> entry.item == StripItem.Hidden } in
-                    mode.profile.hiddenEntryCountRange
+                    challenge.profile.hiddenEntryCountRange
             )
             assertSame(
-                factory.contextFor(mode = mode),
-                factory.contextFor(mode = mode)
+                factory.contextFor(challenge = challenge),
+                factory.contextFor(challenge = challenge)
             )
         }
     }
 
     @Test
     fun identical_requests_produce_identical_puzzles_without_sharing_a_generator_random_stream() = runBlocking {
-        val mode = GeneratedModes.EIGHT_PAIRS
+        val challenge = GeneratedModes.EIGHT_PAIRS_MEDIUM
         val factory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
             generationDispatcher = Dispatchers.Unconfined
         )
-        val request = GeneratedPuzzleGenerationRequest(profile = mode.profile, seed = 1234)
+        val request = GeneratedPuzzleGenerationRequest(profile = challenge.profile, seed = 1234)
 
-        val first = factory.create(mode = mode).generate(request)
-        val second = factory.create(mode = mode).generate(request)
+        val first = factory.create(challenge = challenge).generate(request)
+        val second = factory.create(challenge = challenge).generate(request)
 
         assertEquals(first, second)
     }
 
     @Test
-    fun a_test_only_third_mode_needs_only_one_configuration_entry() = runBlocking {
-        val thirdMode = GeneratedModeConfiguration(
-            id = GeneratedModeId("test-two-pairs"),
-            profile = testTwoPairsProfile()
+    fun a_test_only_third_mode_needs_only_one_challenge_entry() = runBlocking {
+        val profile = testTwoPairsProfile()
+        val modeId = GeneratedModeId("test-two-pairs")
+        val challenge = GeneratedChallenge(
+            id = GeneratedChallengeId("test-two-pairs-low"),
+            modeId = modeId,
+            difficulty = DifficultyTier.LOW,
+            profile = profile
         )
-        val registry = GeneratedModeRegistry(GeneratedModes.registry.all + thirdMode)
+        val thirdMode = GeneratedModeConfiguration(
+            id = modeId,
+            size = profile.size,
+            challenges = listOf(challenge)
+        )
+        val catalog = GeneratedChallengeCatalog(GeneratedModes.catalog.all + thirdMode)
         val factory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
-            modeRegistry = registry,
+            challengeCatalog = catalog,
             generationDispatcher = Dispatchers.Unconfined
         )
 
-        val outcome = factory.create(mode = thirdMode).generate(
-            GeneratedPuzzleGenerationRequest(profile = thirdMode.profile, seed = 42)
+        val outcome = factory.create(challenge = challenge).generate(
+            GeneratedPuzzleGenerationRequest(profile = profile, seed = 42)
         )
         val puzzle = (outcome as GeneratedPuzzleGenerationResult.Generated).initialPuzzle
 
-        assertEquals(thirdMode.profile.size.boardTileCount, puzzle.board.tiles.size)
-        assertEquals(thirdMode.profile.size.stripEntryCount, puzzle.strip.entries.size)
+        assertEquals(thirdMode.size.boardTileCount, puzzle.board.tiles.size)
+        assertEquals(thirdMode.size.stripEntryCount, puzzle.strip.entries.size)
+    }
+
+    @Test
+    fun an_unconfigured_challenge_cannot_create_generation_state() {
+        val unconfigured = GeneratedModes.FOUR_PAIRS_LOW.copy(
+            id = GeneratedChallengeId("unconfigured-four-pairs-low")
+        )
+        val factory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
+            generationDispatcher = Dispatchers.Unconfined
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            factory.contextFor(challenge = unconfigured)
+        }
     }
 }
 
@@ -100,6 +125,7 @@ private fun Tile.hasHiddenExpression(): Boolean = expression.leftOperand == Expr
 private fun testTwoPairsProfile(): GeneratedPuzzleProfile = GeneratedPuzzleProfile.create(
     definition = GeneratedPuzzleProfileDefinition(
         id = GeneratedPuzzleProfileId("test-two-pairs"),
+        difficulty = DifficultyTier.LOW,
         size = GeneratedPuzzleSize(pairCount = 2),
         stripValuePolicy = StripValuePolicy(
             valueRange = 2..12,

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedChallengeCatalogTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedChallengeCatalogTest.kt
@@ -1,0 +1,238 @@
+package org.cescfe.numpairs.feature.generated
+
+import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileDefinition
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileId
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfiles
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleSize
+import org.cescfe.numpairs.domain.generated.profile.GenerationPolicy
+import org.cescfe.numpairs.domain.generated.profile.InitialStripMaskPolicy
+import org.cescfe.numpairs.domain.generated.profile.RequiredKnownStripAnchor
+import org.cescfe.numpairs.domain.generated.profile.ResultConstraints
+import org.cescfe.numpairs.domain.generated.profile.StripKnownEntryDistributionPolicy
+import org.cescfe.numpairs.domain.generated.profile.StripValuePolicy
+import org.cescfe.numpairs.domain.generated.profile.getOrThrow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class GeneratedChallengeCatalogTest {
+    @Test
+    fun difficulty_tiers_are_closed_and_independent_from_size() {
+        assertEquals(
+            listOf(DifficultyTier.LOW, DifficultyTier.MEDIUM, DifficultyTier.HARD),
+            DifficultyTier.entries
+        )
+        assertEquals(DifficultyTier.LOW, GeneratedPuzzleProfiles.FOUR_PAIRS_LOW.difficulty)
+        assertEquals(DifficultyTier.MEDIUM, GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM.difficulty)
+    }
+
+    @Test
+    fun configured_catalog_contains_only_the_two_existing_challenges() {
+        assertEquals("four-pairs", GeneratedModes.FOUR_PAIRS.id.value)
+        assertEquals("eight-pairs", GeneratedModes.EIGHT_PAIRS.id.value)
+        assertEquals("4-pairs-low", GeneratedModes.FOUR_PAIRS_LOW.profile.id.value)
+        assertEquals("8-pairs-medium", GeneratedModes.EIGHT_PAIRS_MEDIUM.profile.id.value)
+        assertEquals(
+            listOf(GeneratedModes.FOUR_PAIRS_LOW, GeneratedModes.EIGHT_PAIRS_MEDIUM),
+            GeneratedModes.catalog.allChallenges
+        )
+        assertSame(
+            GeneratedModes.FOUR_PAIRS_LOW,
+            GeneratedModes.catalog.resolveChallenge(
+                modeId = GeneratedModes.FOUR_PAIRS.id,
+                difficulty = DifficultyTier.LOW
+            )
+        )
+        assertSame(
+            GeneratedModes.EIGHT_PAIRS_MEDIUM,
+            GeneratedModes.catalog.resolveChallenge(
+                modeId = GeneratedModes.EIGHT_PAIRS.id,
+                profileId = GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM.id
+            )
+        )
+    }
+
+    @Test
+    fun one_mode_can_expose_multiple_difficulties_with_the_same_size() {
+        val modeId = GeneratedModeId("four-pairs-test")
+        val low = challenge(
+            id = "four-pairs-test-low",
+            modeId = modeId,
+            profile = fourPairsProfile(id = "four-pairs-test-low-profile", difficulty = DifficultyTier.LOW)
+        )
+        val medium = challenge(
+            id = "four-pairs-test-medium",
+            modeId = modeId,
+            profile = fourPairsProfile(id = "four-pairs-test-medium-profile", difficulty = DifficultyTier.MEDIUM)
+        )
+        val mode = GeneratedModeConfiguration(
+            id = modeId,
+            size = low.profile.size,
+            challenges = listOf(low, medium)
+        )
+        val catalog = GeneratedChallengeCatalog(listOf(mode))
+
+        assertSame(low, catalog.resolveChallenge(modeId = modeId, difficulty = DifficultyTier.LOW))
+        assertSame(medium, catalog.resolveChallenge(modeId = modeId, difficulty = DifficultyTier.MEDIUM))
+        assertNotEquals(low.generatedPuzzleViewModelKey(), medium.generatedPuzzleViewModelKey())
+    }
+
+    @Test
+    fun challenge_and_mode_reject_profile_difficulty_size_and_ownership_mismatches() {
+        val modeId = GeneratedModeId("mismatch-mode")
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedChallenge(
+                id = GeneratedChallengeId("difficulty-mismatch"),
+                modeId = modeId,
+                difficulty = DifficultyTier.HARD,
+                profile = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW
+            )
+        }
+
+        val validChallenge = GeneratedChallenge(
+            id = GeneratedChallengeId("size-mismatch"),
+            modeId = modeId,
+            difficulty = DifficultyTier.LOW,
+            profile = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW
+        )
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedModeConfiguration(
+                id = modeId,
+                size = GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM.size,
+                challenges = listOf(validChallenge)
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedModeConfiguration(
+                id = GeneratedModeId("different-owner"),
+                size = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW.size,
+                challenges = listOf(validChallenge)
+            )
+        }
+    }
+
+    @Test
+    fun catalog_rejects_duplicate_challenge_difficulty_and_profile_identities() {
+        val firstModeId = GeneratedModeId("first-mode")
+        val secondModeId = GeneratedModeId("second-mode")
+        val firstProfile = fourPairsProfile(id = "first-profile", difficulty = DifficultyTier.LOW)
+        val secondProfile = fourPairsProfile(id = "second-profile", difficulty = DifficultyTier.MEDIUM)
+        val duplicateId = GeneratedChallengeId("duplicate-challenge")
+        val firstChallenge = GeneratedChallenge(
+            id = duplicateId,
+            modeId = firstModeId,
+            difficulty = firstProfile.difficulty,
+            profile = firstProfile
+        )
+        val secondChallenge = GeneratedChallenge(
+            id = duplicateId,
+            modeId = secondModeId,
+            difficulty = secondProfile.difficulty,
+            profile = secondProfile
+        )
+        val firstMode = GeneratedModeConfiguration(
+            id = firstModeId,
+            size = firstProfile.size,
+            challenges = listOf(firstChallenge)
+        )
+        val secondMode = GeneratedModeConfiguration(
+            id = secondModeId,
+            size = secondProfile.size,
+            challenges = listOf(secondChallenge)
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedChallengeCatalog(listOf(firstMode, secondMode))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedModeConfiguration(
+                id = firstModeId,
+                size = firstProfile.size,
+                challenges = listOf(
+                    firstChallenge,
+                    firstChallenge.copy(id = GeneratedChallengeId("same-difficulty"))
+                )
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedChallengeCatalog(
+                listOf(
+                    firstMode,
+                    GeneratedModeConfiguration(
+                        id = secondModeId,
+                        size = firstProfile.size,
+                        challenges = listOf(
+                            firstChallenge.copy(
+                                id = GeneratedChallengeId("reused-profile"),
+                                modeId = secondModeId
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun unsupported_mode_difficulty_profile_and_challenge_resolutions_are_rejected() {
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedModes.catalog.resolveChallenge(GeneratedChallengeId("unknown"))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedModes.catalog.resolveChallenge(
+                modeId = GeneratedModes.FOUR_PAIRS.id,
+                difficulty = DifficultyTier.HARD
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedModes.catalog.resolveChallenge(
+                modeId = GeneratedModes.FOUR_PAIRS.id,
+                profileId = GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM.id
+            )
+        }
+        assertEquals(
+            null,
+            GeneratedModes.catalog.resolveChallengeOrNull(
+                modeId = GeneratedModes.FOUR_PAIRS.id.value,
+                profileId = GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM.id.value
+            )
+        )
+    }
+}
+
+private fun challenge(id: String, modeId: GeneratedModeId, profile: GeneratedPuzzleProfile): GeneratedChallenge =
+    GeneratedChallenge(
+        id = GeneratedChallengeId(id),
+        modeId = modeId,
+        difficulty = profile.difficulty,
+        profile = profile
+    )
+
+private fun fourPairsProfile(id: String, difficulty: DifficultyTier): GeneratedPuzzleProfile =
+    GeneratedPuzzleProfile.create(
+        definition = GeneratedPuzzleProfileDefinition(
+            id = GeneratedPuzzleProfileId(id),
+            difficulty = difficulty,
+            size = GeneratedPuzzleSize(pairCount = 4),
+            stripValuePolicy = StripValuePolicy(
+                valueRange = 2..20,
+                maxOccurrencesPerValue = 1
+            ),
+            resultConstraints = ResultConstraints(
+                maxMultiplicationResult = 150,
+                allowsDuplicateBoardResults = false
+            ),
+            initialStripMaskPolicy = InitialStripMaskPolicy(
+                knownEntryCountRange = 3..3,
+                requiredAnchors = setOf(RequiredKnownStripAnchor.HIGHEST_STRIP_ENTRY),
+                distributionPolicy =
+                StripKnownEntryDistributionPolicy.SPREAD_ACROSS_STRIP_AND_PAIRS_WHEN_POSSIBLE,
+                maxConsecutiveHiddenEntries = 2
+            ),
+            generationPolicy = GenerationPolicy(isBoardTileShufflingEnabled = true)
+        )
+    ).getOrThrow()

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModelTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedPuzzleViewModelTest.kt
@@ -48,7 +48,7 @@ class GeneratedPuzzleViewModelTest {
         val writeGate = CompletableDeferred<Unit>()
         val repository = RecordingGeneratedSessionRepository(writeGate = writeGate)
         val viewModel = GeneratedPuzzleViewModel(
-            mode = GeneratedModes.FOUR_PAIRS,
+            challenge = GeneratedModes.FOUR_PAIRS_LOW,
             generationUseCase = generatedPuzzleUseCase(),
             generatedSessionRepository = repository,
             seedSource = QueueGeneratedPuzzleSeedSource(17),
@@ -62,7 +62,7 @@ class GeneratedPuzzleViewModelTest {
         val attemptedSnapshot = repository.replaceAttempts.single()
         assertEquals(GeneratedSessionId("stable-session"), attemptedSnapshot.sessionId)
         assertEquals(GeneratedModes.FOUR_PAIRS.id.value, attemptedSnapshot.modeId)
-        assertEquals(GeneratedModes.FOUR_PAIRS.profile.id.value, attemptedSnapshot.profileId)
+        assertEquals(GeneratedModes.FOUR_PAIRS_LOW.profile.id.value, attemptedSnapshot.profileId)
         assertEquals(17, attemptedSnapshot.seed)
         assertEquals(samplePuzzle, attemptedSnapshot.initialPuzzle)
         assertEquals(samplePuzzle, attemptedSnapshot.currentPuzzle)
@@ -89,7 +89,7 @@ class GeneratedPuzzleViewModelTest {
         )
         val repository = RecordingGeneratedSessionRepository()
         val viewModel = GeneratedPuzzleViewModel(
-            mode = GeneratedModes.FOUR_PAIRS,
+            challenge = GeneratedModes.FOUR_PAIRS_LOW,
             generationUseCase = useCase,
             generatedSessionRepository = repository,
             seedSource = QueueGeneratedPuzzleSeedSource(11, 22, 33),
@@ -141,7 +141,7 @@ class GeneratedPuzzleViewModelTest {
         val replacementWriteGate = CompletableDeferred<Unit>()
         val repository = RecordingGeneratedSessionRepository()
         val viewModel = GeneratedPuzzleViewModel(
-            mode = GeneratedModes.FOUR_PAIRS,
+            challenge = GeneratedModes.FOUR_PAIRS_LOW,
             generationUseCase = QueueGeneratedPuzzleUseCase(
                 CompletableDeferred(samplePuzzle),
                 CompletableDeferred(samplePuzzle)
@@ -184,7 +184,7 @@ class GeneratedPuzzleViewModelTest {
         val readySession = GeneratedModeGameSession(
             snapshot = readySnapshot,
             request = GeneratedPuzzleGenerationRequest(
-                profile = GeneratedModes.FOUR_PAIRS.profile,
+                profile = GeneratedModes.FOUR_PAIRS_LOW.profile,
                 seed = readySnapshot.seed
             )
         )
@@ -212,7 +212,7 @@ class GeneratedPuzzleViewModelTest {
         val existingSnapshot = generatedSessionSnapshot(sessionId = "existing")
         val repository = RecordingGeneratedSessionRepository(initialSession = existingSnapshot)
         val viewModel = GeneratedPuzzleViewModel(
-            mode = GeneratedModes.FOUR_PAIRS,
+            challenge = GeneratedModes.FOUR_PAIRS_LOW,
             generationUseCase = generatedPuzzleUseCase(generatedPuzzle),
             generatedSessionRepository = repository,
             seedSource = QueueGeneratedPuzzleSeedSource(29),
@@ -237,7 +237,7 @@ class GeneratedPuzzleViewModelTest {
             replaceFailure = IOException("storage unavailable")
         )
         val viewModel = GeneratedPuzzleViewModel(
-            mode = GeneratedModes.FOUR_PAIRS,
+            challenge = GeneratedModes.FOUR_PAIRS_LOW,
             generationUseCase = generatedPuzzleUseCase(),
             generatedSessionRepository = repository,
             seedSource = QueueGeneratedPuzzleSeedSource(31),
@@ -266,7 +266,7 @@ class GeneratedPuzzleViewModelTest {
         val repository = RecordingGeneratedSessionRepository(initialSession = snapshot)
         val generationUseCase = UnexpectedGeneratedPuzzleUseCase()
         val viewModel = GeneratedPuzzleViewModel(
-            mode = GeneratedModes.FOUR_PAIRS,
+            challenge = GeneratedModes.FOUR_PAIRS_LOW,
             generationUseCase = generationUseCase,
             generatedSessionRepository = repository
         )
@@ -302,7 +302,7 @@ class GeneratedPuzzleViewModelTest {
             ),
             generatedSessionSnapshot(
                 sessionId = expectedSessionId.value,
-                profileId = GeneratedModes.EIGHT_PAIRS.profile.id.value
+                profileId = GeneratedModes.EIGHT_PAIRS_MEDIUM.profile.id.value
             ),
             generatedSessionSnapshot(
                 sessionId = expectedSessionId.value,
@@ -315,7 +315,7 @@ class GeneratedPuzzleViewModelTest {
             val repository = RecordingGeneratedSessionRepository(initialSession = storedSnapshot)
             val generationUseCase = UnexpectedGeneratedPuzzleUseCase()
             val viewModel = GeneratedPuzzleViewModel(
-                mode = GeneratedModes.FOUR_PAIRS,
+                challenge = GeneratedModes.FOUR_PAIRS_LOW,
                 generationUseCase = generationUseCase,
                 generatedSessionRepository = repository
             )
@@ -341,7 +341,7 @@ class GeneratedPuzzleViewModelTest {
         val firstWriteGate = CompletableDeferred<Unit>()
         val repository = RecordingGeneratedSessionRepository(firstUpdateGate = firstWriteGate)
         val viewModel = GeneratedPuzzleViewModel(
-            mode = GeneratedModes.FOUR_PAIRS,
+            challenge = GeneratedModes.FOUR_PAIRS_LOW,
             generationUseCase = generatedPuzzleUseCase(),
             generatedSessionRepository = repository,
             seedSource = QueueGeneratedPuzzleSeedSource(41),
@@ -379,7 +379,7 @@ class GeneratedPuzzleViewModelTest {
         val initialPuzzle = initialPuzzleFor(solvedPuzzle)
         val repository = RecordingGeneratedSessionRepository()
         val viewModel = GeneratedPuzzleViewModel(
-            mode = GeneratedModes.FOUR_PAIRS,
+            challenge = GeneratedModes.FOUR_PAIRS_LOW,
             generationUseCase = generatedPuzzleUseCase(CompletableDeferred(initialPuzzle)),
             generatedSessionRepository = repository,
             seedSource = QueueGeneratedPuzzleSeedSource(43),
@@ -403,7 +403,7 @@ class GeneratedPuzzleViewModelTest {
         val replacementPuzzle = CompletableDeferred<Puzzle>()
         val repository = RecordingGeneratedSessionRepository()
         val viewModel = GeneratedPuzzleViewModel(
-            mode = GeneratedModes.FOUR_PAIRS,
+            challenge = GeneratedModes.FOUR_PAIRS_LOW,
             generationUseCase = QueueGeneratedPuzzleUseCase(
                 CompletableDeferred(samplePuzzle),
                 replacementPuzzle
@@ -447,7 +447,7 @@ class GeneratedPuzzleViewModelTest {
         val replacementPuzzle = CompletableDeferred<Puzzle>()
         val repository = RecordingGeneratedSessionRepository()
         val viewModel = GeneratedPuzzleViewModel(
-            mode = GeneratedModes.FOUR_PAIRS,
+            challenge = GeneratedModes.FOUR_PAIRS_LOW,
             generationUseCase = QueueGeneratedPuzzleUseCase(
                 CompletableDeferred(samplePuzzle),
                 replacementPuzzle
@@ -608,7 +608,7 @@ private class RecordingGeneratedSessionRepository(
 private fun generatedSessionSnapshot(
     sessionId: String,
     modeId: String = GeneratedModes.FOUR_PAIRS.id.value,
-    profileId: String = GeneratedModes.FOUR_PAIRS.profile.id.value,
+    profileId: String = GeneratedModes.FOUR_PAIRS_LOW.profile.id.value,
     initialPuzzle: Puzzle = samplePuzzle,
     currentPuzzle: Puzzle = samplePuzzle
 ): GeneratedSessionSnapshot = GeneratedSessionSnapshot(

--- a/app/src/test/java/org/cescfe/numpairs/ui/navigation/ResumableGeneratedSessionTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/ui/navigation/ResumableGeneratedSessionTest.kt
@@ -14,15 +14,15 @@ import org.junit.Test
 
 class ResumableGeneratedSessionTest {
     @Test
-    fun `valid unfinished snapshot resolves its configured generated mode`() {
+    fun `valid unfinished snapshot resolves its exact configured challenge`() {
         val snapshot = snapshot()
 
         assertEquals(
             ResumableGeneratedSession(
                 sessionId = snapshot.sessionId,
-                mode = GeneratedModes.FOUR_PAIRS
+                challenge = GeneratedModes.FOUR_PAIRS_LOW
             ),
-            snapshot.toResumableGeneratedSessionOrNull(GeneratedModes.registry)
+            snapshot.toResumableGeneratedSessionOrNull(GeneratedModes.catalog)
         )
     }
 
@@ -32,7 +32,7 @@ class ResumableGeneratedSessionTest {
         val unavailableSnapshots = listOf(
             null,
             snapshot(modeId = "unknown-mode"),
-            snapshot(profileId = GeneratedModes.EIGHT_PAIRS.profile.id.value),
+            snapshot(profileId = GeneratedModes.EIGHT_PAIRS_MEDIUM.profile.id.value),
             snapshot(
                 initialPuzzle = initialPuzzleFor(solvedPuzzle),
                 currentPuzzle = solvedPuzzle
@@ -42,7 +42,7 @@ class ResumableGeneratedSessionTest {
         unavailableSnapshots.forEach { unavailableSnapshot ->
             assertNull(
                 unavailableSnapshot.toResumableGeneratedSessionOrNull(
-                    modeRegistry = GeneratedModes.registry
+                    challengeCatalog = GeneratedModes.catalog
                 )
             )
         }
@@ -51,7 +51,7 @@ class ResumableGeneratedSessionTest {
 
 private fun snapshot(
     modeId: String = GeneratedModes.FOUR_PAIRS.id.value,
-    profileId: String = GeneratedModes.FOUR_PAIRS.profile.id.value,
+    profileId: String = GeneratedModes.FOUR_PAIRS_LOW.profile.id.value,
     initialPuzzle: Puzzle = samplePuzzle,
     currentPuzzle: Puzzle = samplePuzzle
 ): GeneratedSessionSnapshot = GeneratedSessionSnapshot(


### PR DESCRIPTION
## Related Issue

Resolves #493

## Summary

- Add closed difficulty tiers and explicit generated challenge identity.
- Replace the one-profile-per-mode registry with a validated sparse challenge catalog.
- Resolve generation, resumable snapshots, navigation, replay, and retained ViewModel ownership through the selected challenge.
- Keep only 4 Pairs Low and 8 Pairs Medium configured, preserving their stored mode and profile ids and all current player behavior.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew spotlessCheck`
- `./gradlew lintDebug`