### PR TITLE
[241] Add the 4 Pairs Medium generated challenge

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPuzzleDifficultyAssessment.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPuzzleDifficultyAssessment.kt
@@ -91,6 +91,66 @@ data class GeneratedPuzzleDifficultyAssessmentReport(
     val structuralObservations: GeneratedPuzzleStructuralObservations
 )
 
+data class GeneratedPuzzleDifficultyAssessmentPolicy(
+    val executionPolicy: GeneratedPuzzleDifficultyAssessmentExecutionPolicy,
+    val minimumInitialPlausibleCandidateCount: Int,
+    val minimumInitialForcedDeductionCount: Int,
+    val minimumFirstForcedDeductionDepth: Int,
+    val minimumPlausibleDecoyCount: Int,
+    val minimumValidSolutionCount: Int = 1
+) {
+    init {
+        require(minimumInitialPlausibleCandidateCount >= 0)
+        require(minimumInitialForcedDeductionCount >= 0)
+        require(minimumFirstForcedDeductionDepth >= 0)
+        require(minimumPlausibleDecoyCount >= 0)
+        require(minimumValidSolutionCount > 0)
+        require(executionPolicy.validSolutionCountLimit >= minimumValidSolutionCount) {
+            "Difficulty-assessment solution count limit must cover the required minimum."
+        }
+    }
+
+    fun evaluate(report: GeneratedPuzzleDifficultyAssessmentReport): GeneratedPuzzleDifficultyPolicyEvaluation {
+        val unmetRequirements = buildSet {
+            if (report.initialPlausibleCandidateCount < minimumInitialPlausibleCandidateCount) {
+                add(GeneratedPuzzleDifficultyRequirement.INITIAL_PLAUSIBLE_CANDIDATES)
+            }
+            if (report.initialForcedDeductionCount < minimumInitialForcedDeductionCount) {
+                add(GeneratedPuzzleDifficultyRequirement.INITIAL_FORCED_DEDUCTIONS)
+            }
+            if ((report.firstForcedDeductionDepth ?: -1) < minimumFirstForcedDeductionDepth) {
+                add(GeneratedPuzzleDifficultyRequirement.FIRST_FORCED_DEDUCTION_DEPTH)
+            }
+            if (report.structuralObservations.plausibleDecoyCount < minimumPlausibleDecoyCount) {
+                add(GeneratedPuzzleDifficultyRequirement.PLAUSIBLE_DECOYS)
+            }
+            if (report.boundedValidSolutionCount < minimumValidSolutionCount) {
+                add(GeneratedPuzzleDifficultyRequirement.VALID_SOLUTIONS)
+            }
+        }
+        return GeneratedPuzzleDifficultyPolicyEvaluation(
+            report = report,
+            unmetRequirements = unmetRequirements
+        )
+    }
+}
+
+data class GeneratedPuzzleDifficultyPolicyEvaluation(
+    val report: GeneratedPuzzleDifficultyAssessmentReport,
+    val unmetRequirements: Set<GeneratedPuzzleDifficultyRequirement>
+) {
+    val isAccepted: Boolean
+        get() = unmetRequirements.isEmpty()
+}
+
+enum class GeneratedPuzzleDifficultyRequirement {
+    INITIAL_PLAUSIBLE_CANDIDATES,
+    INITIAL_FORCED_DEDUCTIONS,
+    FIRST_FORCED_DEDUCTION_DEPTH,
+    PLAUSIBLE_DECOYS,
+    VALID_SOLUTIONS
+}
+
 sealed interface GeneratedPuzzleDifficultyAssessmentOutcome {
     val workConsumed: Int
 

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPairsPuzzleGenerator.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPairsPuzzleGenerator.kt
@@ -1,6 +1,9 @@
 package org.cescfe.numpairs.domain.generated.generation
 
 import kotlin.random.Random
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPairsDifficultyAssessor
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficultyAssessmentOutcome
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficultyPolicyEvaluation
 import org.cescfe.numpairs.domain.generated.generation.internal.GeneratedPairsPuzzleAssembler
 import org.cescfe.numpairs.domain.generated.generation.internal.GeneratedPairsSearchControl
 import org.cescfe.numpairs.domain.generated.generation.internal.GeneratedPairsSearchControlResult
@@ -123,39 +126,31 @@ class GeneratedPairsPuzzleGenerator(private val context: GeneratedPuzzleGenerati
                 continue
             }
 
-            when (val outcome = buildValidGeneratedPuzzle(candidate = candidate, puzzleAssembler = puzzleAssembler)) {
-                is GeneratedPuzzleBuildOutcome.Created -> return GeneratedPairsPuzzleGenerationOutcome.Generated(
-                    request = request,
-                    puzzle = outcome.puzzle,
-                    attemptsUsed = attemptsUsed,
-                    searchWorkConsumed = searchControl.searchWorkConsumed
-                )
-
-                is GeneratedPuzzleBuildOutcome.Rejected -> {
-                    rejections += GeneratedPairsPuzzleCandidateRejection.FinalValidationFailed(
-                        attempt = attemptsUsed,
-                        violations = outcome.violations
-                    )
-                }
-            }
+            handleBuildOutcome(
+                outcome = buildValidGeneratedPuzzle(
+                    candidate = candidate,
+                    puzzleAssembler = puzzleAssembler,
+                    cancellation = cancellation
+                ),
+                request = request,
+                attemptsUsed = attemptsUsed,
+                searchControl = searchControl,
+                rejections = rejections
+            )?.let { outcome -> return outcome }
         }
 
         fallbackCandidate?.let { candidate ->
-            when (val outcome = buildValidGeneratedPuzzle(candidate = candidate, puzzleAssembler = puzzleAssembler)) {
-                is GeneratedPuzzleBuildOutcome.Created -> return GeneratedPairsPuzzleGenerationOutcome.Generated(
-                    request = request,
-                    puzzle = outcome.puzzle,
-                    attemptsUsed = attemptsUsed,
-                    searchWorkConsumed = searchControl.searchWorkConsumed
-                )
-
-                is GeneratedPuzzleBuildOutcome.Rejected -> {
-                    rejections += GeneratedPairsPuzzleCandidateRejection.FinalValidationFailed(
-                        attempt = attemptsUsed,
-                        violations = outcome.violations
-                    )
-                }
-            }
+            handleBuildOutcome(
+                outcome = buildValidGeneratedPuzzle(
+                    candidate = candidate,
+                    puzzleAssembler = puzzleAssembler,
+                    cancellation = cancellation
+                ),
+                request = request,
+                attemptsUsed = attemptsUsed,
+                searchControl = searchControl,
+                rejections = rejections
+            )?.let { outcome -> return outcome }
         }
 
         return failure(
@@ -169,7 +164,8 @@ class GeneratedPairsPuzzleGenerator(private val context: GeneratedPuzzleGenerati
 
     private fun buildValidGeneratedPuzzle(
         candidate: GeneratedPairsPuzzleCandidate,
-        puzzleAssembler: GeneratedPairsPuzzleAssembler
+        puzzleAssembler: GeneratedPairsPuzzleAssembler,
+        cancellation: GeneratedPuzzleGenerationCancellation
     ): GeneratedPuzzleBuildOutcome {
         val solvedPuzzle = puzzleAssembler.buildSolvedPuzzle(candidate = candidate.solvedCandidate)
         return when (
@@ -179,9 +175,98 @@ class GeneratedPairsPuzzleGenerator(private val context: GeneratedPuzzleGenerati
                 knownEntryIds = candidate.knownEntryIds
             )
         ) {
-            is GeneratedPairsPuzzleCreation.Created -> GeneratedPuzzleBuildOutcome.Created(creation.puzzle)
+            is GeneratedPairsPuzzleCreation.Created -> assessDifficulty(
+                puzzle = creation.puzzle,
+                cancellation = cancellation
+            )
             is GeneratedPairsPuzzleCreation.Rejected -> GeneratedPuzzleBuildOutcome.Rejected(creation.violations)
         }
+    }
+
+    private fun assessDifficulty(
+        puzzle: GeneratedPairsPuzzle,
+        cancellation: GeneratedPuzzleGenerationCancellation
+    ): GeneratedPuzzleBuildOutcome {
+        val policy = profile.difficultyAssessmentPolicy
+            ?: return GeneratedPuzzleBuildOutcome.Created(puzzle = puzzle)
+        return when (
+            val outcome = GeneratedPairsDifficultyAssessor().assess(
+                initialPuzzle = puzzle.initialPuzzle,
+                profile = profile,
+                executionPolicy = policy.executionPolicy,
+                cancellation = { cancellation.isCancellationRequested() }
+            )
+        ) {
+            is GeneratedPuzzleDifficultyAssessmentOutcome.Assessed -> {
+                val evaluation = policy.evaluate(report = outcome.report)
+                if (evaluation.isAccepted) {
+                    GeneratedPuzzleBuildOutcome.Created(puzzle = puzzle)
+                } else {
+                    GeneratedPuzzleBuildOutcome.DifficultyRejected(evaluation = evaluation)
+                }
+            }
+
+            is GeneratedPuzzleDifficultyAssessmentOutcome.Unsatisfiable ->
+                GeneratedPuzzleBuildOutcome.DifficultyUnavailable(outcome = outcome)
+            is GeneratedPuzzleDifficultyAssessmentOutcome.WorkLimitReached ->
+                GeneratedPuzzleBuildOutcome.AssessmentWorkLimitReached
+            is GeneratedPuzzleDifficultyAssessmentOutcome.Cancelled -> GeneratedPuzzleBuildOutcome.Cancelled
+        }
+    }
+
+    private fun handleBuildOutcome(
+        outcome: GeneratedPuzzleBuildOutcome,
+        request: GeneratedPuzzleGenerationRequest,
+        attemptsUsed: Int,
+        searchControl: GeneratedPairsSearchControl,
+        rejections: MutableList<GeneratedPairsPuzzleCandidateRejection>
+    ): GeneratedPairsPuzzleGenerationOutcome? = when (outcome) {
+        is GeneratedPuzzleBuildOutcome.Created -> GeneratedPairsPuzzleGenerationOutcome.Generated(
+            request = request,
+            puzzle = outcome.puzzle,
+            attemptsUsed = attemptsUsed,
+            searchWorkConsumed = searchControl.searchWorkConsumed
+        )
+
+        is GeneratedPuzzleBuildOutcome.Rejected -> {
+            rejections += GeneratedPairsPuzzleCandidateRejection.FinalValidationFailed(
+                attempt = attemptsUsed,
+                violations = outcome.violations
+            )
+            null
+        }
+
+        is GeneratedPuzzleBuildOutcome.DifficultyRejected -> {
+            rejections += GeneratedPairsPuzzleCandidateRejection.DifficultyAssessmentRejected(
+                attempt = attemptsUsed,
+                evaluation = outcome.evaluation
+            )
+            null
+        }
+
+        is GeneratedPuzzleBuildOutcome.DifficultyUnavailable -> {
+            rejections += GeneratedPairsPuzzleCandidateRejection.DifficultyAssessmentUnavailable(
+                attempt = attemptsUsed,
+                outcome = outcome.outcome
+            )
+            null
+        }
+
+        GeneratedPuzzleBuildOutcome.AssessmentWorkLimitReached -> failure(
+            request = request,
+            attemptsUsed = attemptsUsed,
+            searchControl = searchControl,
+            reason = GeneratedPairsPuzzleGenerationFailureReason.DifficultyAssessmentWorkLimitReached,
+            rejections = rejections
+        )
+
+        GeneratedPuzzleBuildOutcome.Cancelled -> failure(
+            request = request,
+            attemptsUsed = attemptsUsed,
+            searchControl = searchControl,
+            reason = GeneratedPairsPuzzleGenerationFailureReason.Cancelled,
+            rejections = rejections
+        )
     }
 }
 
@@ -224,4 +309,10 @@ private data class GeneratedPairsPuzzleCandidate(
 private sealed interface GeneratedPuzzleBuildOutcome {
     data class Created(val puzzle: GeneratedPairsPuzzle) : GeneratedPuzzleBuildOutcome
     data class Rejected(val violations: List<GeneratedPairsPuzzleValidationViolation>) : GeneratedPuzzleBuildOutcome
+    data class DifficultyRejected(val evaluation: GeneratedPuzzleDifficultyPolicyEvaluation) :
+        GeneratedPuzzleBuildOutcome
+    data class DifficultyUnavailable(val outcome: GeneratedPuzzleDifficultyAssessmentOutcome.Unsatisfiable) :
+        GeneratedPuzzleBuildOutcome
+    data object AssessmentWorkLimitReached : GeneratedPuzzleBuildOutcome
+    data object Cancelled : GeneratedPuzzleBuildOutcome
 }

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleGenerationOutcome.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleGenerationOutcome.kt
@@ -1,5 +1,7 @@
 package org.cescfe.numpairs.domain.generated.generation
 
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficultyAssessmentOutcome
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficultyPolicyEvaluation
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileId
 import org.cescfe.numpairs.domain.generated.puzzle.GeneratedPairsPuzzle
@@ -65,6 +67,7 @@ sealed interface GeneratedPairsPuzzleGenerationOutcome {
 sealed interface GeneratedPairsPuzzleGenerationFailureReason {
     data object AttemptsExhausted : GeneratedPairsPuzzleGenerationFailureReason
     data object SearchBudgetExhausted : GeneratedPairsPuzzleGenerationFailureReason
+    data object DifficultyAssessmentWorkLimitReached : GeneratedPairsPuzzleGenerationFailureReason
     data object Cancelled : GeneratedPairsPuzzleGenerationFailureReason
 }
 
@@ -82,6 +85,28 @@ sealed interface GeneratedPairsPuzzleCandidateRejection {
         init {
             require(violations.isNotEmpty()) {
                 "A final validation rejection requires at least one violation."
+            }
+        }
+    }
+
+    data class DifficultyAssessmentRejected(
+        override val attempt: Int,
+        val evaluation: GeneratedPuzzleDifficultyPolicyEvaluation
+    ) : GeneratedPairsPuzzleCandidateRejection {
+        init {
+            require(!evaluation.isAccepted) {
+                "A difficulty-assessment rejection requires unmet policy expectations."
+            }
+        }
+    }
+
+    data class DifficultyAssessmentUnavailable(
+        override val attempt: Int,
+        val outcome: GeneratedPuzzleDifficultyAssessmentOutcome
+    ) : GeneratedPairsPuzzleCandidateRejection {
+        init {
+            require(outcome is GeneratedPuzzleDifficultyAssessmentOutcome.Unsatisfiable) {
+                "Only an unsatisfiable assessment can be recorded as unavailable."
             }
         }
     }

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsGenerationModel.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsGenerationModel.kt
@@ -15,6 +15,8 @@ internal data class GeneratedPairsSolvedCandidate(
 
 internal data class GeneratedPairsVariationPlan(
     val primeProductDecoyDirective: GeneratedPairsPrimeProductDecoyDirective,
+    val repeatedValueGroupDirective: GeneratedPairsRepeatedValueGroupDirective =
+        GeneratedPairsRepeatedValueGroupDirective.Unrestricted,
     val stripEntryVisibilityDirectives: Map<StripEntryId, GeneratedPairsStripEntryVisibilityDirective>
 )
 
@@ -27,6 +29,20 @@ internal sealed interface GeneratedPairsPrimeProductDecoyDirective {
         init {
             require(pairCount > 0) {
                 "A prime-product decoy inclusion directive requires a positive pair count."
+            }
+        }
+    }
+}
+
+internal sealed interface GeneratedPairsRepeatedValueGroupDirective {
+    data object Unrestricted : GeneratedPairsRepeatedValueGroupDirective
+
+    data object Exclude : GeneratedPairsRepeatedValueGroupDirective
+
+    data class Include(val groupCount: Int) : GeneratedPairsRepeatedValueGroupDirective {
+        init {
+            require(groupCount > 0) {
+                "A repeated-value group inclusion directive requires a positive group count."
             }
         }
     }

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsValuePairSelector.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsValuePairSelector.kt
@@ -36,11 +36,12 @@ internal class GeneratedPairsValuePairSelector(
         val plannedPairs = chooseValuePairs(
             candidatePairs = candidatePairs,
             primeProductDecoyDirective = variationPlan.primeProductDecoyDirective,
+            repeatedValueGroupDirective = variationPlan.repeatedValueGroupDirective,
             searchControl = searchControl
         )
 
         if (plannedPairs !is GeneratedPairsSearchOutcome.NoCandidate ||
-            variationPlan.primeProductDecoyDirective == GeneratedPairsPrimeProductDecoyDirective.Unrestricted
+            variationPlan.hasNoValuePairVarietyDirectives()
         ) {
             return plannedPairs
         }
@@ -48,6 +49,7 @@ internal class GeneratedPairsValuePairSelector(
         return chooseValuePairs(
             candidatePairs = candidatePairs,
             primeProductDecoyDirective = GeneratedPairsPrimeProductDecoyDirective.Unrestricted,
+            repeatedValueGroupDirective = GeneratedPairsRepeatedValueGroupDirective.Unrestricted,
             searchControl = searchControl
         )
     }
@@ -55,6 +57,7 @@ internal class GeneratedPairsValuePairSelector(
     private fun chooseValuePairs(
         candidatePairs: List<GeneratedPairsValuePair>,
         primeProductDecoyDirective: GeneratedPairsPrimeProductDecoyDirective,
+        repeatedValueGroupDirective: GeneratedPairsRepeatedValueGroupDirective,
         searchControl: GeneratedPairsSearchControl?
     ): GeneratedPairsSearchOutcome<List<GeneratedPairsValuePair>> = chooseValuePairs(
         candidatePairs = candidatePairs,
@@ -63,7 +66,9 @@ internal class GeneratedPairsValuePairSelector(
         usedResults = emptySet(),
         productAnchorCount = 0,
         primeProductDecoyCount = 0,
+        minimumCandidateIndex = 0,
         primeProductDecoyDirective = primeProductDecoyDirective,
+        repeatedValueGroupDirective = repeatedValueGroupDirective,
         searchControl = searchControl
     )
 
@@ -74,7 +79,9 @@ internal class GeneratedPairsValuePairSelector(
         usedResults: Set<Int>,
         productAnchorCount: Int,
         primeProductDecoyCount: Int,
+        minimumCandidateIndex: Int,
         primeProductDecoyDirective: GeneratedPairsPrimeProductDecoyDirective,
+        repeatedValueGroupDirective: GeneratedPairsRepeatedValueGroupDirective,
         searchControl: GeneratedPairsSearchControl?
     ): GeneratedPairsSearchOutcome<List<GeneratedPairsValuePair>> {
         searchControl?.check()?.let { result ->
@@ -99,10 +106,20 @@ internal class GeneratedPairsValuePairSelector(
             return GeneratedPairsSearchOutcome.NoCandidate
         }
 
+        val repeatedValueGroupCount = valueOccurrences.repeatedValueGroupCount()
+        if (!repeatedValueGroupDirective.canStillBeSatisfied(
+                currentGroupCount = repeatedValueGroupCount,
+                remainingPairSlots = profile.size.pairCount - selectedPairs.size
+            )
+        ) {
+            return GeneratedPairsSearchOutcome.NoCandidate
+        }
+
         if (selectedPairs.size == profile.size.pairCount) {
             return if (
                 constraints.isComplete(pairs = selectedPairs) &&
-                primeProductDecoyDirective.isSatisfiedBy(pairCount = primeProductDecoyCount)
+                primeProductDecoyDirective.isSatisfiedBy(pairCount = primeProductDecoyCount) &&
+                repeatedValueGroupDirective.isSatisfiedBy(groupCount = repeatedValueGroupCount)
             ) {
                 GeneratedPairsSearchOutcome.Found(selectedPairs)
             } else {
@@ -110,19 +127,28 @@ internal class GeneratedPairsValuePairSelector(
             }
         }
 
-        val orderedCandidatePairs = if (
+        var orderedCandidatePairs = candidatePairs.withIndex()
+            .filter { indexedPair -> indexedPair.index >= minimumCandidateIndex }
+        if (repeatedValueGroupDirective.shouldPreferRepeatedValueGroup(
+                currentGroupCount = repeatedValueGroupCount
+            )
+        ) {
+            orderedCandidatePairs = orderedCandidatePairs.sortedByDescending { indexedPair ->
+                valueOccurrences.with(indexedPair.value).repeatedValueGroupCount() - repeatedValueGroupCount
+            }
+        }
+        if (
             primeProductDecoyDirective.shouldPreferPrimeProductDecoy(
                 currentPairCount = primeProductDecoyCount
             )
         ) {
-            candidatePairs.sortedByDescending { pair ->
-                if (pair.isPrimeProductDecoy()) 1 else 0
+            orderedCandidatePairs = orderedCandidatePairs.sortedByDescending { indexedPair ->
+                if (indexedPair.value.isPrimeProductDecoy()) 1 else 0
             }
-        } else {
-            candidatePairs
         }
 
-        orderedCandidatePairs.forEach { candidatePair ->
+        orderedCandidatePairs.forEach { indexedPair ->
+            val candidatePair = indexedPair.value
             searchControl?.consumeCandidateExpansion()?.let { result ->
                 if (result != GeneratedPairsSearchControlResult.Continue) {
                     return result.toSearchOutcome()
@@ -144,17 +170,27 @@ internal class GeneratedPairsValuePairSelector(
             if (!primeProductDecoyDirective.allows(pairCount = updatedPrimeProductDecoyCount)) {
                 return@forEach
             }
+            val updatedValueOccurrences = valueOccurrences.with(candidatePair)
+            if (!repeatedValueGroupDirective.allows(
+                    groupCount = updatedValueOccurrences.repeatedValueGroupCount()
+                )
+            ) {
+                return@forEach
+            }
 
             when (
                 val outcome = chooseValuePairs(
                     candidatePairs = candidatePairs,
                     selectedPairs = selectedPairs + candidatePair,
-                    valueOccurrences = valueOccurrences.with(candidatePair),
+                    valueOccurrences = updatedValueOccurrences,
                     usedResults = usedResults + candidatePair.resultValues,
                     productAnchorCount = productAnchorCount +
                         constraints.productAnchorIncrement(pair = candidatePair),
                     primeProductDecoyCount = updatedPrimeProductDecoyCount,
+                    minimumCandidateIndex = indexedPair.index +
+                        if (profile.resultConstraints.allowsDuplicateBoardResults) 0 else 1,
                     primeProductDecoyDirective = primeProductDecoyDirective,
+                    repeatedValueGroupDirective = repeatedValueGroupDirective,
                     searchControl = searchControl
                 )
             ) {
@@ -190,6 +226,10 @@ internal class GeneratedPairsValuePairSelector(
     }
 }
 
+private fun GeneratedPairsVariationPlan.hasNoValuePairVarietyDirectives(): Boolean =
+    primeProductDecoyDirective == GeneratedPairsPrimeProductDecoyDirective.Unrestricted &&
+        repeatedValueGroupDirective == GeneratedPairsRepeatedValueGroupDirective.Unrestricted
+
 private val GeneratedPairsPrimeProductDecoyDirective.requiredPairCount: Int?
     get() = when (this) {
         GeneratedPairsPrimeProductDecoyDirective.Unrestricted -> null
@@ -215,6 +255,34 @@ private fun GeneratedPairsPrimeProductDecoyDirective.shouldPreferPrimeProductDec
 
 private fun GeneratedPairsPrimeProductDecoyDirective.allows(pairCount: Int): Boolean =
     requiredPairCount?.let { requiredPairCount -> pairCount <= requiredPairCount } ?: true
+
+private val GeneratedPairsRepeatedValueGroupDirective.requiredGroupCount: Int?
+    get() = when (this) {
+        GeneratedPairsRepeatedValueGroupDirective.Unrestricted -> null
+        GeneratedPairsRepeatedValueGroupDirective.Exclude -> 0
+        is GeneratedPairsRepeatedValueGroupDirective.Include -> groupCount
+    }
+
+private fun GeneratedPairsRepeatedValueGroupDirective.canStillBeSatisfied(
+    currentGroupCount: Int,
+    remainingPairSlots: Int
+): Boolean {
+    val requiredGroupCount = requiredGroupCount ?: return true
+
+    return currentGroupCount <= requiredGroupCount &&
+        currentGroupCount + remainingPairSlots * 2 >= requiredGroupCount
+}
+
+private fun GeneratedPairsRepeatedValueGroupDirective.isSatisfiedBy(groupCount: Int): Boolean =
+    requiredGroupCount?.let { requiredGroupCount -> groupCount == requiredGroupCount } ?: true
+
+private fun GeneratedPairsRepeatedValueGroupDirective.shouldPreferRepeatedValueGroup(currentGroupCount: Int): Boolean =
+    requiredGroupCount?.let { requiredGroupCount -> currentGroupCount < requiredGroupCount } ?: false
+
+private fun GeneratedPairsRepeatedValueGroupDirective.allows(groupCount: Int): Boolean =
+    requiredGroupCount?.let { requiredGroupCount -> groupCount <= requiredGroupCount } ?: true
+
+private fun Map<Int, Int>.repeatedValueGroupCount(): Int = values.count { occurrenceCount -> occurrenceCount > 1 }
 
 private fun Map<Int, Int>.with(pair: GeneratedPairsValuePair): Map<Int, Int> {
     val updatedOccurrences = toMutableMap()

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsVariationPlanSelector.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsVariationPlanSelector.kt
@@ -22,6 +22,7 @@ internal class GeneratedPairsVariationPlanSelector(
 
     fun select(): GeneratedPairsVariationPlan = GeneratedPairsVariationPlan(
         primeProductDecoyDirective = selectPrimeProductDecoyDirective(),
+        repeatedValueGroupDirective = selectRepeatedValueGroupDirective(),
         stripEntryVisibilityDirectives = selectStripEntryVisibilityDirectives()
     )
 
@@ -39,6 +40,17 @@ internal class GeneratedPairsVariationPlanSelector(
                     GeneratedPairsPrimeProductDecoyDirective.Exclude
                 }
             }
+        }
+    }
+
+    private fun selectRepeatedValueGroupDirective(): GeneratedPairsRepeatedValueGroupDirective {
+        val target = profile.varietyPolicy.repeatedValueGroupTarget
+            ?: return GeneratedPairsRepeatedValueGroupDirective.Unrestricted
+
+        return if (shouldApply(probability = target.targetPuzzlePercent)) {
+            GeneratedPairsRepeatedValueGroupDirective.Include(groupCount = target.targetGroupCount)
+        } else {
+            GeneratedPairsRepeatedValueGroupDirective.Exclude
         }
     }
 

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPuzzleConstraints.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPuzzleConstraints.kt
@@ -106,6 +106,20 @@ internal class GeneratedStripValueConstraint(private val policy: StripValuePolic
                 )
             )
         }
+
+        policy.maxRepeatedValueGroupCount?.let { maximumAllowed ->
+            val repeatedValueGroups = values.groupingBy { value -> value }
+                .eachCount()
+                .filterValues { occurrenceCount -> occurrenceCount > 1 }
+            if (repeatedValueGroups.size > maximumAllowed) {
+                add(
+                    GeneratedPairsPuzzleValidationViolation.RepeatedStripValueGroupCountExceeded(
+                        maximumAllowed = maximumAllowed,
+                        observedRepeatedValues = repeatedValueGroups.keys
+                    )
+                )
+            }
+        }
     }
 }
 
@@ -222,7 +236,7 @@ internal class GeneratedStripMaskConstraint(private val profile: GeneratedPuzzle
         knownEntryIds: Set<StripEntryId>,
         solutionPairs: Set<UnorderedStripEntryPair>
     ): Boolean = when (profile.initialStripMaskPolicy.distributionPolicy) {
-        StripKnownEntryDistributionPolicy.SPREAD_ACROSS_STRIP_AND_PAIRS_WHEN_POSSIBLE -> {
+        StripKnownEntryDistributionPolicy.SpreadAcrossStripAndPairsWhenPossible -> {
             val solutionPairByEntryId = solutionPairs.flatMap { solutionPair ->
                 listOf(
                     solutionPair.firstEntryId to solutionPair,
@@ -235,7 +249,18 @@ internal class GeneratedStripMaskConstraint(private val profile: GeneratedPuzzle
                 knownSolutionPairs.toSet().size == knownEntryIds.size
         }
 
-        StripKnownEntryDistributionPolicy.UNRESTRICTED -> true
+        is StripKnownEntryDistributionPolicy.AtLeastDistinctSolutionPairs -> {
+            val policy = profile.initialStripMaskPolicy.distributionPolicy
+            val solutionPairByEntryId = solutionPairs.flatMap { solutionPair ->
+                listOf(
+                    solutionPair.firstEntryId to solutionPair,
+                    solutionPair.secondEntryId to solutionPair
+                )
+            }.toMap()
+            knownEntryIds.mapNotNull(solutionPairByEntryId::get).toSet().size >= policy.minimumPairCount
+        }
+
+        StripKnownEntryDistributionPolicy.Unrestricted -> true
     }
 }
 

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzlePairSpecification.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzlePairSpecification.kt
@@ -47,10 +47,9 @@ internal class GeneratedPuzzlePairSpecification(
 
     fun canBeAdded(pair: GeneratedPuzzlePairValues, valueOccurrences: Map<Int, Int>, usedResults: Set<Int>): Boolean =
         isLocallyEligible(pair = pair) &&
-            pair.values.groupingBy { value -> value }.eachCount().all { (value, addedOccurrences) ->
-                valueOccurrences.getOrDefault(value, 0) + addedOccurrences <=
-                    stripValuePolicy.maxOccurrencesPerValue
-            } &&
+            stripValuePolicy.accepts(
+                occurrencesByValue = valueOccurrences.with(pair = pair)
+            ) &&
             resultConstraints.acceptsAdditionalBoardResults(
                 usedResults = usedResults,
                 newResults = pair.results.mapTo(mutableSetOf(), Long::toInt)
@@ -191,10 +190,15 @@ private fun Map<Int, Int>.with(pair: GeneratedPuzzlePairValues): Map<Int, Int> {
 }
 
 internal fun StripValuePolicy.accepts(values: List<Int>): Boolean = values.all { value -> value in valueRange } &&
-    values.groupingBy { value -> value }
-        .eachCount()
-        .values
-        .all { occurrenceCount -> occurrenceCount <= maxOccurrencesPerValue }
+    accepts(occurrencesByValue = values.groupingBy { value -> value }.eachCount())
+
+internal fun StripValuePolicy.accepts(occurrencesByValue: Map<Int, Int>): Boolean =
+    occurrencesByValue.all { (value, occurrenceCount) ->
+        value in valueRange && occurrenceCount <= maxOccurrencesPerValue
+    } &&
+        maxRepeatedValueGroupCount?.let { maximumGroupCount ->
+            occurrencesByValue.values.count { occurrenceCount -> occurrenceCount > 1 } <= maximumGroupCount
+        } != false
 
 internal fun ResultConstraints.acceptsMultiplicationResult(result: Long): Boolean = result <= maxMultiplicationResult
 

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfile.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfile.kt
@@ -1,5 +1,7 @@
 package org.cescfe.numpairs.domain.generated.profile
 
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficultyAssessmentPolicy
+
 data class GeneratedPuzzleProfileId(val value: String) {
     init {
         require(value.isNotBlank()) {
@@ -16,7 +18,8 @@ data class GeneratedPuzzleProfileDefinition(
     val resultConstraints: ResultConstraints,
     val initialStripMaskPolicy: InitialStripMaskPolicy,
     val generationPolicy: GenerationPolicy,
-    val varietyPolicy: GeneratedPuzzleVarietyPolicy = GeneratedPuzzleVarietyPolicy()
+    val varietyPolicy: GeneratedPuzzleVarietyPolicy = GeneratedPuzzleVarietyPolicy(),
+    val difficultyAssessmentPolicy: GeneratedPuzzleDifficultyAssessmentPolicy? = null
 )
 
 class GeneratedPuzzleProfile private constructor(definition: GeneratedPuzzleProfileDefinition) {
@@ -28,6 +31,7 @@ class GeneratedPuzzleProfile private constructor(definition: GeneratedPuzzleProf
     val initialStripMaskPolicy: InitialStripMaskPolicy = definition.initialStripMaskPolicy
     val generationPolicy: GenerationPolicy = definition.generationPolicy
     val varietyPolicy: GeneratedPuzzleVarietyPolicy = definition.varietyPolicy
+    val difficultyAssessmentPolicy: GeneratedPuzzleDifficultyAssessmentPolicy? = definition.difficultyAssessmentPolicy
 
     val hiddenEntryCountRange: IntRange = initialStripMaskPolicy.knownEntryCountRange.let { knownCountRange ->
         (size.stripEntryCount - knownCountRange.last)..(size.stripEntryCount - knownCountRange.first)
@@ -76,7 +80,11 @@ data class GeneratedPuzzleSize(val pairCount: Int) {
     val boardTileCount: Int = pairCount * 2
 }
 
-data class StripValuePolicy(val valueRange: IntRange, val maxOccurrencesPerValue: Int) {
+data class StripValuePolicy(
+    val valueRange: IntRange,
+    val maxOccurrencesPerValue: Int,
+    val maxRepeatedValueGroupCount: Int? = null
+) {
     init {
         require(!valueRange.isEmpty()) {
             "Strip value range must not be empty."
@@ -86,6 +94,9 @@ data class StripValuePolicy(val valueRange: IntRange, val maxOccurrencesPerValue
         }
         require(maxOccurrencesPerValue >= 1) {
             "Maximum occurrences per strip value must be at least 1."
+        }
+        require(maxRepeatedValueGroupCount == null || maxRepeatedValueGroupCount >= 0) {
+            "Maximum repeated strip-value group count must not be negative."
         }
     }
 
@@ -142,14 +153,24 @@ internal fun Set<RequiredKnownStripAnchor>.resolveEntryIds(stripEntryCount: Int)
     }
 }.toSet()
 
-enum class StripKnownEntryDistributionPolicy {
-    SPREAD_ACROSS_STRIP_AND_PAIRS_WHEN_POSSIBLE,
-    UNRESTRICTED
+sealed interface StripKnownEntryDistributionPolicy {
+    data object SpreadAcrossStripAndPairsWhenPossible : StripKnownEntryDistributionPolicy
+
+    data object Unrestricted : StripKnownEntryDistributionPolicy
+
+    data class AtLeastDistinctSolutionPairs(val minimumPairCount: Int) : StripKnownEntryDistributionPolicy {
+        init {
+            require(minimumPairCount > 0) {
+                "Minimum distinct solution-pair count must be positive."
+            }
+        }
+    }
 }
 
 data class GeneratedPuzzleVarietyPolicy(
     val highValueMaskTargets: List<HighValueMaskTarget> = emptyList(),
-    val primeProductDecoyTarget: PrimeProductDecoyTarget? = null
+    val primeProductDecoyTarget: PrimeProductDecoyTarget? = null,
+    val repeatedValueGroupTarget: RepeatedValueGroupTarget? = null
 )
 
 data class HighValueMaskTarget(val rankFromHighest: Int, val targetHiddenProbability: ProbabilityPercent)
@@ -172,6 +193,14 @@ data class PrimeProductDecoyTarget(
     init {
         require(targetPairCount > 0) {
             "Prime-product decoy target pair count must be positive."
+        }
+    }
+}
+
+data class RepeatedValueGroupTarget(val targetPuzzlePercent: ProbabilityPercent, val targetGroupCount: Int) {
+    init {
+        require(targetGroupCount > 0) {
+            "Repeated-value target group count must be positive."
         }
     }
 }

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileCreation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileCreation.kt
@@ -26,6 +26,7 @@ enum class GeneratedPuzzleProfileRuleId(val code: String) {
     REQUIRED_ANCHOR_CAPACITY("profile.required-anchor-capacity"),
     HIDDEN_RUN_FEASIBILITY("profile.hidden-run-feasibility"),
     SPREAD_DISTRIBUTION_CAPACITY("profile.spread-distribution-capacity"),
+    DISTINCT_SOLUTION_PAIR_DISTRIBUTION_FEASIBILITY("profile.distinct-solution-pair-distribution-feasibility"),
     HIGH_VALUE_TARGET_RANK("profile.high-value-target-rank"),
     DUPLICATE_HIGH_VALUE_TARGET_RANK("profile.duplicate-high-value-target-rank"),
     HIGH_VALUE_TARGET_ANCHOR_CONFLICT("profile.high-value-target-anchor-conflict"),
@@ -36,6 +37,7 @@ enum class GeneratedPuzzleProfileRuleId(val code: String) {
     PRODUCT_ANCHOR_SELECTION_FEASIBILITY("profile.product-anchor-selection-feasibility"),
     PRIME_DECOY_TARGET_COUNT("profile.prime-decoy-target-count"),
     PRIME_DECOY_TARGET_FEASIBILITY("profile.prime-decoy-target-feasibility"),
+    REPEATED_VALUE_GROUP_TARGET_FEASIBILITY("profile.repeated-value-group-target-feasibility"),
     ELIGIBLE_VALUE_PAIR_CATALOG("profile.eligible-value-pair-catalog"),
     ARITHMETIC_RESULT_RANGE("profile.arithmetic-result-range"),
     VALIDATION_WORK_LIMIT("profile.validation-work-limit")
@@ -71,6 +73,15 @@ sealed interface GeneratedPuzzleProfileViolation {
         GeneratedPuzzleProfileViolation {
         override val ruleId: GeneratedPuzzleProfileRuleId =
             GeneratedPuzzleProfileRuleId.SPREAD_DISTRIBUTION_CAPACITY
+    }
+
+    data class DistinctSolutionPairDistributionInfeasible(
+        val minimumRequiredPairCount: Int,
+        val puzzlePairCount: Int,
+        val maximumKnownEntryCount: Int
+    ) : GeneratedPuzzleProfileViolation {
+        override val ruleId: GeneratedPuzzleProfileRuleId =
+            GeneratedPuzzleProfileRuleId.DISTINCT_SOLUTION_PAIR_DISTRIBUTION_FEASIBILITY
     }
 
     data class HighValueTargetRankOutsidePuzzle(val rankFromHighest: Int, val stripEntryCount: Int) :
@@ -139,6 +150,15 @@ sealed interface GeneratedPuzzleProfileViolation {
     ) : GeneratedPuzzleProfileViolation {
         override val ruleId: GeneratedPuzzleProfileRuleId =
             GeneratedPuzzleProfileRuleId.PRIME_DECOY_TARGET_FEASIBILITY
+    }
+
+    data class RepeatedValueGroupTargetUnreachable(
+        val targetGroupCount: Int,
+        val maxOccurrencesPerValue: Int,
+        val maxRepeatedValueGroupCount: Int?
+    ) : GeneratedPuzzleProfileViolation {
+        override val ruleId: GeneratedPuzzleProfileRuleId =
+            GeneratedPuzzleProfileRuleId.REPEATED_VALUE_GROUP_TARGET_FEASIBILITY
     }
 
     data class InsufficientEligibleValuePairCatalog(

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileSpecification.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileSpecification.kt
@@ -223,7 +223,8 @@ private object GeneratedPuzzleProfileStructuralEvaluator {
         definition.varietyPolicy.repeatedValueGroupTarget?.let { target ->
             val maximumConfiguredGroupCount = definition.stripValuePolicy.maxRepeatedValueGroupCount
             if (definition.stripValuePolicy.maxOccurrencesPerValue < 2 ||
-                maximumConfiguredGroupCount != null && target.targetGroupCount > maximumConfiguredGroupCount ||
+                maximumConfiguredGroupCount != null &&
+                target.targetGroupCount > maximumConfiguredGroupCount ||
                 target.targetGroupCount > definition.size.stripEntryCount / 2
             ) {
                 add(

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileSpecification.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileSpecification.kt
@@ -67,7 +67,12 @@ private object GeneratedPuzzleProfileStructuralEvaluator {
     ) {
         val valuePolicy = definition.stripValuePolicy
         val distinctValueCount = valuePolicy.valueRange.last.toLong() - valuePolicy.valueRange.first + 1L
-        val availableEntryCount = distinctValueCount * valuePolicy.maxOccurrencesPerValue
+        val repeatedGroupCount = minOf(
+            distinctValueCount,
+            valuePolicy.maxRepeatedValueGroupCount?.toLong() ?: distinctValueCount
+        )
+        val availableEntryCount = distinctValueCount +
+            repeatedGroupCount * (valuePolicy.maxOccurrencesPerValue - 1L)
 
         if (availableEntryCount < definition.size.stripEntryCount) {
             add(
@@ -125,6 +130,20 @@ private object GeneratedPuzzleProfileStructuralEvaluator {
                 )
             )
         }
+        (maskPolicy.distributionPolicy as? StripKnownEntryDistributionPolicy.AtLeastDistinctSolutionPairs)
+            ?.let { distributionPolicy ->
+                if (distributionPolicy.minimumPairCount > definition.size.pairCount ||
+                    distributionPolicy.minimumPairCount > maskPolicy.knownEntryCountRange.last
+                ) {
+                    add(
+                        GeneratedPuzzleProfileViolation.DistinctSolutionPairDistributionInfeasible(
+                            minimumRequiredPairCount = distributionPolicy.minimumPairCount,
+                            puzzlePairCount = definition.size.pairCount,
+                            maximumKnownEntryCount = maskPolicy.knownEntryCountRange.last
+                        )
+                    )
+                }
+            }
     }
 
     private fun MutableList<GeneratedPuzzleProfileViolation>.addProductAnchorStructureViolations(
@@ -197,6 +216,21 @@ private object GeneratedPuzzleProfileStructuralEvaluator {
                     GeneratedPuzzleProfileViolation.PrimeDecoyTargetCountOutsidePuzzle(
                         targetPairCount = target.targetPairCount,
                         pairCount = definition.size.pairCount
+                    )
+                )
+            }
+        }
+        definition.varietyPolicy.repeatedValueGroupTarget?.let { target ->
+            val maximumConfiguredGroupCount = definition.stripValuePolicy.maxRepeatedValueGroupCount
+            if (definition.stripValuePolicy.maxOccurrencesPerValue < 2 ||
+                maximumConfiguredGroupCount != null && target.targetGroupCount > maximumConfiguredGroupCount ||
+                target.targetGroupCount > definition.size.stripEntryCount / 2
+            ) {
+                add(
+                    GeneratedPuzzleProfileViolation.RepeatedValueGroupTargetUnreachable(
+                        targetGroupCount = target.targetGroupCount,
+                        maxOccurrencesPerValue = definition.stripValuePolicy.maxOccurrencesPerValue,
+                        maxRepeatedValueGroupCount = maximumConfiguredGroupCount
                     )
                 )
             }
@@ -490,6 +524,7 @@ private fun GeneratedPuzzleProfileDefinition.requiredKnownEntryIds(): Set<Int> =
 
 private fun GeneratedPuzzleProfileDefinition.maximumKnownCountAllowedByDistribution(): Int =
     when (initialStripMaskPolicy.distributionPolicy) {
-        StripKnownEntryDistributionPolicy.SPREAD_ACROSS_STRIP_AND_PAIRS_WHEN_POSSIBLE -> size.pairCount
-        StripKnownEntryDistributionPolicy.UNRESTRICTED -> size.stripEntryCount
+        StripKnownEntryDistributionPolicy.SpreadAcrossStripAndPairsWhenPossible -> size.pairCount
+        is StripKnownEntryDistributionPolicy.AtLeastDistinctSolutionPairs -> size.stripEntryCount
+        StripKnownEntryDistributionPolicy.Unrestricted -> size.stripEntryCount
     }

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfiles.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfiles.kt
@@ -1,9 +1,13 @@
 package org.cescfe.numpairs.domain.generated.profile
 
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficultyAssessmentExecutionPolicy
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficultyAssessmentPolicy
+
 object GeneratedPuzzleProfiles {
     val FOUR_PAIRS_LOW: GeneratedPuzzleProfile = fourPairsLow()
+    val FOUR_PAIRS_MEDIUM: GeneratedPuzzleProfile = fourPairsMedium()
     val EIGHT_PAIRS_MEDIUM: GeneratedPuzzleProfile = eightPairsMedium()
-    val ALL: List<GeneratedPuzzleProfile> = listOf(FOUR_PAIRS_LOW, EIGHT_PAIRS_MEDIUM)
+    val ALL: List<GeneratedPuzzleProfile> = listOf(FOUR_PAIRS_LOW, FOUR_PAIRS_MEDIUM, EIGHT_PAIRS_MEDIUM)
 
     private fun fourPairsLow(): GeneratedPuzzleProfile {
         val size = GeneratedPuzzleSize(pairCount = 4)
@@ -24,11 +28,79 @@ object GeneratedPuzzleProfiles {
                 initialStripMaskPolicy = InitialStripMaskPolicy(
                     knownEntryCountRange = 3..3,
                     requiredAnchors = setOf(RequiredKnownStripAnchor.HIGHEST_STRIP_ENTRY),
-                    distributionPolicy = StripKnownEntryDistributionPolicy.SPREAD_ACROSS_STRIP_AND_PAIRS_WHEN_POSSIBLE,
+                    distributionPolicy = StripKnownEntryDistributionPolicy.SpreadAcrossStripAndPairsWhenPossible,
                     maxConsecutiveHiddenEntries = 2
                 ),
                 generationPolicy = GenerationPolicy(
                     isBoardTileShufflingEnabled = true
+                )
+            )
+        ).getOrThrow()
+    }
+
+    private fun fourPairsMedium(): GeneratedPuzzleProfile {
+        val size = GeneratedPuzzleSize(pairCount = 4)
+
+        return GeneratedPuzzleProfile.create(
+            definition = GeneratedPuzzleProfileDefinition(
+                id = GeneratedPuzzleProfileId("4-pairs-medium"),
+                difficulty = DifficultyTier.MEDIUM,
+                size = size,
+                stripValuePolicy = StripValuePolicy(
+                    valueRange = 1..40,
+                    maxOccurrencesPerValue = 2,
+                    maxRepeatedValueGroupCount = 1
+                ),
+                resultConstraints = ResultConstraints(
+                    maxMultiplicationResult = 400,
+                    allowsDuplicateBoardResults = false,
+                    productAnchorMix = ProductAnchorMix(
+                        productResultGreaterThan = 80,
+                        countRange = 1..2
+                    )
+                ),
+                initialStripMaskPolicy = InitialStripMaskPolicy(
+                    knownEntryCountRange = 3..3,
+                    requiredAnchors = emptySet(),
+                    distributionPolicy = StripKnownEntryDistributionPolicy.AtLeastDistinctSolutionPairs(
+                        minimumPairCount = 2
+                    ),
+                    maxConsecutiveHiddenEntries = 3
+                ),
+                generationPolicy = GenerationPolicy(
+                    isBoardTileShufflingEnabled = true
+                ),
+                varietyPolicy = GeneratedPuzzleVarietyPolicy(
+                    highValueMaskTargets = listOf(
+                        HighValueMaskTarget(
+                            rankFromHighest = 1,
+                            targetHiddenProbability = ProbabilityPercent(25)
+                        ),
+                        HighValueMaskTarget(
+                            rankFromHighest = 2,
+                            targetHiddenProbability = ProbabilityPercent(40)
+                        )
+                    ),
+                    primeProductDecoyTarget = PrimeProductDecoyTarget(
+                        targetPuzzlePercent = ProbabilityPercent(30),
+                        targetPairCount = 1,
+                        pairPattern = PrimeProductDecoyPairPattern.ONE_AND_PRIME
+                    ),
+                    repeatedValueGroupTarget = RepeatedValueGroupTarget(
+                        targetPuzzlePercent = ProbabilityPercent(35),
+                        targetGroupCount = 1
+                    )
+                ),
+                difficultyAssessmentPolicy = GeneratedPuzzleDifficultyAssessmentPolicy(
+                    executionPolicy = GeneratedPuzzleDifficultyAssessmentExecutionPolicy(
+                        maxCandidateExpansions = 25_000,
+                        validSolutionCountLimit = 20
+                    ),
+                    minimumInitialPlausibleCandidateCount = 6,
+                    minimumInitialForcedDeductionCount = 1,
+                    minimumFirstForcedDeductionDepth = 1,
+                    minimumPlausibleDecoyCount = 1,
+                    minimumValidSolutionCount = 1
                 )
             )
         ).getOrThrow()
@@ -57,7 +129,7 @@ object GeneratedPuzzleProfiles {
                 initialStripMaskPolicy = InitialStripMaskPolicy(
                     knownEntryCountRange = 6..7,
                     requiredAnchors = emptySet(),
-                    distributionPolicy = StripKnownEntryDistributionPolicy.UNRESTRICTED,
+                    distributionPolicy = StripKnownEntryDistributionPolicy.Unrestricted,
                     maxConsecutiveHiddenEntries = 4
                 ),
                 generationPolicy = GenerationPolicy(

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/puzzle/GeneratedPairsPuzzleCreation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/puzzle/GeneratedPairsPuzzleCreation.kt
@@ -118,6 +118,11 @@ sealed interface GeneratedPairsPuzzleValidationViolation {
         override val ruleId = GeneratedPairsPuzzleValidationRuleId.STRIP_VALUE_OCCURRENCE_EXCEEDED
     }
 
+    data class RepeatedStripValueGroupCountExceeded(val maximumAllowed: Int, val observedRepeatedValues: Set<Int>) :
+        GeneratedPairsPuzzleValidationViolation {
+        override val ruleId = GeneratedPairsPuzzleValidationRuleId.REPEATED_STRIP_VALUE_GROUP_COUNT_EXCEEDED
+    }
+
     data class DuplicateBoardResults(val duplicateResults: Set<Int>) : GeneratedPairsPuzzleValidationViolation {
         override val ruleId = GeneratedPairsPuzzleValidationRuleId.DUPLICATE_BOARD_RESULTS
     }
@@ -178,6 +183,7 @@ enum class GeneratedPairsPuzzleValidationRuleId(val code: String) {
     SOLVED_SUM_PRODUCT_PAIRING_MISMATCH("generated.solved-sum-product-pairing-mismatch"),
     STRIP_VALUE_OUTSIDE_RANGE("generated.strip-value-outside-range"),
     STRIP_VALUE_OCCURRENCE_EXCEEDED("generated.strip-value-occurrence-exceeded"),
+    REPEATED_STRIP_VALUE_GROUP_COUNT_EXCEEDED("generated.repeated-strip-value-group-count-exceeded"),
     DUPLICATE_BOARD_RESULTS("generated.duplicate-board-results"),
     MULTIPLICATION_RESULT_EXCEEDED("generated.multiplication-result-exceeded"),
     PRODUCT_ANCHOR_MIX_OUTSIDE_RANGE("generated.product-anchor-mix-outside-range"),

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeConfiguration.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeConfiguration.kt
@@ -142,6 +142,12 @@ object GeneratedModes {
         difficulty = DifficultyTier.LOW,
         profile = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW
     )
+    val FOUR_PAIRS_MEDIUM: GeneratedChallenge = GeneratedChallenge(
+        id = GeneratedChallengeId("four-pairs-medium"),
+        modeId = fourPairsId,
+        difficulty = DifficultyTier.MEDIUM,
+        profile = GeneratedPuzzleProfiles.FOUR_PAIRS_MEDIUM
+    )
     val EIGHT_PAIRS_MEDIUM: GeneratedChallenge = GeneratedChallenge(
         id = GeneratedChallengeId("eight-pairs-medium"),
         modeId = eightPairsId,
@@ -151,7 +157,7 @@ object GeneratedModes {
     val FOUR_PAIRS: GeneratedModeConfiguration = GeneratedModeConfiguration(
         id = fourPairsId,
         size = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW.size,
-        challenges = listOf(FOUR_PAIRS_LOW)
+        challenges = listOf(FOUR_PAIRS_LOW, FOUR_PAIRS_MEDIUM)
     )
     val EIGHT_PAIRS: GeneratedModeConfiguration = GeneratedModeConfiguration(
         id = eightPairsId,

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPairsDifficultyAssessorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPairsDifficultyAssessorTest.kt
@@ -257,7 +257,7 @@ private fun ambiguousProfile(): GeneratedPuzzleProfile = GeneratedPuzzleProfile.
         initialStripMaskPolicy = InitialStripMaskPolicy(
             knownEntryCountRange = 0..0,
             requiredAnchors = emptySet(),
-            distributionPolicy = StripKnownEntryDistributionPolicy.UNRESTRICTED,
+            distributionPolicy = StripKnownEntryDistributionPolicy.Unrestricted,
             maxConsecutiveHiddenEntries = 4
         ),
         generationPolicy = GenerationPolicy(isBoardTileShufflingEnabled = true)

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPuzzleDifficultyAssessmentPolicyTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPuzzleDifficultyAssessmentPolicyTest.kt
@@ -1,0 +1,65 @@
+package org.cescfe.numpairs.domain.generated.assessment
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GeneratedPuzzleDifficultyAssessmentPolicyTest {
+    @Test
+    fun policy_reports_each_unmet_difficulty_expectation_without_requiring_uniqueness() {
+        val policy = GeneratedPuzzleDifficultyAssessmentPolicy(
+            executionPolicy = GeneratedPuzzleDifficultyAssessmentExecutionPolicy(validSolutionCountLimit = 20),
+            minimumInitialPlausibleCandidateCount = 6,
+            minimumInitialForcedDeductionCount = 1,
+            minimumFirstForcedDeductionDepth = 1,
+            minimumPlausibleDecoyCount = 1,
+            minimumValidSolutionCount = 1
+        )
+        val acceptedReport = report(
+            initialPlausibleCandidateCount = 6,
+            initialForcedDeductionCount = 1,
+            firstForcedDeductionDepth = 1,
+            plausibleDecoyCount = 1,
+            validSolutionCount = 2
+        )
+
+        assertTrue(policy.evaluate(acceptedReport).isAccepted)
+        assertEquals(
+            GeneratedPuzzleDifficultyRequirement.entries.toSet(),
+            policy.evaluate(
+                report(
+                    initialPlausibleCandidateCount = 5,
+                    initialForcedDeductionCount = 0,
+                    firstForcedDeductionDepth = null,
+                    plausibleDecoyCount = 0,
+                    validSolutionCount = 0
+                )
+            ).unmetRequirements
+        )
+    }
+}
+
+private fun report(
+    initialPlausibleCandidateCount: Int,
+    initialForcedDeductionCount: Int,
+    firstForcedDeductionDepth: Int?,
+    plausibleDecoyCount: Int,
+    validSolutionCount: Int
+): GeneratedPuzzleDifficultyAssessmentReport = GeneratedPuzzleDifficultyAssessmentReport(
+    initialPlausibleCandidateCount = initialPlausibleCandidateCount,
+    initialForcedDeductionCount = initialForcedDeductionCount,
+    forcedDeductionCount = initialForcedDeductionCount,
+    firstForcedDeductionDepth = firstForcedDeductionDepth,
+    maximumBranchingFactor = 0,
+    exploredAmbiguousStateCount = 0,
+    boundedValidSolutionCount = validSolutionCount,
+    isValidSolutionCountLimitReached = false,
+    structuralObservations = GeneratedPuzzleStructuralObservations(
+        knownEntryCount = 3,
+        longestHiddenRun = 3,
+        knownStripAnchorCount = 0,
+        unambiguousResultAnchorCount = 0,
+        repeatedValueGroupCountRange = 0..1,
+        plausibleDecoyCount = plausibleDecoyCount
+    )
+)

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/FourPairsMediumGeneratedPairsPuzzleGeneratorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/FourPairsMediumGeneratedPairsPuzzleGeneratorTest.kt
@@ -1,0 +1,181 @@
+package org.cescfe.numpairs.domain.generated.generation
+
+import kotlin.math.abs
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPairsDifficultyAssessor
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficultyAssessmentOutcome
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfiles
+import org.cescfe.numpairs.domain.generated.profile.ProbabilityPercent
+import org.cescfe.numpairs.domain.puzzle.assignment.StripEntryId
+import org.cescfe.numpairs.domain.puzzle.assignment.analyzeResolvedPuzzle
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.cescfe.numpairs.domain.puzzle.model.Tile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FourPairsMediumGeneratedPairsPuzzleGeneratorTest {
+    @Test
+    fun four_pairs_medium_generation_satisfies_the_documented_profile() {
+        val profile = GeneratedPuzzleProfiles.FOUR_PAIRS_MEDIUM
+        val generatedPuzzle = generatedPuzzle(profile = profile, seed = 42)
+        val solvedPuzzle = generatedPuzzle.solvedPuzzle
+        val initialPuzzle = generatedPuzzle.initialPuzzle
+        val solvedValues = solvedPuzzle.requireKnownStripValues()
+        val repeatedValueGroupCount = solvedValues.groupingBy { value -> value }
+            .eachCount()
+            .values
+            .count { occurrenceCount -> occurrenceCount > 1 }
+        val anchorMix = requireNotNull(profile.resultConstraints.productAnchorMix)
+        val productAnchorCount = solvedPuzzle.multiplicationTiles().count { tile ->
+            tile.result > anchorMix.productResultGreaterThan
+        }
+
+        assertTrue(solvedValues.all { value -> value in 1..40 })
+        assertTrue(
+            solvedValues.groupingBy { value -> value }.eachCount().values
+                .all { occurrenceCount -> occurrenceCount <= 2 }
+        )
+        assertTrue(repeatedValueGroupCount <= 1)
+        assertTrue(solvedPuzzle.multiplicationTiles().all { tile -> tile.result <= 400 })
+        assertEquals(profile.size.boardTileCount, solvedPuzzle.board.tiles.map(Tile::result).toSet().size)
+        assertTrue(productAnchorCount in 1..2)
+        assertEquals(3, initialPuzzle.knownEntryIds().size)
+        assertEquals(5, initialPuzzle.strip.entries.count { entry -> entry.item == StripItem.Hidden })
+        assertTrue(initialPuzzle.knownEntryIds().distinctSolutionPairCount(generatedPuzzle) >= 2)
+        assertTrue(initialPuzzle.knownEntryIds().maxConsecutiveHiddenEntries(8) <= 3)
+    }
+
+    @Test
+    fun four_pairs_medium_generation_is_deterministic_for_the_same_seed() {
+        val profile = GeneratedPuzzleProfiles.FOUR_PAIRS_MEDIUM
+
+        assertEquals(
+            generatedPuzzle(profile = profile, seed = 1234),
+            generatedPuzzle(profile = profile, seed = 1234)
+        )
+    }
+
+    @Test
+    fun four_pairs_medium_meets_documented_population_targets() {
+        val profile = GeneratedPuzzleProfiles.FOUR_PAIRS_MEDIUM
+        val generatedPuzzles = (1..VARIETY_SAMPLE_SIZE).map { seed ->
+            generatedPuzzle(profile = profile, seed = seed)
+        }
+        val repeatedTarget = requireNotNull(profile.varietyPolicy.repeatedValueGroupTarget)
+        val repeatedPuzzleCount = generatedPuzzles.count { puzzle ->
+            puzzle.solvedPuzzle.requireKnownStripValues().groupingBy { value -> value }
+                .eachCount()
+                .values
+                .count { occurrenceCount -> occurrenceCount > 1 } == repeatedTarget.targetGroupCount
+        }
+        val decoyTarget = requireNotNull(profile.varietyPolicy.primeProductDecoyTarget)
+        val primeProductDecoyPuzzleCount = generatedPuzzles.count { puzzle ->
+            puzzle.solvedPuzzle.multiplicationTiles().count(Tile::isPrimeProductDecoy) == decoyTarget.targetPairCount
+        }
+
+        assertFrequencyWithinTarget(
+            actualCount = repeatedPuzzleCount,
+            targetPercentage = repeatedTarget.targetPuzzlePercent
+        )
+        assertFrequencyWithinTarget(
+            actualCount = primeProductDecoyPuzzleCount,
+            targetPercentage = decoyTarget.targetPuzzlePercent
+        )
+        profile.varietyPolicy.highValueMaskTargets.forEach { target ->
+            val targetEntryIndex = profile.size.stripEntryCount - target.rankFromHighest
+            val hiddenPuzzleCount = generatedPuzzles.count { puzzle ->
+                puzzle.initialPuzzle.strip.entries[targetEntryIndex].item == StripItem.Hidden
+            }
+            assertFrequencyWithinTarget(
+                actualCount = hiddenPuzzleCount,
+                targetPercentage = target.targetHiddenProbability
+            )
+        }
+    }
+
+    @Test
+    fun every_sampled_medium_puzzle_passes_the_bounded_assessment_policy() {
+        val mediumProfile = GeneratedPuzzleProfiles.FOUR_PAIRS_MEDIUM
+        val mediumPolicy = requireNotNull(mediumProfile.difficultyAssessmentPolicy)
+        val assessor = GeneratedPairsDifficultyAssessor()
+        val lowOpeningCandidateMaximum = listOf(1, 42).maxOf { seed ->
+            val lowPuzzle = generatedPuzzle(profile = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW, seed = seed)
+            val outcome = assessor.assess(
+                initialPuzzle = lowPuzzle.initialPuzzle,
+                profile = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW
+            ) as GeneratedPuzzleDifficultyAssessmentOutcome.Assessed
+            outcome.report.initialPlausibleCandidateCount
+        }
+
+        ASSESSMENT_SEEDS.forEach { seed ->
+            val puzzle = generatedPuzzle(profile = mediumProfile, seed = seed)
+            val outcome = assessor.assess(
+                initialPuzzle = puzzle.initialPuzzle,
+                profile = mediumProfile,
+                executionPolicy = mediumPolicy.executionPolicy
+            )
+            assertTrue(
+                "Assessment must complete for seed $seed.",
+                outcome is GeneratedPuzzleDifficultyAssessmentOutcome.Assessed
+            )
+            val report = (outcome as GeneratedPuzzleDifficultyAssessmentOutcome.Assessed).report
+            assertTrue("Assessment policy must accept seed $seed.", mediumPolicy.evaluate(report).isAccepted)
+            assertTrue(report.initialPlausibleCandidateCount > lowOpeningCandidateMaximum)
+        }
+    }
+
+    @Test
+    fun four_pairs_medium_preserves_bounded_failure_and_cancellation() {
+        val profile = GeneratedPuzzleProfiles.FOUR_PAIRS_MEDIUM
+        val budgetFailure = GeneratedPairsPuzzleGenerator(profile).generate(
+            request = GeneratedPuzzleGenerationRequest(
+                profile = profile,
+                seed = 2026,
+                executionPolicy = GeneratedPuzzleGenerationExecutionPolicy(
+                    maxAttempts = 1,
+                    maxSearchWork = 1
+                )
+            )
+        ) as GeneratedPairsPuzzleGenerationOutcome.Failed
+        assertEquals(GeneratedPairsPuzzleGenerationFailureReason.SearchBudgetExhausted, budgetFailure.reason)
+
+        val cancellation = GeneratedPairsPuzzleGenerator(profile).generate(
+            request = GeneratedPuzzleGenerationRequest(profile = profile, seed = 2026),
+            cancellation = { true }
+        ) as GeneratedPairsPuzzleGenerationOutcome.Failed
+        assertEquals(GeneratedPairsPuzzleGenerationFailureReason.Cancelled, cancellation.reason)
+        assertEquals(0, cancellation.searchWorkConsumed)
+    }
+
+    private fun assertFrequencyWithinTarget(actualCount: Int, targetPercentage: ProbabilityPercent) {
+        val actualPercentage = actualCount * 100.0 / VARIETY_SAMPLE_SIZE
+        assertTrue(
+            "Expected ${targetPercentage.value}% within ±$VARIETY_TOLERANCE_PERCENTAGE_POINTS points, " +
+                "but observed $actualPercentage% ($actualCount/$VARIETY_SAMPLE_SIZE).",
+            abs(actualPercentage - targetPercentage.value) <= VARIETY_TOLERANCE_PERCENTAGE_POINTS
+        )
+    }
+
+    private companion object {
+        const val VARIETY_SAMPLE_SIZE = 500
+        const val VARIETY_TOLERANCE_PERCENTAGE_POINTS = 5
+        val ASSESSMENT_SEEDS = 1..50
+    }
+}
+
+private fun Set<Int>.distinctSolutionPairCount(
+    generatedPuzzle: org.cescfe.numpairs.domain.generated.puzzle.GeneratedPairsPuzzle
+): Int {
+    val analysis = generatedPuzzle.solvedPuzzle.analyzeResolvedPuzzle()
+    val pairByEntryId = analysis.resolvedAssignments
+        .filter { assignment -> assignment.operator == Operator.ADDITION }
+        .flatMap { assignment ->
+            val pair = analysis.solutionPairByTileIndex.getValue(assignment.tileIndex)
+            listOf(
+                assignment.leftOperand.stripEntryId to pair,
+                assignment.rightOperand.stripEntryId to pair
+            )
+        }.toMap()
+    return map { entryId -> pairByEntryId.getValue(StripEntryId(entryId)) }.toSet().size
+}

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPairsPuzzleGeneratorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPairsPuzzleGeneratorTest.kt
@@ -105,7 +105,7 @@ class GeneratedPairsPuzzleGeneratorTest {
                 initialStripMaskPolicy = InitialStripMaskPolicy(
                     knownEntryCountRange = 1..1,
                     requiredAnchors = emptySet(),
-                    distributionPolicy = StripKnownEntryDistributionPolicy.UNRESTRICTED,
+                    distributionPolicy = StripKnownEntryDistributionPolicy.Unrestricted,
                     maxConsecutiveHiddenEntries = 3
                 ),
                 generationPolicy = GenerationPolicy(

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleProfileContractTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleProfileContractTest.kt
@@ -21,7 +21,7 @@ class GeneratedPuzzleProfileContractTest {
     @Test
     fun every_registered_profile_satisfies_the_shared_generation_contract() {
         assertEquals(
-            listOf("4-pairs-low", "8-pairs-medium"),
+            listOf("4-pairs-low", "4-pairs-medium", "8-pairs-medium"),
             GeneratedPuzzleProfiles.ALL.map { profile -> profile.id.value }
         )
 
@@ -83,6 +83,13 @@ class GeneratedPuzzleProfileContractTest {
                 occurrenceCount <= profile.stripValuePolicy.maxOccurrencesPerValue
             }
         )
+        profile.stripValuePolicy.maxRepeatedValueGroupCount?.let { maximumGroupCount ->
+            assertTrue(
+                context,
+                solvedValues.groupingBy { value -> value }.eachCount().values
+                    .count { occurrenceCount -> occurrenceCount > 1 } <= maximumGroupCount
+            )
+        }
 
         assertEquals(context, profile.size.boardTileCount, assignments.size)
         assignments.forEach { assignment ->
@@ -140,9 +147,8 @@ class GeneratedPuzzleProfileContractTest {
                 profile.initialStripMaskPolicy.maxConsecutiveHiddenEntries
         )
 
-        if (profile.initialStripMaskPolicy.distributionPolicy ==
-            StripKnownEntryDistributionPolicy.SPREAD_ACROSS_STRIP_AND_PAIRS_WHEN_POSSIBLE
-        ) {
+        val distributionPolicy = profile.initialStripMaskPolicy.distributionPolicy
+        if (distributionPolicy != StripKnownEntryDistributionPolicy.Unrestricted) {
             val additionPairByEntryId = assignments
                 .filter { assignment -> assignment.operator == Operator.ADDITION }
                 .flatMap { assignment ->
@@ -152,11 +158,17 @@ class GeneratedPuzzleProfileContractTest {
                         assignment.rightOperand.stripEntryId to solutionPair
                     )
                 }.toMap()
-            assertEquals(
-                context,
-                knownEntryIds.size,
-                knownEntryIds.map { entryId -> additionPairByEntryId.getValue(StripEntryId(entryId)) }.toSet().size
-            )
+            val knownSolutionPairCount = knownEntryIds
+                .map { entryId -> additionPairByEntryId.getValue(StripEntryId(entryId)) }
+                .toSet()
+                .size
+            when (distributionPolicy) {
+                StripKnownEntryDistributionPolicy.SpreadAcrossStripAndPairsWhenPossible ->
+                    assertEquals(context, knownEntryIds.size, knownSolutionPairCount)
+                is StripKnownEntryDistributionPolicy.AtLeastDistinctSolutionPairs ->
+                    assertTrue(context, knownSolutionPairCount >= distributionPolicy.minimumPairCount)
+                StripKnownEntryDistributionPolicy.Unrestricted -> error("Handled before pair-distribution analysis.")
+            }
         }
 
         assertEquals(context, PuzzleCompletionState.INCOMPLETE, initialPuzzle.completionState)

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedFourPairsMediumConstraintTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedFourPairsMediumConstraintTest.kt
@@ -33,7 +33,8 @@ class GeneratedFourPairsMediumConstraintTest {
         assertTrue(
             violations.any { violation ->
                 violation is GeneratedPairsPuzzleValidationViolation.RepeatedStripValueGroupCountExceeded &&
-                    violation.maximumAllowed == 1 && violation.observedRepeatedValues == setOf(1, 2)
+                    violation.maximumAllowed == 1 &&
+                    violation.observedRepeatedValues == setOf(1, 2)
             }
         )
     }

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedFourPairsMediumConstraintTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedFourPairsMediumConstraintTest.kt
@@ -1,0 +1,111 @@
+package org.cescfe.numpairs.domain.generated.generation.internal
+
+import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileCreation
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileDefinition
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileId
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfileViolation
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleSize
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleVarietyPolicy
+import org.cescfe.numpairs.domain.generated.profile.GenerationPolicy
+import org.cescfe.numpairs.domain.generated.profile.InitialStripMaskPolicy
+import org.cescfe.numpairs.domain.generated.profile.ProbabilityPercent
+import org.cescfe.numpairs.domain.generated.profile.RepeatedValueGroupTarget
+import org.cescfe.numpairs.domain.generated.profile.ResultConstraints
+import org.cescfe.numpairs.domain.generated.profile.StripKnownEntryDistributionPolicy
+import org.cescfe.numpairs.domain.generated.profile.StripValuePolicy
+import org.cescfe.numpairs.domain.generated.puzzle.GeneratedPairsPuzzleValidationViolation
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GeneratedFourPairsMediumConstraintTest {
+    @Test
+    fun solved_values_reject_more_repeated_groups_than_the_profile_allows() {
+        val violations = GeneratedStripValueConstraint(
+            policy = StripValuePolicy(
+                valueRange = 1..40,
+                maxOccurrencesPerValue = 2,
+                maxRepeatedValueGroupCount = 1
+            )
+        ).violationsFor(values = listOf(1, 1, 2, 2, 3, 4, 5, 6))
+
+        assertTrue(
+            violations.any { violation ->
+                violation is GeneratedPairsPuzzleValidationViolation.RepeatedStripValueGroupCountExceeded &&
+                    violation.maximumAllowed == 1 && violation.observedRepeatedValues == setOf(1, 2)
+            }
+        )
+    }
+
+    @Test
+    fun profile_rejects_an_unreachable_repetition_target() {
+        val creation = profileCreation(
+            stripValuePolicy = StripValuePolicy(
+                valueRange = 1..40,
+                maxOccurrencesPerValue = 1
+            ),
+            varietyPolicy = GeneratedPuzzleVarietyPolicy(
+                repeatedValueGroupTarget = RepeatedValueGroupTarget(
+                    targetPuzzlePercent = ProbabilityPercent(35),
+                    targetGroupCount = 1
+                )
+            )
+        )
+
+        assertTrue(
+            (creation as GeneratedPuzzleProfileCreation.Rejected).violations.any { violation ->
+                violation is GeneratedPuzzleProfileViolation.RepeatedValueGroupTargetUnreachable
+            }
+        )
+    }
+
+    @Test
+    fun profile_rejects_a_distinct_pair_distribution_that_known_entries_cannot_cover() {
+        val creation = profileCreation(
+            initialStripMaskPolicy = InitialStripMaskPolicy(
+                knownEntryCountRange = 2..2,
+                requiredAnchors = emptySet(),
+                distributionPolicy = StripKnownEntryDistributionPolicy.AtLeastDistinctSolutionPairs(
+                    minimumPairCount = 3
+                ),
+                maxConsecutiveHiddenEntries = 3
+            )
+        )
+
+        assertTrue(
+            (creation as GeneratedPuzzleProfileCreation.Rejected).violations.any { violation ->
+                violation is GeneratedPuzzleProfileViolation.DistinctSolutionPairDistributionInfeasible
+            }
+        )
+    }
+}
+
+private fun profileCreation(
+    stripValuePolicy: StripValuePolicy = StripValuePolicy(
+        valueRange = 1..40,
+        maxOccurrencesPerValue = 2,
+        maxRepeatedValueGroupCount = 1
+    ),
+    initialStripMaskPolicy: InitialStripMaskPolicy = InitialStripMaskPolicy(
+        knownEntryCountRange = 3..3,
+        requiredAnchors = emptySet(),
+        distributionPolicy = StripKnownEntryDistributionPolicy.AtLeastDistinctSolutionPairs(minimumPairCount = 2),
+        maxConsecutiveHiddenEntries = 3
+    ),
+    varietyPolicy: GeneratedPuzzleVarietyPolicy = GeneratedPuzzleVarietyPolicy()
+): GeneratedPuzzleProfileCreation = GeneratedPuzzleProfile.create(
+    definition = GeneratedPuzzleProfileDefinition(
+        id = GeneratedPuzzleProfileId("medium-constraint-test"),
+        difficulty = DifficultyTier.MEDIUM,
+        size = GeneratedPuzzleSize(pairCount = 4),
+        stripValuePolicy = stripValuePolicy,
+        resultConstraints = ResultConstraints(
+            maxMultiplicationResult = 400,
+            allowsDuplicateBoardResults = false
+        ),
+        initialStripMaskPolicy = initialStripMaskPolicy,
+        generationPolicy = GenerationPolicy(isBoardTileShufflingEnabled = true),
+        varietyPolicy = varietyPolicy
+    )
+)

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsValuePairSelectorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsValuePairSelectorTest.kt
@@ -88,14 +88,50 @@ class GeneratedPairsValuePairSelectorTest {
         assertNotNull(selectedPairs)
         assertEquals(0, selectedPairs.orEmpty().count(GeneratedPairsValuePair::isPrimeProductDecoy))
     }
+
+    @Test
+    fun repetition_plans_select_exactly_one_or_zero_repeated_value_groups() {
+        val selector = GeneratedPairsValuePairSelector(
+            profile = GeneratedPuzzleProfiles.FOUR_PAIRS_MEDIUM,
+            random = Random(42)
+        )
+        val includedPairs = requireNotNull(
+            selector.selectValuePairs(
+                variationPlan = variationPlan(
+                    repeatedValueGroupDirective = GeneratedPairsRepeatedValueGroupDirective.Include(groupCount = 1)
+                )
+            )
+        )
+        val excludedPairs = requireNotNull(
+            selector.selectValuePairs(
+                variationPlan = variationPlan(
+                    repeatedValueGroupDirective = GeneratedPairsRepeatedValueGroupDirective.Exclude
+                )
+            )
+        )
+
+        assertEquals(1, includedPairs.repeatedValueGroupCount())
+        assertEquals(0, excludedPairs.repeatedValueGroupCount())
+    }
 }
 
 private fun variationPlan(
-    primeProductDecoyDirective: GeneratedPairsPrimeProductDecoyDirective
+    primeProductDecoyDirective: GeneratedPairsPrimeProductDecoyDirective =
+        GeneratedPairsPrimeProductDecoyDirective.Unrestricted,
+    repeatedValueGroupDirective: GeneratedPairsRepeatedValueGroupDirective =
+        GeneratedPairsRepeatedValueGroupDirective.Unrestricted
 ): GeneratedPairsVariationPlan = GeneratedPairsVariationPlan(
     primeProductDecoyDirective = primeProductDecoyDirective,
+    repeatedValueGroupDirective = repeatedValueGroupDirective,
     stripEntryVisibilityDirectives = emptyMap()
 )
+
+private fun List<GeneratedPairsValuePair>.repeatedValueGroupCount(): Int =
+    flatMap { pair -> listOf(pair.firstValue, pair.secondValue) }
+        .groupingBy { value -> value }
+        .eachCount()
+        .values
+        .count { occurrenceCount -> occurrenceCount > 1 }
 
 private fun singlePairProfile(id: String, valueRange: IntRange, maxMultiplicationResult: Int): GeneratedPuzzleProfile {
     val size = GeneratedPuzzleSize(pairCount = 1)
@@ -116,7 +152,7 @@ private fun singlePairProfile(id: String, valueRange: IntRange, maxMultiplicatio
             initialStripMaskPolicy = InitialStripMaskPolicy(
                 knownEntryCountRange = 1..1,
                 requiredAnchors = emptySet(),
-                distributionPolicy = StripKnownEntryDistributionPolicy.UNRESTRICTED,
+                distributionPolicy = StripKnownEntryDistributionPolicy.Unrestricted,
                 maxConsecutiveHiddenEntries = 1
             ),
             generationPolicy = GenerationPolicy(

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsVariationPlanSelectorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsVariationPlanSelectorTest.kt
@@ -107,6 +107,30 @@ class GeneratedPairsVariationPlanSelectorTest {
         )
         assertTrue(thresholdRolls.isEmpty())
     }
+
+    @Test
+    fun repeated_value_target_selects_exact_inclusion_or_exclusion_directives() {
+        val profile = GeneratedPuzzleProfiles.FOUR_PAIRS_MEDIUM
+        val includeRolls = ArrayDeque(listOf(99, 34, 99, 99))
+        val includePlan = GeneratedPairsVariationPlanSelector(
+            profile = profile,
+            nextProbabilityRoll = includeRolls::removeFirst
+        ).select()
+        assertEquals(
+            GeneratedPairsRepeatedValueGroupDirective.Include(groupCount = 1),
+            includePlan.repeatedValueGroupDirective
+        )
+
+        val excludeRolls = ArrayDeque(listOf(99, 35, 99, 99))
+        val excludePlan = GeneratedPairsVariationPlanSelector(
+            profile = profile,
+            nextProbabilityRoll = excludeRolls::removeFirst
+        ).select()
+        assertEquals(
+            GeneratedPairsRepeatedValueGroupDirective.Exclude,
+            excludePlan.repeatedValueGroupDirective
+        )
+    }
 }
 
 private fun GeneratedPuzzleProfile.withTargetProbabilities(percentage: Int): GeneratedPuzzleProfile =

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileTest.kt
@@ -154,7 +154,7 @@ class GeneratedPuzzleProfileTest {
                     initialStripMaskPolicy = validMaskPolicy().copy(
                         knownEntryCountRange = 3..3,
                         distributionPolicy =
-                        StripKnownEntryDistributionPolicy.SPREAD_ACROSS_STRIP_AND_PAIRS_WHEN_POSSIBLE
+                        StripKnownEntryDistributionPolicy.SpreadAcrossStripAndPairsWhenPossible
                     )
                 ),
                 expectedRuleId = GeneratedPuzzleProfileRuleId.SPREAD_DISTRIBUTION_CAPACITY
@@ -376,7 +376,7 @@ class GeneratedPuzzleProfileTest {
             stripValuePolicy = StripValuePolicy(valueRange = 2..3, maxOccurrencesPerValue = 1),
             initialStripMaskPolicy = validMaskPolicy().copy(
                 knownEntryCountRange = 3..5,
-                distributionPolicy = StripKnownEntryDistributionPolicy.SPREAD_ACROSS_STRIP_AND_PAIRS_WHEN_POSSIBLE
+                distributionPolicy = StripKnownEntryDistributionPolicy.SpreadAcrossStripAndPairsWhenPossible
             ),
             resultConstraints = ResultConstraints(
                 maxMultiplicationResult = 10,
@@ -454,6 +454,7 @@ class GeneratedPuzzleProfileTest {
                 "profile.required-anchor-capacity",
                 "profile.hidden-run-feasibility",
                 "profile.spread-distribution-capacity",
+                "profile.distinct-solution-pair-distribution-feasibility",
                 "profile.high-value-target-rank",
                 "profile.duplicate-high-value-target-rank",
                 "profile.high-value-target-anchor-conflict",
@@ -464,6 +465,7 @@ class GeneratedPuzzleProfileTest {
                 "profile.product-anchor-selection-feasibility",
                 "profile.prime-decoy-target-count",
                 "profile.prime-decoy-target-feasibility",
+                "profile.repeated-value-group-target-feasibility",
                 "profile.eligible-value-pair-catalog",
                 "profile.arithmetic-result-range",
                 "profile.validation-work-limit"
@@ -493,7 +495,7 @@ class GeneratedPuzzleProfileTest {
             InitialStripMaskPolicy(
                 knownEntryCountRange = IntRange.EMPTY,
                 requiredAnchors = emptySet(),
-                distributionPolicy = StripKnownEntryDistributionPolicy.UNRESTRICTED,
+                distributionPolicy = StripKnownEntryDistributionPolicy.Unrestricted,
                 maxConsecutiveHiddenEntries = 2
             )
         }
@@ -542,7 +544,7 @@ private fun smallestBoundedDefinition(): GeneratedPuzzleProfileDefinition = Gene
     initialStripMaskPolicy = InitialStripMaskPolicy(
         knownEntryCountRange = 1..1,
         requiredAnchors = setOf(RequiredKnownStripAnchor.HIGHEST_STRIP_ENTRY),
-        distributionPolicy = StripKnownEntryDistributionPolicy.UNRESTRICTED,
+        distributionPolicy = StripKnownEntryDistributionPolicy.Unrestricted,
         maxConsecutiveHiddenEntries = 1
     ),
     generationPolicy = GenerationPolicy(isBoardTileShufflingEnabled = true)
@@ -569,7 +571,7 @@ private fun validResultConstraints(): ResultConstraints = ResultConstraints(
 private fun validMaskPolicy(): InitialStripMaskPolicy = InitialStripMaskPolicy(
     knownEntryCountRange = 2..2,
     requiredAnchors = setOf(RequiredKnownStripAnchor.HIGHEST_STRIP_ENTRY),
-    distributionPolicy = StripKnownEntryDistributionPolicy.UNRESTRICTED,
+    distributionPolicy = StripKnownEntryDistributionPolicy.Unrestricted,
     maxConsecutiveHiddenEntries = 2
 )
 

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfilesTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfilesTest.kt
@@ -31,13 +31,72 @@ class GeneratedPuzzleProfilesTest {
             profile.initialStripMaskPolicy.requiredAnchors
         )
         assertEquals(
-            StripKnownEntryDistributionPolicy.SPREAD_ACROSS_STRIP_AND_PAIRS_WHEN_POSSIBLE,
+            StripKnownEntryDistributionPolicy.SpreadAcrossStripAndPairsWhenPossible,
             profile.initialStripMaskPolicy.distributionPolicy
         )
         assertEquals(2, profile.initialStripMaskPolicy.maxConsecutiveHiddenEntries)
 
         assertTrue(profile.generationPolicy.isBoardTileShufflingEnabled)
         assertNull(profile.varietyPolicy.primeProductDecoyTarget)
+    }
+
+    @Test
+    fun four_pairs_medium_profile_matches_documented_rules() {
+        val profile = GeneratedPuzzleProfiles.FOUR_PAIRS_MEDIUM
+
+        assertEquals(GeneratedPuzzleProfileId("4-pairs-medium"), profile.id)
+        assertEquals(DifficultyTier.MEDIUM, profile.difficulty)
+        assertEquals(4, profile.size.pairCount)
+        assertEquals(8, profile.size.stripEntryCount)
+        assertEquals(8, profile.size.boardTileCount)
+
+        assertEquals(1..40, profile.stripValuePolicy.valueRange)
+        assertEquals(2, profile.stripValuePolicy.maxOccurrencesPerValue)
+        assertEquals(1, profile.stripValuePolicy.maxRepeatedValueGroupCount)
+        assertTrue(profile.stripValuePolicy.allowsOne)
+
+        assertEquals(400, profile.resultConstraints.maxMultiplicationResult)
+        assertFalse(profile.resultConstraints.allowsDuplicateBoardResults)
+        val anchorMix = requireNotNull(profile.resultConstraints.productAnchorMix)
+        assertEquals(80, anchorMix.productResultGreaterThan)
+        assertEquals(1..2, anchorMix.countRange)
+
+        assertEquals(3..3, profile.initialStripMaskPolicy.knownEntryCountRange)
+        assertEquals(5..5, profile.hiddenEntryCountRange)
+        assertTrue(profile.initialStripMaskPolicy.requiredAnchors.isEmpty())
+        assertEquals(
+            StripKnownEntryDistributionPolicy.AtLeastDistinctSolutionPairs(minimumPairCount = 2),
+            profile.initialStripMaskPolicy.distributionPolicy
+        )
+        assertEquals(3, profile.initialStripMaskPolicy.maxConsecutiveHiddenEntries)
+
+        assertEquals(
+            listOf(
+                HighValueMaskTarget(1, ProbabilityPercent(25)),
+                HighValueMaskTarget(2, ProbabilityPercent(40))
+            ),
+            profile.varietyPolicy.highValueMaskTargets
+        )
+        val decoyTarget = requireNotNull(profile.varietyPolicy.primeProductDecoyTarget)
+        assertEquals(ProbabilityPercent(30), decoyTarget.targetPuzzlePercent)
+        assertEquals(1, decoyTarget.targetPairCount)
+        assertEquals(PrimeProductDecoyPairPattern.ONE_AND_PRIME, decoyTarget.pairPattern)
+        assertEquals(
+            RepeatedValueGroupTarget(
+                targetPuzzlePercent = ProbabilityPercent(35),
+                targetGroupCount = 1
+            ),
+            profile.varietyPolicy.repeatedValueGroupTarget
+        )
+        assertTrue(profile.generationPolicy.isBoardTileShufflingEnabled)
+        val assessmentPolicy = requireNotNull(profile.difficultyAssessmentPolicy)
+        assertEquals(25_000, assessmentPolicy.executionPolicy.maxCandidateExpansions)
+        assertEquals(20, assessmentPolicy.executionPolicy.validSolutionCountLimit)
+        assertEquals(6, assessmentPolicy.minimumInitialPlausibleCandidateCount)
+        assertEquals(1, assessmentPolicy.minimumInitialForcedDeductionCount)
+        assertEquals(1, assessmentPolicy.minimumFirstForcedDeductionDepth)
+        assertEquals(1, assessmentPolicy.minimumPlausibleDecoyCount)
+        assertEquals(1, assessmentPolicy.minimumValidSolutionCount)
     }
 
     @Test
@@ -64,7 +123,7 @@ class GeneratedPuzzleProfilesTest {
         assertEquals(9..10, profile.hiddenEntryCountRange)
         assertEquals(emptySet<RequiredKnownStripAnchor>(), profile.initialStripMaskPolicy.requiredAnchors)
         assertEquals(
-            StripKnownEntryDistributionPolicy.UNRESTRICTED,
+            StripKnownEntryDistributionPolicy.Unrestricted,
             profile.initialStripMaskPolicy.distributionPolicy
         )
         assertEquals(4, profile.initialStripMaskPolicy.maxConsecutiveHiddenEntries)

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/puzzle/internal/GeneratedPairsPuzzleValidatorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/puzzle/internal/GeneratedPairsPuzzleValidatorTest.kt
@@ -431,6 +431,7 @@ class GeneratedPairsPuzzleValidatorTest {
                 "generated.solved-sum-product-pairing-mismatch",
                 "generated.strip-value-outside-range",
                 "generated.strip-value-occurrence-exceeded",
+                "generated.repeated-strip-value-group-count-exceeded",
                 "generated.duplicate-board-results",
                 "generated.multiplication-result-exceeded",
                 "generated.product-anchor-mix-outside-range",

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/ConfiguredGeneratedPuzzleGenerationUseCaseFactoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/ConfiguredGeneratedPuzzleGenerationUseCaseFactoryTest.kt
@@ -138,7 +138,7 @@ private fun testTwoPairsProfile(): GeneratedPuzzleProfile = GeneratedPuzzleProfi
         initialStripMaskPolicy = InitialStripMaskPolicy(
             knownEntryCountRange = 1..1,
             requiredAnchors = setOf(RequiredKnownStripAnchor.HIGHEST_STRIP_ENTRY),
-            distributionPolicy = StripKnownEntryDistributionPolicy.UNRESTRICTED,
+            distributionPolicy = StripKnownEntryDistributionPolicy.Unrestricted,
             maxConsecutiveHiddenEntries = 3
         ),
         generationPolicy = GenerationPolicy(

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedChallengeCatalogTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedChallengeCatalogTest.kt
@@ -27,18 +27,31 @@ class GeneratedChallengeCatalogTest {
             DifficultyTier.entries
         )
         assertEquals(DifficultyTier.LOW, GeneratedPuzzleProfiles.FOUR_PAIRS_LOW.difficulty)
+        assertEquals(DifficultyTier.MEDIUM, GeneratedPuzzleProfiles.FOUR_PAIRS_MEDIUM.difficulty)
         assertEquals(DifficultyTier.MEDIUM, GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM.difficulty)
     }
 
     @Test
-    fun configured_catalog_contains_only_the_two_existing_challenges() {
+    fun configured_catalog_registers_low_and_medium_for_four_pairs() {
         assertEquals("four-pairs", GeneratedModes.FOUR_PAIRS.id.value)
         assertEquals("eight-pairs", GeneratedModes.EIGHT_PAIRS.id.value)
         assertEquals("4-pairs-low", GeneratedModes.FOUR_PAIRS_LOW.profile.id.value)
+        assertEquals("4-pairs-medium", GeneratedModes.FOUR_PAIRS_MEDIUM.profile.id.value)
         assertEquals("8-pairs-medium", GeneratedModes.EIGHT_PAIRS_MEDIUM.profile.id.value)
         assertEquals(
-            listOf(GeneratedModes.FOUR_PAIRS_LOW, GeneratedModes.EIGHT_PAIRS_MEDIUM),
+            listOf(
+                GeneratedModes.FOUR_PAIRS_LOW,
+                GeneratedModes.FOUR_PAIRS_MEDIUM,
+                GeneratedModes.EIGHT_PAIRS_MEDIUM
+            ),
             GeneratedModes.catalog.allChallenges
+        )
+        assertSame(
+            GeneratedModes.FOUR_PAIRS_MEDIUM,
+            GeneratedModes.catalog.resolveChallenge(
+                modeId = GeneratedModes.FOUR_PAIRS.id,
+                difficulty = DifficultyTier.MEDIUM
+            )
         )
         assertSame(
             GeneratedModes.FOUR_PAIRS_LOW,
@@ -230,7 +243,7 @@ private fun fourPairsProfile(id: String, difficulty: DifficultyTier): GeneratedP
                 knownEntryCountRange = 3..3,
                 requiredAnchors = setOf(RequiredKnownStripAnchor.HIGHEST_STRIP_ENTRY),
                 distributionPolicy =
-                StripKnownEntryDistributionPolicy.SPREAD_ACROSS_STRIP_AND_PAIRS_WHEN_POSSIBLE,
+                StripKnownEntryDistributionPolicy.SpreadAcrossStripAndPairsWhenPossible,
                 maxConsecutiveHiddenEntries = 2
             ),
             generationPolicy = GenerationPolicy(isBoardTileShufflingEnabled = true)

--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -3,8 +3,8 @@
 ## Document Status
 
 - Status: product reference for generated puzzle construction
-- Implemented profiles: generated `4 Pairs Low` and `8 Pairs Medium`
-- v8 target profiles: generated `4 Pairs Medium` and `8 Pairs Hard`
+- Implemented profiles: generated `4 Pairs Low`, `4 Pairs Medium`, and `8 Pairs Medium`
+- Remaining v8 target profile: generated `8 Pairs Hard`
 - Related references:
   - `docs/product/prd/prd-v5.md`
   - `docs/product/prd/prd-v7.md`
@@ -221,7 +221,7 @@ These constraints keep the first generated mode approachable, reduce arithmetic 
 
 ### `4 Pairs Medium`
 
-Status: specified for v8; not implemented.
+Status: implemented in v8.
 
 Shape:
 


### PR DESCRIPTION
## Related Issue

Resolves #495

## Summary

- Add and register the stable 4 Pairs Medium profile and challenge while keeping the current menu launch on Low.
- Model bounded repetition, distinct-pair masking distribution, population variety targets, and a reusable difficulty-assessment policy.
- Reject generated candidates outside the documented Medium assessment band without imposing solution uniqueness on player completion.
- Cover profile validation, deterministic generation, bounded failure/cancellation, the 1..500 population corpus, assessment characterization, catalog behavior, and existing-profile regression.