### PR TITLE
[240] Add bounded generated puzzle difficulty assessment

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPairsDifficultyAssessor.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPairsDifficultyAssessor.kt
@@ -1,0 +1,465 @@
+package org.cescfe.numpairs.domain.generated.assessment
+
+import org.cescfe.numpairs.domain.generated.generation.internal.requiredKnownEntryIds
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
+import org.cescfe.numpairs.domain.puzzle.assignment.StripEntryId
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+
+class GeneratedPairsDifficultyAssessor {
+    fun assess(
+        initialPuzzle: Puzzle,
+        profile: GeneratedPuzzleProfile,
+        executionPolicy: GeneratedPuzzleDifficultyAssessmentExecutionPolicy =
+            GeneratedPuzzleDifficultyAssessmentExecutionPolicy(),
+        cancellation: GeneratedPuzzleDifficultyAssessmentCancellation =
+            GeneratedPuzzleDifficultyAssessmentCancellation.None
+    ): GeneratedPuzzleDifficultyAssessmentOutcome {
+        val knownEntryCount = initialPuzzle.strip.entries.count { entry -> entry.item is StripItem.Known }
+        val longestHiddenRun = initialPuzzle.longestHiddenRun()
+        if (cancellation.isCancelled()) {
+            return GeneratedPuzzleDifficultyAssessmentOutcome.Cancelled(workConsumed = 0)
+        }
+        if (!initialPuzzle.hasExpectedAssessmentShape(profile = profile)) {
+            return GeneratedPuzzleDifficultyAssessmentOutcome.Unsatisfiable(
+                initialPlausibleCandidateCount = 0,
+                knownEntryCount = knownEntryCount,
+                longestHiddenRun = longestHiddenRun,
+                workConsumed = 0
+            )
+        }
+
+        val resultCounts = initialPuzzle.board.tiles
+            .map { tile -> tile.result }
+            .groupingBy { result -> result }
+            .eachCount()
+        val workControl = AssessmentWorkControl(
+            executionPolicy = executionPolicy,
+            cancellation = cancellation
+        )
+        val candidates = candidatesFor(
+            initialPuzzle = initialPuzzle,
+            profile = profile,
+            resultCounts = resultCounts,
+            workControl = workControl
+        )
+        when (workControl.termination) {
+            AssessmentTermination.CANCELLED -> {
+                return GeneratedPuzzleDifficultyAssessmentOutcome.Cancelled(
+                    workConsumed = workControl.workConsumed
+                )
+            }
+
+            AssessmentTermination.WORK_LIMIT -> {
+                return GeneratedPuzzleDifficultyAssessmentOutcome.WorkLimitReached(
+                    maximumCandidateExpansions = executionPolicy.maxCandidateExpansions,
+                    workConsumed = workControl.workConsumed
+                )
+            }
+
+            null -> Unit
+        }
+        if (candidates.isEmpty()) {
+            return GeneratedPuzzleDifficultyAssessmentOutcome.Unsatisfiable(
+                initialPlausibleCandidateCount = 0,
+                knownEntryCount = knownEntryCount,
+                longestHiddenRun = longestHiddenRun,
+                workConsumed = workControl.workConsumed
+            )
+        }
+
+        val search = AssessmentSearch(
+            initialPuzzle = initialPuzzle,
+            profile = profile,
+            candidates = candidates,
+            initialResultCounts = resultCounts,
+            workControl = workControl
+        )
+        search.run()
+
+        return when (search.termination) {
+            AssessmentTermination.CANCELLED -> GeneratedPuzzleDifficultyAssessmentOutcome.Cancelled(
+                workConsumed = search.workConsumed
+            )
+
+            AssessmentTermination.WORK_LIMIT -> GeneratedPuzzleDifficultyAssessmentOutcome.WorkLimitReached(
+                maximumCandidateExpansions = executionPolicy.maxCandidateExpansions,
+                workConsumed = search.workConsumed
+            )
+
+            null -> {
+                if (search.canonicalSolutionCount == 0) {
+                    GeneratedPuzzleDifficultyAssessmentOutcome.Unsatisfiable(
+                        initialPlausibleCandidateCount = candidates.size,
+                        knownEntryCount = knownEntryCount,
+                        longestHiddenRun = longestHiddenRun,
+                        workConsumed = search.workConsumed
+                    )
+                } else {
+                    GeneratedPuzzleDifficultyAssessmentOutcome.Assessed(
+                        report = GeneratedPuzzleDifficultyAssessmentReport(
+                            initialPlausibleCandidateCount = candidates.size,
+                            initialForcedDeductionCount = search.initialForcedFacts.size,
+                            forcedDeductionCount = search.forcedFacts.size,
+                            firstForcedDeductionDepth = search.firstForcedDeductionDepth,
+                            maximumBranchingFactor = search.maximumBranchingFactor,
+                            exploredAmbiguousStateCount = search.exploredAmbiguousStateCount,
+                            boundedValidSolutionCount = minOf(
+                                search.canonicalSolutionCount,
+                                executionPolicy.validSolutionCountLimit
+                            ),
+                            isValidSolutionCountLimitReached =
+                            search.canonicalSolutionCount > executionPolicy.validSolutionCountLimit,
+                            structuralObservations = GeneratedPuzzleStructuralObservations(
+                                knownEntryCount = knownEntryCount,
+                                longestHiddenRun = longestHiddenRun,
+                                knownStripAnchorCount = initialPuzzle.knownStripAnchorCount(profile = profile),
+                                unambiguousResultAnchorCount =
+                                initialPuzzle.unambiguousResultAnchorCount(candidates = candidates),
+                                repeatedValueGroupCountRange =
+                                search.minimumRepeatedValueGroupCount..search.maximumRepeatedValueGroupCount,
+                                plausibleDecoyCount = candidates.count { candidate ->
+                                    candidate.fact !in search.solutionFacts
+                                }
+                            )
+                        ),
+                        workConsumed = search.workConsumed
+                    )
+                }
+            }
+        }
+    }
+}
+
+private class AssessmentSearch(
+    private val initialPuzzle: Puzzle,
+    private val profile: GeneratedPuzzleProfile,
+    private val candidates: List<PairCandidate>,
+    private val initialResultCounts: Map<Int, Int>,
+    private val workControl: AssessmentWorkControl
+) {
+    val termination: AssessmentTermination?
+        get() = workControl.termination
+    val workConsumed: Int
+        get() = workControl.workConsumed
+    var maximumBranchingFactor: Int = 0
+        private set
+    var exploredAmbiguousStateCount: Int = 0
+        private set
+    val forcedFacts: MutableSet<GeneratedPairAssessmentFact> = linkedSetOf()
+    val initialForcedFacts: MutableSet<GeneratedPairAssessmentFact> = linkedSetOf()
+    var firstForcedDeductionDepth: Int? = null
+        private set
+    val solutionFacts: MutableSet<GeneratedPairAssessmentFact> = linkedSetOf()
+    var canonicalSolutionCount: Int = 0
+        private set
+    var minimumRepeatedValueGroupCount: Int = Int.MAX_VALUE
+        private set
+    var maximumRepeatedValueGroupCount: Int = Int.MIN_VALUE
+        private set
+
+    private val canonicalSolutions = mutableSetOf<CanonicalSolution>()
+
+    fun run() {
+        search(
+            state = AssessmentSearchState(
+                remainingResultCounts = initialResultCounts,
+                selectedValueCounts = emptyMap(),
+                selectedFacts = emptyList()
+            ),
+            hasSpeculativeBranch = false
+        )
+    }
+
+    private fun search(state: AssessmentSearchState, hasSpeculativeBranch: Boolean): Boolean {
+        if (checkTermination()) {
+            return false
+        }
+        if (state.remainingResultCounts.values.all { count -> count == 0 }) {
+            return recordSolutionIfValid(state = state)
+        }
+
+        val viableCandidates = candidates.filter { candidate ->
+            candidate.canConsume(results = state.remainingResultCounts) &&
+                state.canAdd(candidate = candidate, profile = profile, initialPuzzle = initialPuzzle)
+        }
+        val choices = state.remainingResultCounts
+            .filterValues { count -> count > 0 }
+            .keys
+            .sorted()
+            .map { result ->
+                viableCandidates.filter { candidate -> candidate.consumes(result = result) }
+            }
+            .minWithOrNull(
+                compareBy<List<PairCandidate>> { resultChoices -> resultChoices.size }
+                    .thenBy { resultChoices -> resultChoices.firstOrNull()?.fact }
+            )
+            .orEmpty()
+        if (choices.isEmpty()) {
+            return false
+        }
+
+        if (choices.size > 1) {
+            maximumBranchingFactor = maxOf(maximumBranchingFactor, choices.size)
+            exploredAmbiguousStateCount++
+        }
+
+        var foundSolution = false
+        choices.forEach { candidate ->
+            if (!workControl.consumeCandidateExpansion()) {
+                return foundSolution
+            }
+            val childFoundSolution = search(
+                state = state.with(candidate = candidate),
+                hasSpeculativeBranch = hasSpeculativeBranch || choices.size > 1
+            )
+            foundSolution = foundSolution || childFoundSolution
+            if (termination != null) {
+                return foundSolution
+            }
+        }
+
+        if (choices.size == 1 && foundSolution) {
+            val forcedFact = choices.single().fact
+            forcedFacts += forcedFact
+            if (!hasSpeculativeBranch) {
+                initialForcedFacts += forcedFact
+                val depth = state.selectedFacts.size + 1
+                firstForcedDeductionDepth = firstForcedDeductionDepth?.let { currentDepth ->
+                    minOf(currentDepth, depth)
+                } ?: depth
+            }
+        }
+        return foundSolution
+    }
+
+    private fun recordSolutionIfValid(state: AssessmentSearchState): Boolean {
+        val sortedValues = state.selectedValueCounts.entries.flatMap { (value, count) ->
+            List(count) { value }
+        }.sorted()
+        if (!initialPuzzle.matchesCompletedStrip(values = sortedValues)) {
+            return false
+        }
+
+        val solution = CanonicalSolution(
+            facts = state.selectedFacts.sorted(),
+            sortedValues = sortedValues
+        )
+        if (!canonicalSolutions.add(solution)) {
+            return true
+        }
+
+        canonicalSolutionCount++
+        solutionFacts += solution.facts
+        val repeatedGroupCount = sortedValues
+            .groupingBy { value -> value }
+            .eachCount()
+            .count { (_, count) -> count > 1 }
+        minimumRepeatedValueGroupCount = minOf(minimumRepeatedValueGroupCount, repeatedGroupCount)
+        maximumRepeatedValueGroupCount = maxOf(maximumRepeatedValueGroupCount, repeatedGroupCount)
+        return true
+    }
+
+    private fun checkTermination(): Boolean = workControl.checkTermination()
+}
+
+private data class AssessmentSearchState(
+    val remainingResultCounts: Map<Int, Int>,
+    val selectedValueCounts: Map<Int, Int>,
+    val selectedFacts: List<GeneratedPairAssessmentFact>
+) {
+    fun canAdd(candidate: PairCandidate, profile: GeneratedPuzzleProfile, initialPuzzle: Puzzle): Boolean {
+        val updatedValueCounts = selectedValueCounts
+            .withIncrement(candidate.fact.firstValue)
+            .withIncrement(candidate.fact.secondValue)
+        return updatedValueCounts.values.all { count -> count <= profile.stripValuePolicy.maxOccurrencesPerValue } &&
+            initialPuzzle.canStillFitKnownEntries(
+                selectedValueCounts = updatedValueCounts,
+                allowedValueRange = profile.stripValuePolicy.valueRange
+            )
+    }
+
+    fun with(candidate: PairCandidate): AssessmentSearchState = copy(
+        remainingResultCounts = candidate.consume(results = remainingResultCounts),
+        selectedValueCounts = selectedValueCounts
+            .withIncrement(candidate.fact.firstValue)
+            .withIncrement(candidate.fact.secondValue),
+        selectedFacts = selectedFacts + candidate.fact
+    )
+}
+
+private data class PairCandidate(val fact: GeneratedPairAssessmentFact) {
+    private val resultConsumption: Map<Int, Int> = listOf(fact.sumResult, fact.productResult)
+        .groupingBy { result -> result }
+        .eachCount()
+
+    fun canConsume(results: Map<Int, Int>): Boolean = resultConsumption.all { (result, count) ->
+        results.getOrDefault(result, 0) >= count
+    }
+
+    fun consume(results: Map<Int, Int>): Map<Int, Int> = results.toMutableMap().apply {
+        resultConsumption.forEach { (result, count) ->
+            this[result] = getValue(result) - count
+        }
+    }
+
+    fun consumes(result: Int): Boolean = result in resultConsumption
+}
+
+private data class CanonicalSolution(val facts: List<GeneratedPairAssessmentFact>, val sortedValues: List<Int>)
+
+private enum class AssessmentTermination {
+    CANCELLED,
+    WORK_LIMIT
+}
+
+private class AssessmentWorkControl(
+    private val executionPolicy: GeneratedPuzzleDifficultyAssessmentExecutionPolicy,
+    private val cancellation: GeneratedPuzzleDifficultyAssessmentCancellation
+) {
+    var termination: AssessmentTermination? = null
+        private set
+    var workConsumed: Int = 0
+        private set
+
+    fun consumeCandidateExpansion(): Boolean {
+        if (checkTermination()) {
+            return false
+        }
+        if (workConsumed >= executionPolicy.maxCandidateExpansions) {
+            termination = AssessmentTermination.WORK_LIMIT
+            return false
+        }
+        workConsumed++
+        return true
+    }
+
+    fun checkTermination(): Boolean {
+        if (termination != null) {
+            return true
+        }
+        if (cancellation.isCancelled()) {
+            termination = AssessmentTermination.CANCELLED
+            return true
+        }
+        return false
+    }
+}
+
+private fun candidatesFor(
+    initialPuzzle: Puzzle,
+    profile: GeneratedPuzzleProfile,
+    resultCounts: Map<Int, Int>,
+    workControl: AssessmentWorkControl
+): List<PairCandidate> {
+    val candidates = mutableListOf<PairCandidate>()
+    profile.stripValuePolicy.valueRange.forEach { firstValue ->
+        (firstValue..profile.stripValuePolicy.valueRange.last).forEach { secondValue ->
+            if (!workControl.consumeCandidateExpansion()) {
+                return candidates
+            }
+            val sum = firstValue.toLong() + secondValue.toLong()
+            val product = firstValue.toLong() * secondValue.toLong()
+            if (
+                sum <= Int.MAX_VALUE &&
+                product <= minOf(Int.MAX_VALUE.toLong(), profile.resultConstraints.maxMultiplicationResult.toLong())
+            ) {
+                val candidate = PairCandidate(
+                    fact = GeneratedPairAssessmentFact.canonical(
+                        firstOperand = firstValue,
+                        secondOperand = secondValue,
+                        sumResult = sum.toInt(),
+                        productResult = product.toInt()
+                    )
+                )
+                val valueCounts = emptyMap<Int, Int>()
+                    .withIncrement(firstValue)
+                    .withIncrement(secondValue)
+                if (
+                    candidate.canConsume(results = resultCounts) &&
+                    valueCounts.values.all { count ->
+                        count <= profile.stripValuePolicy.maxOccurrencesPerValue
+                    } &&
+                    initialPuzzle.canStillFitKnownEntries(
+                        selectedValueCounts = valueCounts,
+                        allowedValueRange = profile.stripValuePolicy.valueRange
+                    )
+                ) {
+                    candidates += candidate
+                }
+            }
+        }
+    }
+    return candidates.distinct().sortedBy(PairCandidate::fact)
+}
+
+private fun Puzzle.hasExpectedAssessmentShape(profile: GeneratedPuzzleProfile): Boolean =
+    board.tiles.size == profile.size.boardTileCount &&
+        strip.entries.size == profile.size.stripEntryCount &&
+        board.tiles.all { tile ->
+            tile.expression.leftOperand == Expression.Operand.Hidden &&
+                tile.expression.operator == Operator.Hidden &&
+                tile.expression.rightOperand == Expression.Operand.Hidden
+        } &&
+        strip.entries.all { entry ->
+            entry.item == StripItem.Hidden || entry.item is StripItem.Known
+        }
+
+private fun Puzzle.matchesCompletedStrip(values: List<Int>): Boolean = values.size == strip.entries.size &&
+    strip.entries.indices.all { index ->
+        when (val item = strip.entries[index].item) {
+            StripItem.Hidden -> true
+            is StripItem.Known -> item.value == values[index]
+            is StripItem.PlayerEntered -> false
+        }
+    }
+
+private fun Puzzle.canStillFitKnownEntries(selectedValueCounts: Map<Int, Int>, allowedValueRange: IntRange): Boolean {
+    if (selectedValueCounts.keys.any { value -> value !in allowedValueRange }) {
+        return false
+    }
+    val totalEntryCount = strip.entries.size
+    return strip.entries.withIndex().all { (index, entry) ->
+        val knownValue = (entry.item as? StripItem.Known)?.value ?: return@all true
+        val selectedBelow = selectedValueCounts
+            .filterKeys { value -> value < knownValue }
+            .values
+            .sum()
+        val selectedAbove = selectedValueCounts
+            .filterKeys { value -> value > knownValue }
+            .values
+            .sum()
+        selectedBelow <= index && selectedAbove <= totalEntryCount - index - 1
+    }
+}
+
+private fun Puzzle.longestHiddenRun(): Int {
+    var longest = 0
+    var current = 0
+    strip.entries.forEach { entry ->
+        if (entry.item == StripItem.Hidden) {
+            current++
+            longest = maxOf(longest, current)
+        } else {
+            current = 0
+        }
+    }
+    return longest
+}
+
+private fun Puzzle.knownStripAnchorCount(profile: GeneratedPuzzleProfile): Int {
+    val requiredAnchorIds = profile.requiredKnownEntryIds()
+    return strip.entries.count { entry ->
+        entry.item is StripItem.Known && StripEntryId(entry.id) in requiredAnchorIds
+    }
+}
+
+private fun Puzzle.unambiguousResultAnchorCount(candidates: List<PairCandidate>): Int = board.tiles.count { tile ->
+    candidates.count { candidate -> candidate.consumes(result = tile.result) } == 1
+}
+
+private fun Map<Int, Int>.withIncrement(value: Int): Map<Int, Int> = toMutableMap().apply {
+    this[value] = getOrDefault(value, 0) + 1
+}

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPuzzleDifficultyAssessment.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPuzzleDifficultyAssessment.kt
@@ -1,0 +1,111 @@
+package org.cescfe.numpairs.domain.generated.assessment
+
+data class GeneratedPuzzleDifficultyAssessmentExecutionPolicy(
+    val maxCandidateExpansions: Int = 250_000,
+    val validSolutionCountLimit: Int = 100
+) {
+    init {
+        require(maxCandidateExpansions > 0) {
+            "Difficulty-assessment candidate expansion limit must be positive."
+        }
+        require(validSolutionCountLimit > 0) {
+            "Difficulty-assessment solution count limit must be positive."
+        }
+    }
+}
+
+fun interface GeneratedPuzzleDifficultyAssessmentCancellation {
+    fun isCancelled(): Boolean
+
+    companion object {
+        val None: GeneratedPuzzleDifficultyAssessmentCancellation =
+            GeneratedPuzzleDifficultyAssessmentCancellation { false }
+    }
+}
+
+@ConsistentCopyVisibility
+data class GeneratedPairAssessmentFact private constructor(
+    val firstValue: Int,
+    val secondValue: Int,
+    val sumResult: Int,
+    val productResult: Int
+) : Comparable<GeneratedPairAssessmentFact> {
+    override fun compareTo(other: GeneratedPairAssessmentFact): Int = compareValuesBy(
+        this,
+        other,
+        GeneratedPairAssessmentFact::firstValue,
+        GeneratedPairAssessmentFact::secondValue,
+        GeneratedPairAssessmentFact::sumResult,
+        GeneratedPairAssessmentFact::productResult
+    )
+
+    companion object {
+        fun canonical(
+            firstOperand: Int,
+            secondOperand: Int,
+            sumResult: Int = firstOperand + secondOperand,
+            productResult: Int = firstOperand * secondOperand
+        ): GeneratedPairAssessmentFact {
+            require(firstOperand > 0 && secondOperand > 0) {
+                "Assessment fact operands must be positive."
+            }
+            val (firstValue, secondValue) = if (firstOperand <= secondOperand) {
+                firstOperand to secondOperand
+            } else {
+                secondOperand to firstOperand
+            }
+            require(firstValue.toLong() + secondValue.toLong() == sumResult.toLong()) {
+                "Assessment fact sum must match its operands."
+            }
+            require(firstValue.toLong() * secondValue.toLong() == productResult.toLong()) {
+                "Assessment fact product must match its operands."
+            }
+            return GeneratedPairAssessmentFact(
+                firstValue = firstValue,
+                secondValue = secondValue,
+                sumResult = sumResult,
+                productResult = productResult
+            )
+        }
+    }
+}
+
+data class GeneratedPuzzleStructuralObservations(
+    val knownEntryCount: Int,
+    val longestHiddenRun: Int,
+    val knownStripAnchorCount: Int,
+    val unambiguousResultAnchorCount: Int,
+    val repeatedValueGroupCountRange: IntRange,
+    val plausibleDecoyCount: Int
+)
+
+data class GeneratedPuzzleDifficultyAssessmentReport(
+    val initialPlausibleCandidateCount: Int,
+    val initialForcedDeductionCount: Int,
+    val forcedDeductionCount: Int,
+    val firstForcedDeductionDepth: Int?,
+    val maximumBranchingFactor: Int,
+    val exploredAmbiguousStateCount: Int,
+    val boundedValidSolutionCount: Int,
+    val isValidSolutionCountLimitReached: Boolean,
+    val structuralObservations: GeneratedPuzzleStructuralObservations
+)
+
+sealed interface GeneratedPuzzleDifficultyAssessmentOutcome {
+    val workConsumed: Int
+
+    data class Assessed(val report: GeneratedPuzzleDifficultyAssessmentReport, override val workConsumed: Int) :
+        GeneratedPuzzleDifficultyAssessmentOutcome
+
+    data class Unsatisfiable(
+        val initialPlausibleCandidateCount: Int,
+        val knownEntryCount: Int,
+        val longestHiddenRun: Int,
+        override val workConsumed: Int
+    ) : GeneratedPuzzleDifficultyAssessmentOutcome
+
+    data class Cancelled(override val workConsumed: Int) : GeneratedPuzzleDifficultyAssessmentOutcome
+
+    data class WorkLimitReached(val maximumCandidateExpansions: Int, override val workConsumed: Int) :
+        GeneratedPuzzleDifficultyAssessmentOutcome
+}

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPairsDifficultyAssessorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPairsDifficultyAssessorTest.kt
@@ -1,0 +1,279 @@
+package org.cescfe.numpairs.domain.generated.assessment
+
+import org.cescfe.numpairs.domain.generated.generation.generatedPuzzle
+import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileDefinition
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileId
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfiles
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleSize
+import org.cescfe.numpairs.domain.generated.profile.GenerationPolicy
+import org.cescfe.numpairs.domain.generated.profile.InitialStripMaskPolicy
+import org.cescfe.numpairs.domain.generated.profile.ResultConstraints
+import org.cescfe.numpairs.domain.generated.profile.StripKnownEntryDistributionPolicy
+import org.cescfe.numpairs.domain.generated.profile.StripValuePolicy
+import org.cescfe.numpairs.domain.generated.profile.getOrThrow
+import org.cescfe.numpairs.domain.puzzle.model.Board
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.Strip
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.cescfe.numpairs.domain.puzzle.model.Tile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GeneratedPairsDifficultyAssessorTest {
+    private val assessor = GeneratedPairsDifficultyAssessor()
+
+    @Test
+    fun canonical_pair_facts_ignore_left_right_order_but_preserve_operator_results() {
+        assertEquals(
+            GeneratedPairAssessmentFact.canonical(firstOperand = 2, secondOperand = 3),
+            GeneratedPairAssessmentFact.canonical(firstOperand = 3, secondOperand = 2)
+        )
+        assertNotEquals(
+            GeneratedPairAssessmentFact.canonical(firstOperand = 1, secondOperand = 5),
+            GeneratedPairAssessmentFact.canonical(firstOperand = 2, secondOperand = 3)
+        )
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedPairAssessmentFact.canonical(
+                firstOperand = 2,
+                secondOperand = 3,
+                sumResult = 6,
+                productResult = 5
+            )
+        }
+    }
+
+    @Test
+    fun assessment_is_deterministic_and_ignores_board_action_order() {
+        val puzzle = ambiguousPuzzle()
+        val reorderedPuzzle = puzzle.copy(
+            board = puzzle.board.copy(tiles = puzzle.board.tiles.reversed())
+        )
+
+        val first = assessor.assess(initialPuzzle = puzzle, profile = ambiguousProfile())
+        val second = assessor.assess(initialPuzzle = puzzle, profile = ambiguousProfile())
+        val reordered = assessor.assess(initialPuzzle = reorderedPuzzle, profile = ambiguousProfile())
+
+        assertEquals(first, second)
+        assertEquals(first, reordered)
+    }
+
+    @Test
+    fun assessment_reports_ambiguity_for_distinct_valid_solution_equivalence_classes() {
+        val outcome = assessor.assess(
+            initialPuzzle = ambiguousPuzzle(),
+            profile = ambiguousProfile(),
+            executionPolicy = GeneratedPuzzleDifficultyAssessmentExecutionPolicy(
+                validSolutionCountLimit = 1
+            )
+        ) as GeneratedPuzzleDifficultyAssessmentOutcome.Assessed
+
+        assertEquals(1, outcome.report.boundedValidSolutionCount)
+        assertTrue(outcome.report.isValidSolutionCountLimitReached)
+        assertTrue(outcome.report.initialPlausibleCandidateCount >= 3)
+        assertTrue(outcome.report.maximumBranchingFactor >= 2)
+        assertTrue(outcome.report.exploredAmbiguousStateCount >= 1)
+        assertEquals(0, outcome.report.structuralObservations.knownEntryCount)
+        assertEquals(4, outcome.report.structuralObservations.longestHiddenRun)
+        assertEquals(1..1, outcome.report.structuralObservations.repeatedValueGroupCountRange)
+    }
+
+    @Test
+    fun equal_value_entry_permutations_collapse_to_arithmetic_solution_classes() {
+        val puzzle = Puzzle(
+            board = Board(tiles = listOf(5, 5, 6, 6).map(::hiddenTile)),
+            strip = Strip.fromItems(items = List(4) { StripItem.Hidden })
+        )
+
+        val outcome = assessor.assess(
+            initialPuzzle = puzzle,
+            profile = ambiguousProfile()
+        ) as GeneratedPuzzleDifficultyAssessmentOutcome.Assessed
+
+        assertEquals(3, outcome.report.boundedValidSolutionCount)
+        assertFalse(outcome.report.isValidSolutionCountLimitReached)
+    }
+
+    @Test
+    fun impossible_candidate_returns_unsatisfiable() {
+        val puzzle = ambiguousPuzzle().copy(
+            board = Board(
+                tiles = listOf(2, 3, 5, 100).map(::hiddenTile)
+            )
+        )
+
+        val outcome = assessor.assess(initialPuzzle = puzzle, profile = ambiguousProfile())
+
+        assertTrue(outcome is GeneratedPuzzleDifficultyAssessmentOutcome.Unsatisfiable)
+    }
+
+    @Test
+    fun work_and_cancellation_are_typed_and_bounded() {
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedPuzzleDifficultyAssessmentExecutionPolicy(maxCandidateExpansions = 0)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedPuzzleDifficultyAssessmentExecutionPolicy(validSolutionCountLimit = 0)
+        }
+        val workLimited = assessor.assess(
+            initialPuzzle = ambiguousPuzzle(),
+            profile = ambiguousProfile(),
+            executionPolicy = GeneratedPuzzleDifficultyAssessmentExecutionPolicy(
+                maxCandidateExpansions = 1
+            )
+        )
+        assertEquals(
+            GeneratedPuzzleDifficultyAssessmentOutcome.WorkLimitReached(
+                maximumCandidateExpansions = 1,
+                workConsumed = 1
+            ),
+            workLimited
+        )
+
+        var cancellationChecks = 0
+        val cancelled = assessor.assess(
+            initialPuzzle = ambiguousPuzzle(),
+            profile = ambiguousProfile(),
+            cancellation = GeneratedPuzzleDifficultyAssessmentCancellation {
+                cancellationChecks++
+                cancellationChecks > 3
+            }
+        )
+        assertTrue(cancelled is GeneratedPuzzleDifficultyAssessmentOutcome.Cancelled)
+        assertTrue(cancelled.workConsumed > 0)
+    }
+
+    @Test
+    fun existing_profiles_are_assessed_over_a_deterministic_seed_corpus() {
+        val expectedCharacterization = mapOf(
+            ("4-pairs-low" to 1) to Characterization(
+                initialCandidates = 4,
+                forcedDeductions = 4,
+                resultAnchors = 8,
+                repeatedGroups = 0..0,
+                decoys = 0,
+                work = 194
+            ),
+            ("4-pairs-low" to 42) to Characterization(
+                initialCandidates = 5,
+                forcedDeductions = 4,
+                resultAnchors = 6,
+                repeatedGroups = 0..0,
+                decoys = 1,
+                work = 194
+            ),
+            ("8-pairs-medium" to 1) to Characterization(
+                initialCandidates = 13,
+                forcedDeductions = 8,
+                resultAnchors = 7,
+                repeatedGroups = 4..4,
+                decoys = 5,
+                work = 4_958
+            ),
+            ("8-pairs-medium" to 42) to Characterization(
+                initialCandidates = 12,
+                forcedDeductions = 8,
+                resultAnchors = 9,
+                repeatedGroups = 0..0,
+                decoys = 4,
+                work = 4_958
+            )
+        )
+        val corpus = listOf(
+            GeneratedPuzzleProfiles.FOUR_PAIRS_LOW to listOf(1, 42),
+            GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM to listOf(1, 42)
+        )
+
+        corpus.forEach { (profile, seeds) ->
+            seeds.forEach { seed ->
+                val puzzle = generatedPuzzle(profile = profile, seed = seed).initialPuzzle
+                val first = assessor.assess(initialPuzzle = puzzle, profile = profile)
+                val second = assessor.assess(initialPuzzle = puzzle, profile = profile)
+
+                assertEquals(first, second)
+                val assessed = first as GeneratedPuzzleDifficultyAssessmentOutcome.Assessed
+                assertEquals(
+                    expectedCharacterization.getValue(profile.id.value to seed),
+                    assessed.characterization()
+                )
+                assertTrue(assessed.report.initialPlausibleCandidateCount >= profile.size.pairCount)
+                assertEquals(profile.size.pairCount, assessed.report.initialForcedDeductionCount)
+                assertEquals(1, assessed.report.firstForcedDeductionDepth)
+                assertEquals(0, assessed.report.maximumBranchingFactor)
+                assertEquals(0, assessed.report.exploredAmbiguousStateCount)
+                assertTrue(assessed.report.boundedValidSolutionCount >= 1)
+                assertFalse(assessed.report.isValidSolutionCountLimitReached)
+                assertTrue(
+                    assessed.report.structuralObservations.knownEntryCount in
+                        profile.initialStripMaskPolicy.knownEntryCountRange
+                )
+                assertTrue(
+                    assessed.report.structuralObservations.longestHiddenRun <=
+                        profile.initialStripMaskPolicy.maxConsecutiveHiddenEntries
+                )
+            }
+        }
+    }
+}
+
+private data class Characterization(
+    val initialCandidates: Int,
+    val forcedDeductions: Int,
+    val resultAnchors: Int,
+    val repeatedGroups: IntRange,
+    val decoys: Int,
+    val work: Int
+)
+
+private fun GeneratedPuzzleDifficultyAssessmentOutcome.Assessed.characterization(): Characterization = Characterization(
+    initialCandidates = report.initialPlausibleCandidateCount,
+    forcedDeductions = report.forcedDeductionCount,
+    resultAnchors = report.structuralObservations.unambiguousResultAnchorCount,
+    repeatedGroups = report.structuralObservations.repeatedValueGroupCountRange,
+    decoys = report.structuralObservations.plausibleDecoyCount,
+    work = workConsumed
+)
+
+private fun ambiguousProfile(): GeneratedPuzzleProfile = GeneratedPuzzleProfile.create(
+    definition = GeneratedPuzzleProfileDefinition(
+        id = GeneratedPuzzleProfileId("assessment-ambiguous-two-pairs"),
+        difficulty = DifficultyTier.MEDIUM,
+        size = GeneratedPuzzleSize(pairCount = 2),
+        stripValuePolicy = StripValuePolicy(
+            valueRange = 1..6,
+            maxOccurrencesPerValue = 2
+        ),
+        resultConstraints = ResultConstraints(
+            maxMultiplicationResult = 36,
+            allowsDuplicateBoardResults = true
+        ),
+        initialStripMaskPolicy = InitialStripMaskPolicy(
+            knownEntryCountRange = 0..0,
+            requiredAnchors = emptySet(),
+            distributionPolicy = StripKnownEntryDistributionPolicy.UNRESTRICTED,
+            maxConsecutiveHiddenEntries = 4
+        ),
+        generationPolicy = GenerationPolicy(isBoardTileShufflingEnabled = true)
+    )
+).getOrThrow()
+
+private fun ambiguousPuzzle(): Puzzle = Puzzle(
+    board = Board(tiles = listOf(2, 3, 5, 6).map(::hiddenTile)),
+    strip = Strip.fromItems(items = List(4) { StripItem.Hidden })
+)
+
+private fun hiddenTile(result: Int): Tile = Tile(
+    expression = Expression(
+        leftOperand = Expression.Operand.Hidden,
+        operator = Operator.Hidden,
+        rightOperand = Expression.Operand.Hidden
+    ),
+    result = result
+)


### PR DESCRIPTION
## Related Issue

Resolves #494

## Summary

- Add a platform-independent deterministic difficulty assessor over canonical pair facts and result/value exact cover.
- Report candidate, forced-deduction, depth, branching, ambiguity, bounded-solution, anchor, repetition, hidden-run, and decoy metrics.
- Bound candidate enumeration and search with typed assessed, unsatisfiable, cancelled, and work-limit outcomes.
- Characterize deterministic 4 Pairs Low and 8 Pairs Medium seed fixtures without changing either profile or player completion rules.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew spotlessCheck`
- `./gradlew lintDebug`