### PR TITLE
[242] Add the 8 Pairs Hard generated challenge

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPuzzleDifficultyAssessment.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPuzzleDifficultyAssessment.kt
@@ -95,15 +95,24 @@ data class GeneratedPuzzleDifficultyAssessmentPolicy(
     val executionPolicy: GeneratedPuzzleDifficultyAssessmentExecutionPolicy,
     val minimumInitialPlausibleCandidateCount: Int,
     val minimumInitialForcedDeductionCount: Int,
+    val maximumInitialForcedDeductionCount: Int? = null,
     val minimumFirstForcedDeductionDepth: Int,
     val minimumPlausibleDecoyCount: Int,
+    val minimumMaximumBranchingFactor: Int = 0,
+    val minimumExploredAmbiguousStateCount: Int = 0,
     val minimumValidSolutionCount: Int = 1
 ) {
     init {
         require(minimumInitialPlausibleCandidateCount >= 0)
         require(minimumInitialForcedDeductionCount >= 0)
+        require(
+            maximumInitialForcedDeductionCount == null ||
+                maximumInitialForcedDeductionCount >= minimumInitialForcedDeductionCount
+        )
         require(minimumFirstForcedDeductionDepth >= 0)
         require(minimumPlausibleDecoyCount >= 0)
+        require(minimumMaximumBranchingFactor >= 0)
+        require(minimumExploredAmbiguousStateCount >= 0)
         require(minimumValidSolutionCount > 0)
         require(executionPolicy.validSolutionCountLimit >= minimumValidSolutionCount) {
             "Difficulty-assessment solution count limit must cover the required minimum."
@@ -118,11 +127,23 @@ data class GeneratedPuzzleDifficultyAssessmentPolicy(
             if (report.initialForcedDeductionCount < minimumInitialForcedDeductionCount) {
                 add(GeneratedPuzzleDifficultyRequirement.INITIAL_FORCED_DEDUCTIONS)
             }
+            if (maximumInitialForcedDeductionCount?.let { maximum ->
+                    report.initialForcedDeductionCount > maximum
+                } == true
+            ) {
+                add(GeneratedPuzzleDifficultyRequirement.INITIAL_FORCED_DEDUCTION_MAXIMUM)
+            }
             if ((report.firstForcedDeductionDepth ?: -1) < minimumFirstForcedDeductionDepth) {
                 add(GeneratedPuzzleDifficultyRequirement.FIRST_FORCED_DEDUCTION_DEPTH)
             }
             if (report.structuralObservations.plausibleDecoyCount < minimumPlausibleDecoyCount) {
                 add(GeneratedPuzzleDifficultyRequirement.PLAUSIBLE_DECOYS)
+            }
+            if (report.maximumBranchingFactor < minimumMaximumBranchingFactor) {
+                add(GeneratedPuzzleDifficultyRequirement.MAXIMUM_BRANCHING_FACTOR)
+            }
+            if (report.exploredAmbiguousStateCount < minimumExploredAmbiguousStateCount) {
+                add(GeneratedPuzzleDifficultyRequirement.EXPLORED_AMBIGUOUS_STATES)
             }
             if (report.boundedValidSolutionCount < minimumValidSolutionCount) {
                 add(GeneratedPuzzleDifficultyRequirement.VALID_SOLUTIONS)
@@ -146,8 +167,11 @@ data class GeneratedPuzzleDifficultyPolicyEvaluation(
 enum class GeneratedPuzzleDifficultyRequirement {
     INITIAL_PLAUSIBLE_CANDIDATES,
     INITIAL_FORCED_DEDUCTIONS,
+    INITIAL_FORCED_DEDUCTION_MAXIMUM,
     FIRST_FORCED_DEDUCTION_DEPTH,
     PLAUSIBLE_DECOYS,
+    MAXIMUM_BRANCHING_FACTOR,
+    EXPLORED_AMBIGUOUS_STATES,
     VALID_SOLUTIONS
 }
 

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleGenerationOutcome.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleGenerationOutcome.kt
@@ -21,7 +21,7 @@ data class GeneratedPuzzleGenerationExecutionPolicy(
     }
 
     private companion object {
-        const val DEFAULT_MAX_ATTEMPTS = 50
+        const val DEFAULT_MAX_ATTEMPTS = 80
         const val DEFAULT_MAX_SEARCH_WORK = 250_000
     }
 }
@@ -29,7 +29,10 @@ data class GeneratedPuzzleGenerationExecutionPolicy(
 data class GeneratedPuzzleGenerationRequest(
     val profile: GeneratedPuzzleProfile,
     val seed: Int,
-    val executionPolicy: GeneratedPuzzleGenerationExecutionPolicy = GeneratedPuzzleGenerationExecutionPolicy()
+    val executionPolicy: GeneratedPuzzleGenerationExecutionPolicy = GeneratedPuzzleGenerationExecutionPolicy(
+        maxAttempts = profile.generationPolicy.maxAttempts,
+        maxSearchWork = profile.generationPolicy.maxSearchWork
+    )
 ) {
     val profileId: GeneratedPuzzleProfileId
         get() = profile.id

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsGenerationModel.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsGenerationModel.kt
@@ -46,6 +46,14 @@ internal sealed interface GeneratedPairsRepeatedValueGroupDirective {
             }
         }
     }
+
+    data class IncludeRange(val groupCountRange: IntRange) : GeneratedPairsRepeatedValueGroupDirective {
+        init {
+            require(!groupCountRange.isEmpty() && groupCountRange.first > 0) {
+                "A repeated-value group inclusion range must contain positive counts."
+            }
+        }
+    }
 }
 
 internal enum class GeneratedPairsStripEntryVisibilityDirective {

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsValuePairSelector.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsValuePairSelector.kt
@@ -256,31 +256,32 @@ private fun GeneratedPairsPrimeProductDecoyDirective.shouldPreferPrimeProductDec
 private fun GeneratedPairsPrimeProductDecoyDirective.allows(pairCount: Int): Boolean =
     requiredPairCount?.let { requiredPairCount -> pairCount <= requiredPairCount } ?: true
 
-private val GeneratedPairsRepeatedValueGroupDirective.requiredGroupCount: Int?
+private val GeneratedPairsRepeatedValueGroupDirective.requiredGroupCountRange: IntRange?
     get() = when (this) {
         GeneratedPairsRepeatedValueGroupDirective.Unrestricted -> null
-        GeneratedPairsRepeatedValueGroupDirective.Exclude -> 0
-        is GeneratedPairsRepeatedValueGroupDirective.Include -> groupCount
+        GeneratedPairsRepeatedValueGroupDirective.Exclude -> 0..0
+        is GeneratedPairsRepeatedValueGroupDirective.Include -> groupCount..groupCount
+        is GeneratedPairsRepeatedValueGroupDirective.IncludeRange -> groupCountRange
     }
 
 private fun GeneratedPairsRepeatedValueGroupDirective.canStillBeSatisfied(
     currentGroupCount: Int,
     remainingPairSlots: Int
 ): Boolean {
-    val requiredGroupCount = requiredGroupCount ?: return true
+    val requiredRange = requiredGroupCountRange ?: return true
 
-    return currentGroupCount <= requiredGroupCount &&
-        currentGroupCount + remainingPairSlots * 2 >= requiredGroupCount
+    return currentGroupCount <= requiredRange.last &&
+        currentGroupCount + remainingPairSlots * 2 >= requiredRange.first
 }
 
 private fun GeneratedPairsRepeatedValueGroupDirective.isSatisfiedBy(groupCount: Int): Boolean =
-    requiredGroupCount?.let { requiredGroupCount -> groupCount == requiredGroupCount } ?: true
+    requiredGroupCountRange?.let { requiredRange -> groupCount in requiredRange } ?: true
 
 private fun GeneratedPairsRepeatedValueGroupDirective.shouldPreferRepeatedValueGroup(currentGroupCount: Int): Boolean =
-    requiredGroupCount?.let { requiredGroupCount -> currentGroupCount < requiredGroupCount } ?: false
+    requiredGroupCountRange?.let { requiredRange -> currentGroupCount < requiredRange.first } ?: false
 
 private fun GeneratedPairsRepeatedValueGroupDirective.allows(groupCount: Int): Boolean =
-    requiredGroupCount?.let { requiredGroupCount -> groupCount <= requiredGroupCount } ?: true
+    requiredGroupCountRange?.let { requiredRange -> groupCount <= requiredRange.last } ?: true
 
 private fun Map<Int, Int>.repeatedValueGroupCount(): Int = values.count { occurrenceCount -> occurrenceCount > 1 }
 

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsVariationPlanSelector.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsVariationPlanSelector.kt
@@ -45,7 +45,16 @@ internal class GeneratedPairsVariationPlanSelector(
 
     private fun selectRepeatedValueGroupDirective(): GeneratedPairsRepeatedValueGroupDirective {
         val target = profile.varietyPolicy.repeatedValueGroupTarget
-            ?: return GeneratedPairsRepeatedValueGroupDirective.Unrestricted
+        if (target == null) {
+            val minimumGroupCount = profile.stripValuePolicy.minRepeatedValueGroupCount
+            if (minimumGroupCount == 0) {
+                return GeneratedPairsRepeatedValueGroupDirective.Unrestricted
+            }
+            val maximumGroupCount = profile.stripValuePolicy.maxRepeatedValueGroupCount ?: minimumGroupCount
+            return GeneratedPairsRepeatedValueGroupDirective.IncludeRange(
+                groupCountRange = minimumGroupCount..maximumGroupCount
+            )
+        }
 
         return if (shouldApply(probability = target.targetPuzzlePercent)) {
             GeneratedPairsRepeatedValueGroupDirective.Include(groupCount = target.targetGroupCount)

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPuzzleConstraints.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPuzzleConstraints.kt
@@ -107,10 +107,18 @@ internal class GeneratedStripValueConstraint(private val policy: StripValuePolic
             )
         }
 
+        val repeatedValueGroups = values.groupingBy { value -> value }
+            .eachCount()
+            .filterValues { occurrenceCount -> occurrenceCount > 1 }
+        if (repeatedValueGroups.size < policy.minRepeatedValueGroupCount) {
+            add(
+                GeneratedPairsPuzzleValidationViolation.RepeatedStripValueGroupCountBelowMinimum(
+                    minimumRequired = policy.minRepeatedValueGroupCount,
+                    observedRepeatedValues = repeatedValueGroups.keys
+                )
+            )
+        }
         policy.maxRepeatedValueGroupCount?.let { maximumAllowed ->
-            val repeatedValueGroups = values.groupingBy { value -> value }
-                .eachCount()
-                .filterValues { occurrenceCount -> occurrenceCount > 1 }
             if (repeatedValueGroups.size > maximumAllowed) {
                 add(
                     GeneratedPairsPuzzleValidationViolation.RepeatedStripValueGroupCountExceeded(

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzlePairSpecification.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzlePairSpecification.kt
@@ -41,13 +41,17 @@ internal class GeneratedPuzzlePairSpecification(
         return GeneratedPuzzleProfileBoundedEvaluation.Completed(value = pairs)
     }
 
-    fun isLocallyEligible(pair: GeneratedPuzzlePairValues): Boolean = stripValuePolicy.accepts(values = pair.values) &&
-        resultConstraints.acceptsMultiplicationResult(result = pair.product) &&
-        resultConstraints.acceptsBoardResults(results = pair.results)
+    fun isLocallyEligible(pair: GeneratedPuzzlePairValues): Boolean =
+        pair.values.all { value -> value in stripValuePolicy.valueRange } &&
+            stripValuePolicy.acceptsOccurrenceLimits(
+                occurrencesByValue = pair.values.groupingBy { value -> value }.eachCount()
+            ) &&
+            resultConstraints.acceptsMultiplicationResult(result = pair.product) &&
+            resultConstraints.acceptsBoardResults(results = pair.results)
 
     fun canBeAdded(pair: GeneratedPuzzlePairValues, valueOccurrences: Map<Int, Int>, usedResults: Set<Int>): Boolean =
         isLocallyEligible(pair = pair) &&
-            stripValuePolicy.accepts(
+            stripValuePolicy.acceptsOccurrenceLimits(
                 occurrencesByValue = valueOccurrences.with(pair = pair)
             ) &&
             resultConstraints.acceptsAdditionalBoardResults(
@@ -116,7 +120,8 @@ internal class GeneratedPuzzlePairSpecification(
         }
         if (selectedPairCount == targetPairCount) {
             return GeneratedPuzzleProfileBoundedEvaluation.Completed(
-                value = productAnchorMix == null || productAnchorCount in productAnchorMix.countRange
+                value = stripValuePolicy.accepts(occurrencesByValue = valueOccurrences) &&
+                    (productAnchorMix == null || productAnchorCount in productAnchorMix.countRange)
             )
         }
 
@@ -193,6 +198,10 @@ internal fun StripValuePolicy.accepts(values: List<Int>): Boolean = values.all {
     accepts(occurrencesByValue = values.groupingBy { value -> value }.eachCount())
 
 internal fun StripValuePolicy.accepts(occurrencesByValue: Map<Int, Int>): Boolean =
+    acceptsOccurrenceLimits(occurrencesByValue = occurrencesByValue) &&
+        occurrencesByValue.values.count { occurrenceCount -> occurrenceCount > 1 } >= minRepeatedValueGroupCount
+
+internal fun StripValuePolicy.acceptsOccurrenceLimits(occurrencesByValue: Map<Int, Int>): Boolean =
     occurrencesByValue.all { (value, occurrenceCount) ->
         value in valueRange && occurrenceCount <= maxOccurrencesPerValue
     } &&

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfile.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfile.kt
@@ -83,7 +83,8 @@ data class GeneratedPuzzleSize(val pairCount: Int) {
 data class StripValuePolicy(
     val valueRange: IntRange,
     val maxOccurrencesPerValue: Int,
-    val maxRepeatedValueGroupCount: Int? = null
+    val maxRepeatedValueGroupCount: Int? = null,
+    val minRepeatedValueGroupCount: Int = 0
 ) {
     init {
         require(!valueRange.isEmpty()) {
@@ -95,8 +96,17 @@ data class StripValuePolicy(
         require(maxOccurrencesPerValue >= 1) {
             "Maximum occurrences per strip value must be at least 1."
         }
+        require(minRepeatedValueGroupCount >= 0) {
+            "Minimum repeated strip-value group count must not be negative."
+        }
         require(maxRepeatedValueGroupCount == null || maxRepeatedValueGroupCount >= 0) {
             "Maximum repeated strip-value group count must not be negative."
+        }
+        require(maxRepeatedValueGroupCount == null || minRepeatedValueGroupCount <= maxRepeatedValueGroupCount) {
+            "Repeated strip-value group minimum must not exceed its maximum."
+        }
+        require(maxOccurrencesPerValue > 1 || minRepeatedValueGroupCount == 0) {
+            "Repeated strip-value groups require values to allow more than one occurrence."
         }
     }
 
@@ -183,7 +193,20 @@ data class ProbabilityPercent(val value: Int) {
     }
 }
 
-data class GenerationPolicy(val isBoardTileShufflingEnabled: Boolean)
+data class GenerationPolicy(
+    val isBoardTileShufflingEnabled: Boolean,
+    val maxAttempts: Int = 80,
+    val maxSearchWork: Int = 250_000
+) {
+    init {
+        require(maxAttempts > 0) {
+            "Maximum profile generation attempts must be positive."
+        }
+        require(maxSearchWork > 0) {
+            "Maximum profile generation search work must be positive."
+        }
+    }
+}
 
 data class PrimeProductDecoyTarget(
     val targetPuzzlePercent: ProbabilityPercent,

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileCreation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileCreation.kt
@@ -22,6 +22,7 @@ fun GeneratedPuzzleProfileCreation.getOrThrow(): GeneratedPuzzleProfile = when (
 
 enum class GeneratedPuzzleProfileRuleId(val code: String) {
     STRIP_VALUE_CAPACITY("profile.strip-value-capacity"),
+    REPEATED_VALUE_GROUP_RANGE_FEASIBILITY("profile.repeated-value-group-range-feasibility"),
     KNOWN_ENTRY_RANGE("profile.known-entry-range"),
     REQUIRED_ANCHOR_CAPACITY("profile.required-anchor-capacity"),
     HIDDEN_RUN_FEASIBILITY("profile.hidden-run-feasibility"),
@@ -49,6 +50,14 @@ sealed interface GeneratedPuzzleProfileViolation {
     data class InsufficientStripValueCapacity(val requiredEntryCount: Int, val availableEntryCount: Long) :
         GeneratedPuzzleProfileViolation {
         override val ruleId: GeneratedPuzzleProfileRuleId = GeneratedPuzzleProfileRuleId.STRIP_VALUE_CAPACITY
+    }
+
+    data class RepeatedValueGroupRangeInfeasible(
+        val minimumRequiredGroupCount: Int,
+        val maximumPossibleGroupCount: Int
+    ) : GeneratedPuzzleProfileViolation {
+        override val ruleId: GeneratedPuzzleProfileRuleId =
+            GeneratedPuzzleProfileRuleId.REPEATED_VALUE_GROUP_RANGE_FEASIBILITY
     }
 
     data class KnownEntryRangeOutsidePuzzle(val configuredRange: IntRange, val stripEntryCount: Int) :

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileSpecification.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileSpecification.kt
@@ -82,6 +82,18 @@ private object GeneratedPuzzleProfileStructuralEvaluator {
                 )
             )
         }
+        val maximumPossibleRepeatedGroupCount = minOf(
+            distinctValueCount,
+            definition.size.stripEntryCount.toLong() / 2
+        )
+        if (valuePolicy.minRepeatedValueGroupCount > maximumPossibleRepeatedGroupCount) {
+            add(
+                GeneratedPuzzleProfileViolation.RepeatedValueGroupRangeInfeasible(
+                    minimumRequiredGroupCount = valuePolicy.minRepeatedValueGroupCount,
+                    maximumPossibleGroupCount = maximumPossibleRepeatedGroupCount.toInt()
+                )
+            )
+        }
 
         val maximumValue = valuePolicy.valueRange.last
         if (maximumValue.toLong() * maximumValue > Int.MAX_VALUE) {

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfiles.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfiles.kt
@@ -7,7 +7,9 @@ object GeneratedPuzzleProfiles {
     val FOUR_PAIRS_LOW: GeneratedPuzzleProfile = fourPairsLow()
     val FOUR_PAIRS_MEDIUM: GeneratedPuzzleProfile = fourPairsMedium()
     val EIGHT_PAIRS_MEDIUM: GeneratedPuzzleProfile = eightPairsMedium()
-    val ALL: List<GeneratedPuzzleProfile> = listOf(FOUR_PAIRS_LOW, FOUR_PAIRS_MEDIUM, EIGHT_PAIRS_MEDIUM)
+    val EIGHT_PAIRS_HARD: GeneratedPuzzleProfile = eightPairsHard()
+    val ALL: List<GeneratedPuzzleProfile> =
+        listOf(FOUR_PAIRS_LOW, FOUR_PAIRS_MEDIUM, EIGHT_PAIRS_MEDIUM, EIGHT_PAIRS_HARD)
 
     private fun fourPairsLow(): GeneratedPuzzleProfile {
         val size = GeneratedPuzzleSize(pairCount = 4)
@@ -155,6 +157,80 @@ object GeneratedPuzzleProfiles {
                         targetPairCount = 1,
                         pairPattern = PrimeProductDecoyPairPattern.ONE_AND_PRIME
                     )
+                )
+            )
+        ).getOrThrow()
+    }
+
+    private fun eightPairsHard(): GeneratedPuzzleProfile {
+        val size = GeneratedPuzzleSize(pairCount = 8)
+
+        return GeneratedPuzzleProfile.create(
+            definition = GeneratedPuzzleProfileDefinition(
+                id = GeneratedPuzzleProfileId("8-pairs-hard"),
+                difficulty = DifficultyTier.HARD,
+                size = size,
+                stripValuePolicy = StripValuePolicy(
+                    valueRange = 1..99,
+                    maxOccurrencesPerValue = 2,
+                    minRepeatedValueGroupCount = 1,
+                    maxRepeatedValueGroupCount = 2
+                ),
+                resultConstraints = ResultConstraints(
+                    maxMultiplicationResult = 1000,
+                    allowsDuplicateBoardResults = false,
+                    productAnchorMix = ProductAnchorMix(
+                        productResultGreaterThan = 198,
+                        countRange = 0..1
+                    )
+                ),
+                initialStripMaskPolicy = InitialStripMaskPolicy(
+                    knownEntryCountRange = 4..5,
+                    requiredAnchors = emptySet(),
+                    distributionPolicy = StripKnownEntryDistributionPolicy.AtLeastDistinctSolutionPairs(
+                        minimumPairCount = 3
+                    ),
+                    maxConsecutiveHiddenEntries = 5
+                ),
+                generationPolicy = GenerationPolicy(
+                    isBoardTileShufflingEnabled = true,
+                    maxAttempts = 160,
+                    maxSearchWork = 600_000
+                ),
+                varietyPolicy = GeneratedPuzzleVarietyPolicy(
+                    highValueMaskTargets = listOf(
+                        HighValueMaskTarget(
+                            rankFromHighest = 1,
+                            targetHiddenProbability = ProbabilityPercent(60)
+                        ),
+                        HighValueMaskTarget(
+                            rankFromHighest = 2,
+                            targetHiddenProbability = ProbabilityPercent(70)
+                        ),
+                        HighValueMaskTarget(
+                            rankFromHighest = 3,
+                            targetHiddenProbability = ProbabilityPercent(70)
+                        )
+                    ),
+                    primeProductDecoyTarget = PrimeProductDecoyTarget(
+                        targetPuzzlePercent = ProbabilityPercent(60),
+                        targetPairCount = 1,
+                        pairPattern = PrimeProductDecoyPairPattern.ONE_AND_PRIME
+                    )
+                ),
+                difficultyAssessmentPolicy = GeneratedPuzzleDifficultyAssessmentPolicy(
+                    executionPolicy = GeneratedPuzzleDifficultyAssessmentExecutionPolicy(
+                        maxCandidateExpansions = 100_000,
+                        validSolutionCountLimit = 50
+                    ),
+                    minimumInitialPlausibleCandidateCount = 11,
+                    minimumInitialForcedDeductionCount = 1,
+                    maximumInitialForcedDeductionCount = 7,
+                    minimumFirstForcedDeductionDepth = 1,
+                    minimumPlausibleDecoyCount = 3,
+                    minimumMaximumBranchingFactor = 2,
+                    minimumExploredAmbiguousStateCount = 1,
+                    minimumValidSolutionCount = 1
                 )
             )
         ).getOrThrow()

--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/puzzle/GeneratedPairsPuzzleCreation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/puzzle/GeneratedPairsPuzzleCreation.kt
@@ -123,6 +123,13 @@ sealed interface GeneratedPairsPuzzleValidationViolation {
         override val ruleId = GeneratedPairsPuzzleValidationRuleId.REPEATED_STRIP_VALUE_GROUP_COUNT_EXCEEDED
     }
 
+    data class RepeatedStripValueGroupCountBelowMinimum(
+        val minimumRequired: Int,
+        val observedRepeatedValues: Set<Int>
+    ) : GeneratedPairsPuzzleValidationViolation {
+        override val ruleId = GeneratedPairsPuzzleValidationRuleId.REPEATED_STRIP_VALUE_GROUP_COUNT_BELOW_MINIMUM
+    }
+
     data class DuplicateBoardResults(val duplicateResults: Set<Int>) : GeneratedPairsPuzzleValidationViolation {
         override val ruleId = GeneratedPairsPuzzleValidationRuleId.DUPLICATE_BOARD_RESULTS
     }
@@ -184,6 +191,7 @@ enum class GeneratedPairsPuzzleValidationRuleId(val code: String) {
     STRIP_VALUE_OUTSIDE_RANGE("generated.strip-value-outside-range"),
     STRIP_VALUE_OCCURRENCE_EXCEEDED("generated.strip-value-occurrence-exceeded"),
     REPEATED_STRIP_VALUE_GROUP_COUNT_EXCEEDED("generated.repeated-strip-value-group-count-exceeded"),
+    REPEATED_STRIP_VALUE_GROUP_COUNT_BELOW_MINIMUM("generated.repeated-strip-value-group-count-below-minimum"),
     DUPLICATE_BOARD_RESULTS("generated.duplicate-board-results"),
     MULTIPLICATION_RESULT_EXCEEDED("generated.multiplication-result-exceeded"),
     PRODUCT_ANCHOR_MIX_OUTSIDE_RANGE("generated.product-anchor-mix-outside-range"),

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeConfiguration.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeConfiguration.kt
@@ -154,6 +154,12 @@ object GeneratedModes {
         difficulty = DifficultyTier.MEDIUM,
         profile = GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM
     )
+    val EIGHT_PAIRS_HARD: GeneratedChallenge = GeneratedChallenge(
+        id = GeneratedChallengeId("eight-pairs-hard"),
+        modeId = eightPairsId,
+        difficulty = DifficultyTier.HARD,
+        profile = GeneratedPuzzleProfiles.EIGHT_PAIRS_HARD
+    )
     val FOUR_PAIRS: GeneratedModeConfiguration = GeneratedModeConfiguration(
         id = fourPairsId,
         size = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW.size,
@@ -162,7 +168,7 @@ object GeneratedModes {
     val EIGHT_PAIRS: GeneratedModeConfiguration = GeneratedModeConfiguration(
         id = eightPairsId,
         size = GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM.size,
-        challenges = listOf(EIGHT_PAIRS_MEDIUM)
+        challenges = listOf(EIGHT_PAIRS_MEDIUM, EIGHT_PAIRS_HARD)
     )
     val catalog: GeneratedChallengeCatalog = GeneratedChallengeCatalog(
         configurations = listOf(FOUR_PAIRS, EIGHT_PAIRS)

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPuzzleDifficultyAssessmentPolicyTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/assessment/GeneratedPuzzleDifficultyAssessmentPolicyTest.kt
@@ -11,8 +11,11 @@ class GeneratedPuzzleDifficultyAssessmentPolicyTest {
             executionPolicy = GeneratedPuzzleDifficultyAssessmentExecutionPolicy(validSolutionCountLimit = 20),
             minimumInitialPlausibleCandidateCount = 6,
             minimumInitialForcedDeductionCount = 1,
+            maximumInitialForcedDeductionCount = 1,
             minimumFirstForcedDeductionDepth = 1,
             minimumPlausibleDecoyCount = 1,
+            minimumMaximumBranchingFactor = 2,
+            minimumExploredAmbiguousStateCount = 1,
             minimumValidSolutionCount = 1
         )
         val acceptedReport = report(
@@ -20,19 +23,31 @@ class GeneratedPuzzleDifficultyAssessmentPolicyTest {
             initialForcedDeductionCount = 1,
             firstForcedDeductionDepth = 1,
             plausibleDecoyCount = 1,
-            validSolutionCount = 2
+            validSolutionCount = 2,
+            maximumBranchingFactor = 2,
+            exploredAmbiguousStateCount = 1
         )
 
         assertTrue(policy.evaluate(acceptedReport).isAccepted)
         assertEquals(
-            GeneratedPuzzleDifficultyRequirement.entries.toSet(),
+            setOf(
+                GeneratedPuzzleDifficultyRequirement.INITIAL_PLAUSIBLE_CANDIDATES,
+                GeneratedPuzzleDifficultyRequirement.INITIAL_FORCED_DEDUCTION_MAXIMUM,
+                GeneratedPuzzleDifficultyRequirement.FIRST_FORCED_DEDUCTION_DEPTH,
+                GeneratedPuzzleDifficultyRequirement.PLAUSIBLE_DECOYS,
+                GeneratedPuzzleDifficultyRequirement.MAXIMUM_BRANCHING_FACTOR,
+                GeneratedPuzzleDifficultyRequirement.EXPLORED_AMBIGUOUS_STATES,
+                GeneratedPuzzleDifficultyRequirement.VALID_SOLUTIONS
+            ),
             policy.evaluate(
                 report(
                     initialPlausibleCandidateCount = 5,
-                    initialForcedDeductionCount = 0,
+                    initialForcedDeductionCount = 2,
                     firstForcedDeductionDepth = null,
                     plausibleDecoyCount = 0,
-                    validSolutionCount = 0
+                    validSolutionCount = 0,
+                    maximumBranchingFactor = 0,
+                    exploredAmbiguousStateCount = 0
                 )
             ).unmetRequirements
         )
@@ -44,14 +59,16 @@ private fun report(
     initialForcedDeductionCount: Int,
     firstForcedDeductionDepth: Int?,
     plausibleDecoyCount: Int,
-    validSolutionCount: Int
+    validSolutionCount: Int,
+    maximumBranchingFactor: Int,
+    exploredAmbiguousStateCount: Int
 ): GeneratedPuzzleDifficultyAssessmentReport = GeneratedPuzzleDifficultyAssessmentReport(
     initialPlausibleCandidateCount = initialPlausibleCandidateCount,
     initialForcedDeductionCount = initialForcedDeductionCount,
     forcedDeductionCount = initialForcedDeductionCount,
     firstForcedDeductionDepth = firstForcedDeductionDepth,
-    maximumBranchingFactor = 0,
-    exploredAmbiguousStateCount = 0,
+    maximumBranchingFactor = maximumBranchingFactor,
+    exploredAmbiguousStateCount = exploredAmbiguousStateCount,
     boundedValidSolutionCount = validSolutionCount,
     isValidSolutionCountLimitReached = false,
     structuralObservations = GeneratedPuzzleStructuralObservations(

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/EightPairsHardGeneratedPairsPuzzleGeneratorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/EightPairsHardGeneratedPairsPuzzleGeneratorTest.kt
@@ -1,0 +1,172 @@
+package org.cescfe.numpairs.domain.generated.generation
+
+import kotlin.math.abs
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPairsDifficultyAssessor
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficultyAssessmentOutcome
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfiles
+import org.cescfe.numpairs.domain.generated.profile.ProbabilityPercent
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.cescfe.numpairs.domain.puzzle.model.Tile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EightPairsHardGeneratedPairsPuzzleGeneratorTest {
+    @Test
+    fun eight_pairs_hard_generation_satisfies_the_documented_profile() {
+        val profile = GeneratedPuzzleProfiles.EIGHT_PAIRS_HARD
+        val puzzle = generatedPuzzle(profile = profile, seed = 42)
+        val solvedValues = puzzle.solvedPuzzle.requireKnownStripValues()
+        val repeatedValueGroupCount = solvedValues.repeatedValueGroupCount()
+        val anchorMix = requireNotNull(profile.resultConstraints.productAnchorMix)
+        val productAnchorCount = puzzle.solvedPuzzle.multiplicationTiles().count { tile ->
+            tile.result > anchorMix.productResultGreaterThan
+        }
+        val knownEntryIds = puzzle.initialPuzzle.knownEntryIds()
+
+        assertTrue(solvedValues.all { value -> value in 1..99 })
+        assertTrue(
+            solvedValues.groupingBy { value -> value }.eachCount().values
+                .all { occurrenceCount -> occurrenceCount <= 2 }
+        )
+        assertTrue(repeatedValueGroupCount in 1..2)
+        assertTrue(puzzle.solvedPuzzle.multiplicationTiles().all { tile -> tile.result <= 1000 })
+        assertEquals(16, puzzle.solvedPuzzle.board.tiles.map(Tile::result).toSet().size)
+        assertTrue(productAnchorCount in 0..1)
+        assertTrue(knownEntryIds.size in 4..5)
+        assertTrue(puzzle.initialPuzzle.strip.entries.count { entry -> entry.item == StripItem.Hidden } in 11..12)
+        assertTrue(knownEntryIds.distinctSolutionPairCount(puzzle) >= 3)
+        assertTrue(knownEntryIds.maxConsecutiveHiddenEntries(16) <= 5)
+    }
+
+    @Test
+    fun eight_pairs_hard_generation_is_deterministic_for_the_same_seed() {
+        val profile = GeneratedPuzzleProfiles.EIGHT_PAIRS_HARD
+
+        assertEquals(
+            generatedPuzzle(profile = profile, seed = 1234),
+            generatedPuzzle(profile = profile, seed = 1234)
+        )
+    }
+
+    @Test
+    fun hard_generation_meets_population_targets_and_stays_within_execution_bounds() {
+        val profile = GeneratedPuzzleProfiles.EIGHT_PAIRS_HARD
+        val generatedOutcomes = (1..VARIETY_SAMPLE_SIZE).map { seed ->
+            val outcome = GeneratedPairsPuzzleGenerator(profile).generate(
+                request = GeneratedPuzzleGenerationRequest(profile = profile, seed = seed)
+            )
+            check(outcome is GeneratedPairsPuzzleGenerationOutcome.Generated) {
+                "Hard generation failed for seed $seed: $outcome"
+            }
+            outcome
+        }
+        assertTrue(generatedOutcomes.all { outcome -> outcome.attemptsUsed <= 160 })
+        assertTrue(generatedOutcomes.all { outcome -> outcome.searchWorkConsumed <= 600_000 })
+        assertTrue(
+            generatedOutcomes.all { outcome ->
+                outcome.puzzle.solvedPuzzle.requireKnownStripValues().repeatedValueGroupCount() in 1..2
+            }
+        )
+
+        val decoyTarget = requireNotNull(profile.varietyPolicy.primeProductDecoyTarget)
+        val primeProductDecoyPuzzleCount = generatedOutcomes.count { outcome ->
+            outcome.puzzle.solvedPuzzle.multiplicationTiles().count(Tile::isPrimeProductDecoy) ==
+                decoyTarget.targetPairCount
+        }
+        assertFrequencyWithinTarget(
+            actualCount = primeProductDecoyPuzzleCount,
+            targetPercentage = decoyTarget.targetPuzzlePercent
+        )
+        profile.varietyPolicy.highValueMaskTargets.forEach { target ->
+            val targetEntryIndex = profile.size.stripEntryCount - target.rankFromHighest
+            val hiddenPuzzleCount = generatedOutcomes.count { outcome ->
+                outcome.puzzle.initialPuzzle.strip.entries[targetEntryIndex].item == StripItem.Hidden
+            }
+            assertFrequencyWithinTarget(
+                actualCount = hiddenPuzzleCount,
+                targetPercentage = target.targetHiddenProbability
+            )
+        }
+    }
+
+    @Test
+    fun every_sampled_hard_puzzle_passes_the_evidence_based_assessment_policy() {
+        val hardProfile = GeneratedPuzzleProfiles.EIGHT_PAIRS_HARD
+        val hardPolicy = requireNotNull(hardProfile.difficultyAssessmentPolicy)
+        val assessor = GeneratedPairsDifficultyAssessor()
+
+        ASSESSMENT_SEEDS.forEach { seed ->
+            val puzzle = generatedPuzzle(profile = hardProfile, seed = seed)
+            val outcome = assessor.assess(
+                initialPuzzle = puzzle.initialPuzzle,
+                profile = hardProfile,
+                executionPolicy = hardPolicy.executionPolicy
+            )
+            assertTrue(
+                "Assessment must complete for seed $seed.",
+                outcome is GeneratedPuzzleDifficultyAssessmentOutcome.Assessed
+            )
+            val report = (outcome as GeneratedPuzzleDifficultyAssessmentOutcome.Assessed).report
+            assertTrue("Hard policy must accept seed $seed.", hardPolicy.evaluate(report).isAccepted)
+            assertTrue(report.initialForcedDeductionCount < hardProfile.size.pairCount)
+            assertTrue(report.maximumBranchingFactor >= 2)
+            assertTrue(report.exploredAmbiguousStateCount >= 1)
+        }
+    }
+
+    @Test
+    fun eight_pairs_hard_preserves_bounded_failure_and_cancellation() {
+        val profile = GeneratedPuzzleProfiles.EIGHT_PAIRS_HARD
+        val budgetFailure = GeneratedPairsPuzzleGenerator(profile).generate(
+            request = GeneratedPuzzleGenerationRequest(
+                profile = profile,
+                seed = 2026,
+                executionPolicy = GeneratedPuzzleGenerationExecutionPolicy(
+                    maxAttempts = 1,
+                    maxSearchWork = 1
+                )
+            )
+        ) as GeneratedPairsPuzzleGenerationOutcome.Failed
+        assertEquals(GeneratedPairsPuzzleGenerationFailureReason.SearchBudgetExhausted, budgetFailure.reason)
+
+        val cancellation = GeneratedPairsPuzzleGenerator(profile).generate(
+            request = GeneratedPuzzleGenerationRequest(profile = profile, seed = 2026),
+            cancellation = { true }
+        ) as GeneratedPairsPuzzleGenerationOutcome.Failed
+        assertEquals(GeneratedPairsPuzzleGenerationFailureReason.Cancelled, cancellation.reason)
+        assertEquals(0, cancellation.searchWorkConsumed)
+    }
+
+    @Test
+    fun hard_generation_handles_a_high_retry_fixture_within_its_profile_budget() {
+        val profile = GeneratedPuzzleProfiles.EIGHT_PAIRS_HARD
+        val outcome = GeneratedPairsPuzzleGenerator(profile).generate(
+            request = GeneratedPuzzleGenerationRequest(profile = profile, seed = 386)
+        )
+
+        assertTrue(outcome is GeneratedPairsPuzzleGenerationOutcome.Generated)
+        assertTrue(outcome.attemptsUsed <= profile.generationPolicy.maxAttempts)
+        assertTrue(outcome.searchWorkConsumed <= profile.generationPolicy.maxSearchWork)
+    }
+
+    private fun assertFrequencyWithinTarget(actualCount: Int, targetPercentage: ProbabilityPercent) {
+        val actualPercentage = actualCount * 100.0 / VARIETY_SAMPLE_SIZE
+        assertTrue(
+            "Expected ${targetPercentage.value}% within ±$VARIETY_TOLERANCE_PERCENTAGE_POINTS points, " +
+                "but observed $actualPercentage% ($actualCount/$VARIETY_SAMPLE_SIZE).",
+            abs(actualPercentage - targetPercentage.value) <= VARIETY_TOLERANCE_PERCENTAGE_POINTS
+        )
+    }
+
+    private companion object {
+        const val VARIETY_SAMPLE_SIZE = 500
+        const val VARIETY_TOLERANCE_PERCENTAGE_POINTS = 5
+        val ASSESSMENT_SEEDS = 1..50
+    }
+}
+
+private fun List<Int>.repeatedValueGroupCount(): Int = groupingBy { value -> value }
+    .eachCount()
+    .values
+    .count { occurrenceCount -> occurrenceCount > 1 }

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/FourPairsMediumGeneratedPairsPuzzleGeneratorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/FourPairsMediumGeneratedPairsPuzzleGeneratorTest.kt
@@ -5,9 +5,6 @@ import org.cescfe.numpairs.domain.generated.assessment.GeneratedPairsDifficultyA
 import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficultyAssessmentOutcome
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfiles
 import org.cescfe.numpairs.domain.generated.profile.ProbabilityPercent
-import org.cescfe.numpairs.domain.puzzle.assignment.StripEntryId
-import org.cescfe.numpairs.domain.puzzle.assignment.analyzeResolvedPuzzle
-import org.cescfe.numpairs.domain.puzzle.model.Operator
 import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.cescfe.numpairs.domain.puzzle.model.Tile
 import org.junit.Assert.assertEquals
@@ -162,20 +159,4 @@ class FourPairsMediumGeneratedPairsPuzzleGeneratorTest {
         const val VARIETY_TOLERANCE_PERCENTAGE_POINTS = 5
         val ASSESSMENT_SEEDS = 1..50
     }
-}
-
-private fun Set<Int>.distinctSolutionPairCount(
-    generatedPuzzle: org.cescfe.numpairs.domain.generated.puzzle.GeneratedPairsPuzzle
-): Int {
-    val analysis = generatedPuzzle.solvedPuzzle.analyzeResolvedPuzzle()
-    val pairByEntryId = analysis.resolvedAssignments
-        .filter { assignment -> assignment.operator == Operator.ADDITION }
-        .flatMap { assignment ->
-            val pair = analysis.solutionPairByTileIndex.getValue(assignment.tileIndex)
-            listOf(
-                assignment.leftOperand.stripEntryId to pair,
-                assignment.rightOperand.stripEntryId to pair
-            )
-        }.toMap()
-    return map { entryId -> pairByEntryId.getValue(StripEntryId(entryId)) }.toSet().size
 }

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPairsPuzzleTestSupport.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPairsPuzzleTestSupport.kt
@@ -1,6 +1,9 @@
 package org.cescfe.numpairs.domain.generated.generation
 
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
+import org.cescfe.numpairs.domain.generated.puzzle.GeneratedPairsPuzzle
+import org.cescfe.numpairs.domain.puzzle.assignment.StripEntryId
+import org.cescfe.numpairs.domain.puzzle.assignment.analyzeResolvedPuzzle
 import org.cescfe.numpairs.domain.puzzle.model.Expression
 import org.cescfe.numpairs.domain.puzzle.model.Operator
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
@@ -78,6 +81,20 @@ internal fun Set<Int>.maxConsecutiveHiddenEntries(totalEntryCount: Int): Int {
     }
 
     return maxHiddenCount
+}
+
+internal fun Set<Int>.distinctSolutionPairCount(generatedPuzzle: GeneratedPairsPuzzle): Int {
+    val analysis = generatedPuzzle.solvedPuzzle.analyzeResolvedPuzzle()
+    val pairByEntryId = analysis.resolvedAssignments
+        .filter { assignment -> assignment.operator == Operator.ADDITION }
+        .flatMap { assignment ->
+            val pair = analysis.solutionPairByTileIndex.getValue(assignment.tileIndex)
+            listOf(
+                assignment.leftOperand.stripEntryId to pair,
+                assignment.rightOperand.stripEntryId to pair
+            )
+        }.toMap()
+    return map { entryId -> pairByEntryId.getValue(StripEntryId(entryId)) }.toSet().size
 }
 
 private fun Int.isPrime(): Boolean {

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleProfileContractTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleProfileContractTest.kt
@@ -21,7 +21,7 @@ class GeneratedPuzzleProfileContractTest {
     @Test
     fun every_registered_profile_satisfies_the_shared_generation_contract() {
         assertEquals(
-            listOf("4-pairs-low", "4-pairs-medium", "8-pairs-medium"),
+            listOf("4-pairs-low", "4-pairs-medium", "8-pairs-medium", "8-pairs-hard"),
             GeneratedPuzzleProfiles.ALL.map { profile -> profile.id.value }
         )
 
@@ -90,6 +90,12 @@ class GeneratedPuzzleProfileContractTest {
                     .count { occurrenceCount -> occurrenceCount > 1 } <= maximumGroupCount
             )
         }
+        assertTrue(
+            context,
+            solvedValues.groupingBy { value -> value }.eachCount().values
+                .count { occurrenceCount -> occurrenceCount > 1 } >=
+                profile.stripValuePolicy.minRepeatedValueGroupCount
+        )
 
         assertEquals(context, profile.size.boardTileCount, assignments.size)
         assignments.forEach { assignment ->

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedFourPairsMediumConstraintTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedFourPairsMediumConstraintTest.kt
@@ -40,6 +40,26 @@ class GeneratedFourPairsMediumConstraintTest {
     }
 
     @Test
+    fun solved_values_reject_fewer_repeated_groups_than_the_profile_requires() {
+        val violations = GeneratedStripValueConstraint(
+            policy = StripValuePolicy(
+                valueRange = 1..99,
+                maxOccurrencesPerValue = 2,
+                minRepeatedValueGroupCount = 1,
+                maxRepeatedValueGroupCount = 2
+            )
+        ).violationsFor(values = (1..16).toList())
+
+        assertTrue(
+            violations.any { violation ->
+                violation is GeneratedPairsPuzzleValidationViolation.RepeatedStripValueGroupCountBelowMinimum &&
+                    violation.minimumRequired == 1 &&
+                    violation.observedRepeatedValues.isEmpty()
+            }
+        )
+    }
+
+    @Test
     fun profile_rejects_an_unreachable_repetition_target() {
         val creation = profileCreation(
             stripValuePolicy = StripValuePolicy(
@@ -77,6 +97,24 @@ class GeneratedFourPairsMediumConstraintTest {
         assertTrue(
             (creation as GeneratedPuzzleProfileCreation.Rejected).violations.any { violation ->
                 violation is GeneratedPuzzleProfileViolation.DistinctSolutionPairDistributionInfeasible
+            }
+        )
+    }
+
+    @Test
+    fun profile_rejects_more_required_repeated_groups_than_the_puzzle_can_hold() {
+        val creation = profileCreation(
+            stripValuePolicy = StripValuePolicy(
+                valueRange = 1..40,
+                maxOccurrencesPerValue = 2,
+                minRepeatedValueGroupCount = 5,
+                maxRepeatedValueGroupCount = 5
+            )
+        )
+
+        assertTrue(
+            (creation as GeneratedPuzzleProfileCreation.Rejected).violations.any { violation ->
+                violation is GeneratedPuzzleProfileViolation.RepeatedValueGroupRangeInfeasible
             }
         )
     }

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsValuePairSelectorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsValuePairSelectorTest.kt
@@ -113,6 +113,24 @@ class GeneratedPairsValuePairSelectorTest {
         assertEquals(1, includedPairs.repeatedValueGroupCount())
         assertEquals(0, excludedPairs.repeatedValueGroupCount())
     }
+
+    @Test
+    fun repetition_range_plan_selects_a_hard_valid_group_count() {
+        val selectedPairs = requireNotNull(
+            GeneratedPairsValuePairSelector(
+                profile = GeneratedPuzzleProfiles.EIGHT_PAIRS_HARD,
+                random = Random(42)
+            ).selectValuePairs(
+                variationPlan = variationPlan(
+                    repeatedValueGroupDirective = GeneratedPairsRepeatedValueGroupDirective.IncludeRange(
+                        groupCountRange = 1..2
+                    )
+                )
+            )
+        )
+
+        assertEquals(2, selectedPairs.repeatedValueGroupCount())
+    }
 }
 
 private fun variationPlan(

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsVariationPlanSelectorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/internal/GeneratedPairsVariationPlanSelectorTest.kt
@@ -131,6 +131,22 @@ class GeneratedPairsVariationPlanSelectorTest {
             excludePlan.repeatedValueGroupDirective
         )
     }
+
+    @Test
+    fun mandatory_repetition_range_does_not_consume_a_probability_roll() {
+        val profile = GeneratedPuzzleProfiles.EIGHT_PAIRS_HARD
+        val rolls = ArrayDeque(listOf(99, 99, 99, 99))
+        val plan = GeneratedPairsVariationPlanSelector(
+            profile = profile,
+            nextProbabilityRoll = rolls::removeFirst
+        ).select()
+
+        assertEquals(
+            GeneratedPairsRepeatedValueGroupDirective.IncludeRange(groupCountRange = 1..2),
+            plan.repeatedValueGroupDirective
+        )
+        assertTrue(rolls.isEmpty())
+    }
 }
 
 private fun GeneratedPuzzleProfile.withTargetProbabilities(percentage: Int): GeneratedPuzzleProfile =

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfileTest.kt
@@ -450,6 +450,7 @@ class GeneratedPuzzleProfileTest {
         assertEquals(
             listOf(
                 "profile.strip-value-capacity",
+                "profile.repeated-value-group-range-feasibility",
                 "profile.known-entry-range",
                 "profile.required-anchor-capacity",
                 "profile.hidden-run-feasibility",
@@ -486,6 +487,21 @@ class GeneratedPuzzleProfileTest {
             StripValuePolicy(valueRange = 0..2, maxOccurrencesPerValue = 1)
         }
         assertThrows(IllegalArgumentException::class.java) {
+            StripValuePolicy(
+                valueRange = 1..10,
+                maxOccurrencesPerValue = 2,
+                maxRepeatedValueGroupCount = 1,
+                minRepeatedValueGroupCount = 2
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            StripValuePolicy(
+                valueRange = 1..10,
+                maxOccurrencesPerValue = 1,
+                minRepeatedValueGroupCount = 1
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
             ResultConstraints(maxMultiplicationResult = 0, allowsDuplicateBoardResults = false)
         }
         assertThrows(IllegalArgumentException::class.java) {
@@ -513,6 +529,9 @@ class GeneratedPuzzleProfileTest {
         }
         assertThrows(IllegalArgumentException::class.java) {
             GeneratedPuzzleProfileValidationLimits(maxMaskStates = 0)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GenerationPolicy(isBoardTileShufflingEnabled = true, maxAttempts = 0)
         }
     }
 }

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfilesTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfilesTest.kt
@@ -152,4 +152,58 @@ class GeneratedPuzzleProfilesTest {
         assertEquals(1, primeProductDecoyTarget.targetPairCount)
         assertEquals(PrimeProductDecoyPairPattern.ONE_AND_PRIME, primeProductDecoyTarget.pairPattern)
     }
+
+    @Test
+    fun eight_pairs_hard_profile_matches_documented_rules() {
+        val profile = GeneratedPuzzleProfiles.EIGHT_PAIRS_HARD
+
+        assertEquals(GeneratedPuzzleProfileId("8-pairs-hard"), profile.id)
+        assertEquals(DifficultyTier.HARD, profile.difficulty)
+        assertEquals(8, profile.size.pairCount)
+        assertEquals(16, profile.size.stripEntryCount)
+        assertEquals(1..99, profile.stripValuePolicy.valueRange)
+        assertEquals(2, profile.stripValuePolicy.maxOccurrencesPerValue)
+        assertEquals(1, profile.stripValuePolicy.minRepeatedValueGroupCount)
+        assertEquals(2, profile.stripValuePolicy.maxRepeatedValueGroupCount)
+        assertTrue(profile.stripValuePolicy.allowsOne)
+
+        assertEquals(1000, profile.resultConstraints.maxMultiplicationResult)
+        assertFalse(profile.resultConstraints.allowsDuplicateBoardResults)
+        val anchorMix = requireNotNull(profile.resultConstraints.productAnchorMix)
+        assertEquals(198, anchorMix.productResultGreaterThan)
+        assertEquals(0..1, anchorMix.countRange)
+
+        assertEquals(4..5, profile.initialStripMaskPolicy.knownEntryCountRange)
+        assertEquals(11..12, profile.hiddenEntryCountRange)
+        assertTrue(profile.initialStripMaskPolicy.requiredAnchors.isEmpty())
+        assertEquals(
+            StripKnownEntryDistributionPolicy.AtLeastDistinctSolutionPairs(minimumPairCount = 3),
+            profile.initialStripMaskPolicy.distributionPolicy
+        )
+        assertEquals(5, profile.initialStripMaskPolicy.maxConsecutiveHiddenEntries)
+        assertEquals(
+            listOf(
+                HighValueMaskTarget(1, ProbabilityPercent(60)),
+                HighValueMaskTarget(2, ProbabilityPercent(70)),
+                HighValueMaskTarget(3, ProbabilityPercent(70))
+            ),
+            profile.varietyPolicy.highValueMaskTargets
+        )
+        val decoyTarget = requireNotNull(profile.varietyPolicy.primeProductDecoyTarget)
+        assertEquals(ProbabilityPercent(60), decoyTarget.targetPuzzlePercent)
+        assertEquals(1, decoyTarget.targetPairCount)
+
+        val assessmentPolicy = requireNotNull(profile.difficultyAssessmentPolicy)
+        assertEquals(100_000, assessmentPolicy.executionPolicy.maxCandidateExpansions)
+        assertEquals(50, assessmentPolicy.executionPolicy.validSolutionCountLimit)
+        assertEquals(11, assessmentPolicy.minimumInitialPlausibleCandidateCount)
+        assertEquals(1, assessmentPolicy.minimumInitialForcedDeductionCount)
+        assertEquals(7, assessmentPolicy.maximumInitialForcedDeductionCount)
+        assertEquals(3, assessmentPolicy.minimumPlausibleDecoyCount)
+        assertEquals(2, assessmentPolicy.minimumMaximumBranchingFactor)
+        assertEquals(1, assessmentPolicy.minimumExploredAmbiguousStateCount)
+        assertTrue(profile.generationPolicy.isBoardTileShufflingEnabled)
+        assertEquals(160, profile.generationPolicy.maxAttempts)
+        assertEquals(600_000, profile.generationPolicy.maxSearchWork)
+    }
 }

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/puzzle/internal/GeneratedPairsPuzzleValidatorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/puzzle/internal/GeneratedPairsPuzzleValidatorTest.kt
@@ -432,6 +432,7 @@ class GeneratedPairsPuzzleValidatorTest {
                 "generated.strip-value-outside-range",
                 "generated.strip-value-occurrence-exceeded",
                 "generated.repeated-strip-value-group-count-exceeded",
+                "generated.repeated-strip-value-group-count-below-minimum",
                 "generated.duplicate-board-results",
                 "generated.multiplication-result-exceeded",
                 "generated.product-anchor-mix-outside-range",

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedChallengeCatalogTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedChallengeCatalogTest.kt
@@ -29,6 +29,7 @@ class GeneratedChallengeCatalogTest {
         assertEquals(DifficultyTier.LOW, GeneratedPuzzleProfiles.FOUR_PAIRS_LOW.difficulty)
         assertEquals(DifficultyTier.MEDIUM, GeneratedPuzzleProfiles.FOUR_PAIRS_MEDIUM.difficulty)
         assertEquals(DifficultyTier.MEDIUM, GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM.difficulty)
+        assertEquals(DifficultyTier.HARD, GeneratedPuzzleProfiles.EIGHT_PAIRS_HARD.difficulty)
     }
 
     @Test
@@ -38,11 +39,13 @@ class GeneratedChallengeCatalogTest {
         assertEquals("4-pairs-low", GeneratedModes.FOUR_PAIRS_LOW.profile.id.value)
         assertEquals("4-pairs-medium", GeneratedModes.FOUR_PAIRS_MEDIUM.profile.id.value)
         assertEquals("8-pairs-medium", GeneratedModes.EIGHT_PAIRS_MEDIUM.profile.id.value)
+        assertEquals("8-pairs-hard", GeneratedModes.EIGHT_PAIRS_HARD.profile.id.value)
         assertEquals(
             listOf(
                 GeneratedModes.FOUR_PAIRS_LOW,
                 GeneratedModes.FOUR_PAIRS_MEDIUM,
-                GeneratedModes.EIGHT_PAIRS_MEDIUM
+                GeneratedModes.EIGHT_PAIRS_MEDIUM,
+                GeneratedModes.EIGHT_PAIRS_HARD
             ),
             GeneratedModes.catalog.allChallenges
         )
@@ -65,6 +68,13 @@ class GeneratedChallengeCatalogTest {
             GeneratedModes.catalog.resolveChallenge(
                 modeId = GeneratedModes.EIGHT_PAIRS.id,
                 profileId = GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM.id
+            )
+        )
+        assertSame(
+            GeneratedModes.EIGHT_PAIRS_HARD,
+            GeneratedModes.catalog.resolveChallenge(
+                modeId = GeneratedModes.EIGHT_PAIRS.id,
+                difficulty = DifficultyTier.HARD
             )
         )
     }

--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -3,8 +3,9 @@
 ## Document Status
 
 - Status: product reference for generated puzzle construction
-- Implemented profiles: generated `4 Pairs Low`, `4 Pairs Medium`, and `8 Pairs Medium`
-- Remaining v8 target profile: generated `8 Pairs Hard`
+- Implemented profiles: generated `4 Pairs Low`, `4 Pairs Medium`, `8 Pairs Medium`, and
+  `8 Pairs Hard`
+- v8 generated challenge matrix: implemented
 - Related references:
   - `docs/product/prd/prd-v5.md`
   - `docs/product/prd/prd-v7.md`
@@ -351,7 +352,7 @@ Solving-tip implications:
 
 ### `8 Pairs Hard`
 
-Status: specified for v8; not implemented.
+Status: implemented in v8.
 
 Shape:
 
@@ -399,10 +400,11 @@ Assessment expectations:
 
 - assessment must complete within the configured Hard work policy
 - at least 1 valid solution equivalence class must exist; uniqueness is not required
-- at least 1 opening fact must be derivable without speculative commitment
+- between 1 and 7 opening facts must be derivable without speculative commitment; the existing
+  `8 Pairs Medium` characterization exposes all 8 solution facts immediately
 - at least 3 locally plausible decoys must remain after direct arithmetic filtering
-- the first forced fact must require at least 2 chained propagation layers
 - at least 1 ambiguous state must remain after direct local filtering
+- the maximum observed branching factor must be at least 2
 - characterization must demonstrate greater deductive depth and ambiguity than `8 Pairs Medium`
   without exceeding the bounded Hard envelope
 


### PR DESCRIPTION
## Related Issue

Resolves #496

## Summary

- Add and register the deterministic 8 Pairs Hard profile with its documented structural, variety, and bounded generation policies.
- Extend profile validation and generation to support mandatory repeated-value ranges and profile-specific execution budgets.
- Gate Hard candidates with bounded deductive evidence for ambiguity, branching, decoys, and non-trivial opening deductions.
- Cover the profile with deterministic, 500-seed population, assessment, cancellation, performance-bound, and regression tests.