### PR TITLE
[243] Persist difficulty by generated mode

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/data/generated/selection/DataStoreGeneratedDifficultySelectionRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/generated/selection/DataStoreGeneratedDifficultySelectionRepository.kt
@@ -1,0 +1,84 @@
+package org.cescfe.numpairs.data.generated.selection
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import java.io.IOException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
+import org.cescfe.numpairs.feature.generated.GeneratedChallengeCatalog
+import org.cescfe.numpairs.feature.generated.GeneratedModeId
+
+class DataStoreGeneratedDifficultySelectionRepository(
+    private val dataStore: DataStore<Preferences>,
+    private val catalog: GeneratedChallengeCatalog,
+    private val fallbackDifficultyByMode: Map<GeneratedModeId, DifficultyTier>
+) : GeneratedDifficultySelectionRepository {
+    init {
+        val configuredModeIds = catalog.all.map { mode -> mode.id }.toSet()
+        require(fallbackDifficultyByMode.keys == configuredModeIds) {
+            "Every configured generated mode must have exactly one difficulty fallback."
+        }
+        fallbackDifficultyByMode.forEach { (modeId, difficulty) ->
+            require(catalog.supports(modeId = modeId, difficulty = difficulty)) {
+                "The fallback for mode ${modeId.value} must be a supported difficulty."
+            }
+        }
+    }
+
+    override fun selectedDifficulty(modeId: GeneratedModeId): Flow<DifficultyTier?> {
+        val fallback = fallbackDifficultyByMode[modeId] ?: return flowOf(null)
+
+        return dataStore.data
+            .catch { throwable ->
+                if (throwable is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw throwable
+                }
+            }
+            .map { preferences ->
+                preferences[difficultyPreferenceKey(modeId)]
+                    .toDifficultyTierOrNull()
+                    ?.takeIf { difficulty -> catalog.supports(modeId = modeId, difficulty = difficulty) }
+                    ?: fallback
+            }
+            .distinctUntilChanged()
+    }
+
+    override suspend fun selectDifficulty(modeId: GeneratedModeId, difficulty: DifficultyTier) {
+        require(catalog.supports(modeId = modeId, difficulty = difficulty)) {
+            "Difficulty ${difficulty.name} is not supported for generated mode ${modeId.value}."
+        }
+
+        dataStore.edit { preferences ->
+            preferences[difficultyPreferenceKey(modeId)] = difficulty.persistedValue
+        }
+    }
+}
+
+internal fun difficultyPreferenceKey(modeId: GeneratedModeId): Preferences.Key<String> =
+    stringPreferencesKey("generated_selected_difficulty_${modeId.value}")
+
+private fun GeneratedChallengeCatalog.supports(modeId: GeneratedModeId, difficulty: DifficultyTier): Boolean =
+    allChallenges.any { challenge -> challenge.modeId == modeId && challenge.difficulty == difficulty }
+
+private val DifficultyTier.persistedValue: String
+    get() = when (this) {
+        DifficultyTier.LOW -> "low"
+        DifficultyTier.MEDIUM -> "medium"
+        DifficultyTier.HARD -> "hard"
+    }
+
+private fun String?.toDifficultyTierOrNull(): DifficultyTier? = when (this) {
+    "low" -> DifficultyTier.LOW
+    "medium" -> DifficultyTier.MEDIUM
+    "hard" -> DifficultyTier.HARD
+    else -> null
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/generated/selection/GeneratedDifficultySelectionRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/generated/selection/GeneratedDifficultySelectionRepository.kt
@@ -1,0 +1,11 @@
+package org.cescfe.numpairs.data.generated.selection
+
+import kotlinx.coroutines.flow.Flow
+import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
+import org.cescfe.numpairs.feature.generated.GeneratedModeId
+
+interface GeneratedDifficultySelectionRepository {
+    fun selectedDifficulty(modeId: GeneratedModeId): Flow<DifficultyTier?>
+
+    suspend fun selectDifficulty(modeId: GeneratedModeId, difficulty: DifficultyTier)
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/generated/selection/GeneratedDifficultySelectionRepositoryFactory.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/generated/selection/GeneratedDifficultySelectionRepositoryFactory.kt
@@ -1,0 +1,29 @@
+package org.cescfe.numpairs.data.generated.selection
+
+import android.content.Context
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStore
+import org.cescfe.numpairs.feature.generated.GeneratedModes
+
+fun createGeneratedDifficultySelectionRepository(context: Context): GeneratedDifficultySelectionRepository {
+    val applicationContext = context.applicationContext
+
+    return DataStoreGeneratedDifficultySelectionRepository(
+        dataStore = applicationContext.generatedDifficultySelectionDataStore,
+        catalog = GeneratedModes.catalog,
+        fallbackDifficultyByMode = mapOf(
+            GeneratedModes.FOUR_PAIRS.id to GeneratedModes.FOUR_PAIRS_LOW.difficulty,
+            GeneratedModes.EIGHT_PAIRS.id to GeneratedModes.EIGHT_PAIRS_MEDIUM.difficulty
+        )
+    )
+}
+
+private const val GENERATED_DIFFICULTY_SELECTION_DATA_STORE_NAME = "generated_difficulty_selection"
+
+private val Context.generatedDifficultySelectionDataStore by preferencesDataStore(
+    name = GENERATED_DIFFICULTY_SELECTION_DATA_STORE_NAME,
+    corruptionHandler = ReplaceFileCorruptionHandler {
+        emptyPreferences()
+    }
+)

--- a/app/src/test/java/org/cescfe/numpairs/data/generated/selection/DataStoreGeneratedDifficultySelectionRepositoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/generated/selection/DataStoreGeneratedDifficultySelectionRepositoryTest.kt
@@ -1,0 +1,223 @@
+package org.cescfe.numpairs.data.generated.selection
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import java.io.File
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
+import org.cescfe.numpairs.feature.generated.GeneratedModeId
+import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DataStoreGeneratedDifficultySelectionRepositoryTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val dataStoreJobs = mutableListOf<Job>()
+
+    @After
+    fun tearDown() {
+        dataStoreJobs.forEach(Job::cancel)
+    }
+
+    @Test
+    fun fresh_preferences_expose_mode_specific_fallbacks_without_persisting_them() = runBlocking {
+        val fixture = createRepository()
+
+        assertEquals(
+            DifficultyTier.LOW,
+            fixture.repository.selectedDifficulty(GeneratedModes.FOUR_PAIRS.id).first()
+        )
+        assertEquals(
+            DifficultyTier.MEDIUM,
+            fixture.repository.selectedDifficulty(GeneratedModes.EIGHT_PAIRS.id).first()
+        )
+        assertTrue(fixture.dataStore.data.first().asMap().isEmpty())
+    }
+
+    @Test
+    fun explicit_supported_selections_persist_independently_across_recreation() = runBlocking {
+        val dataStoreFile = createDataStoreFile()
+        val firstFixture = createRepository(dataStoreFile)
+
+        firstFixture.repository.selectDifficulty(
+            modeId = GeneratedModes.FOUR_PAIRS.id,
+            difficulty = DifficultyTier.MEDIUM
+        )
+        firstFixture.repository.selectDifficulty(
+            modeId = GeneratedModes.EIGHT_PAIRS.id,
+            difficulty = DifficultyTier.HARD
+        )
+        firstFixture.close()
+
+        val secondFixture = createRepository(dataStoreFile)
+
+        assertEquals(
+            DifficultyTier.MEDIUM,
+            secondFixture.repository.selectedDifficulty(GeneratedModes.FOUR_PAIRS.id).first()
+        )
+        assertEquals(
+            DifficultyTier.HARD,
+            secondFixture.repository.selectedDifficulty(GeneratedModes.EIGHT_PAIRS.id).first()
+        )
+    }
+
+    @Test
+    fun changing_one_mode_does_not_overwrite_the_other_mode() = runBlocking {
+        val fixture = createRepository()
+        fixture.repository.selectDifficulty(GeneratedModes.FOUR_PAIRS.id, DifficultyTier.MEDIUM)
+
+        assertEquals(
+            DifficultyTier.MEDIUM,
+            fixture.repository.selectedDifficulty(GeneratedModes.FOUR_PAIRS.id).first()
+        )
+        assertEquals(
+            DifficultyTier.MEDIUM,
+            fixture.repository.selectedDifficulty(GeneratedModes.EIGHT_PAIRS.id).first()
+        )
+
+        fixture.repository.selectDifficulty(GeneratedModes.EIGHT_PAIRS.id, DifficultyTier.HARD)
+
+        assertEquals(
+            DifficultyTier.MEDIUM,
+            fixture.repository.selectedDifficulty(GeneratedModes.FOUR_PAIRS.id).first()
+        )
+        assertEquals(
+            DifficultyTier.HARD,
+            fixture.repository.selectedDifficulty(GeneratedModes.EIGHT_PAIRS.id).first()
+        )
+    }
+
+    @Test
+    fun unknown_future_and_unsupported_values_fall_back_without_rewriting_storage() = runBlocking {
+        val fixture = createRepository()
+        val fourPairsKey = difficultyPreferenceKey(GeneratedModes.FOUR_PAIRS.id)
+        val eightPairsKey = difficultyPreferenceKey(GeneratedModes.EIGHT_PAIRS.id)
+        fixture.dataStore.edit { preferences ->
+            preferences[fourPairsKey] = "hard"
+            preferences[eightPairsKey] = "future-difficulty"
+        }
+
+        assertEquals(
+            DifficultyTier.LOW,
+            fixture.repository.selectedDifficulty(GeneratedModes.FOUR_PAIRS.id).first()
+        )
+        assertEquals(
+            DifficultyTier.MEDIUM,
+            fixture.repository.selectedDifficulty(GeneratedModes.EIGHT_PAIRS.id).first()
+        )
+        val storedPreferences = fixture.dataStore.data.first()
+        assertEquals("hard", storedPreferences[fourPairsKey])
+        assertEquals("future-difficulty", storedPreferences[eightPairsKey])
+    }
+
+    @Test
+    fun unknown_mode_is_ignored_and_exposes_no_invented_fallback() = runBlocking {
+        val fixture = createRepository()
+        val unknownMode = GeneratedModeId("future-mode")
+        val unknownModeKey = stringPreferencesKey("generated_selected_difficulty_${unknownMode.value}")
+        fixture.dataStore.edit { preferences ->
+            preferences[unknownModeKey] = "hard"
+        }
+
+        assertNull(fixture.repository.selectedDifficulty(unknownMode).first())
+        assertEquals("hard", fixture.dataStore.data.first()[unknownModeKey])
+    }
+
+    @Test
+    fun unsupported_and_unknown_explicit_selections_fail_before_writing() {
+        val fixture = createRepository()
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                fixture.repository.selectDifficulty(GeneratedModes.FOUR_PAIRS.id, DifficultyTier.HARD)
+            }
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                fixture.repository.selectDifficulty(GeneratedModeId("future-mode"), DifficultyTier.LOW)
+            }
+        }
+
+        runBlocking {
+            assertTrue(fixture.dataStore.data.first().asMap().isEmpty())
+        }
+    }
+
+    @Test
+    fun corrupt_preferences_file_recovers_to_safe_fallbacks() = runBlocking {
+        val dataStoreFile = createDataStoreFile().apply {
+            parentFile?.mkdirs()
+            writeBytes(byteArrayOf(1, 2, 3, 4))
+        }
+        val fixture = createRepository(dataStoreFile)
+
+        assertEquals(
+            DifficultyTier.LOW,
+            fixture.repository.selectedDifficulty(GeneratedModes.FOUR_PAIRS.id).first()
+        )
+        assertEquals(
+            DifficultyTier.MEDIUM,
+            fixture.repository.selectedDifficulty(GeneratedModes.EIGHT_PAIRS.id).first()
+        )
+    }
+
+    private fun createRepository(dataStoreFile: File = createDataStoreFile()): RepositoryFixture {
+        val job = SupervisorJob()
+        dataStoreJobs += job
+        val dataStore = PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler {
+                emptyPreferences()
+            },
+            scope = CoroutineScope(job + Dispatchers.IO),
+            produceFile = { dataStoreFile }
+        )
+
+        return RepositoryFixture(
+            repository = DataStoreGeneratedDifficultySelectionRepository(
+                dataStore = dataStore,
+                catalog = GeneratedModes.catalog,
+                fallbackDifficultyByMode = mapOf(
+                    GeneratedModes.FOUR_PAIRS.id to DifficultyTier.LOW,
+                    GeneratedModes.EIGHT_PAIRS.id to DifficultyTier.MEDIUM
+                )
+            ),
+            dataStore = dataStore,
+            job = job
+        )
+    }
+
+    private fun createDataStoreFile(): File = File(
+        temporaryFolder.root,
+        "${UUID.randomUUID()}.preferences_pb"
+    )
+
+    private data class RepositoryFixture(
+        val repository: GeneratedDifficultySelectionRepository,
+        val dataStore: DataStore<Preferences>,
+        private val job: Job
+    ) {
+        suspend fun close() {
+            job.cancelAndJoin()
+        }
+    }
+}

--- a/docs/technical/generated-session-persistence.md
+++ b/docs/technical/generated-session-persistence.md
@@ -2,7 +2,7 @@
 
 ## Document Status
 
-- Status: implemented v7 persistence boundary with the v8 multi-profile contract documented
+- Status: implemented v7 session persistence and v8 remembered-difficulty preference boundaries
 - Product contracts: `docs/product/prd/prd-v7.md` and `docs/product/prd/prd-v8.md`
 - Related generation reference: `docs/product/puzzle-generation.md`
 - Related domain decision: `docs/technical/adr/adr-005-model-sparse-generated-challenges.md`
@@ -44,6 +44,12 @@ Opening the selector, showing a fallback, pressing Play, resuming or restoring a
 a session, completing a puzzle, and using `Play another` do not write this preference. The two mode
 values remain independent, and neither completion nor any other v8 behavior stores progression,
 locks, completion counts, rewards, or statistics.
+
+The remembered values live in the dedicated Preferences DataStore file
+`datastore/generated_difficulty_selection.preferences_pb`. This keeps the aggregate and its
+corruption recovery independent from personalization, onboarding, and the resumable generated
+session. The file stores one stable difficulty id under each stable generated-mode identity; it
+does not store display copy, profile parameters, completion data, or transient selector state.
 
 ---
 


### PR DESCRIPTION
## Related Issue

Resolves #497

## Summary

- Add an observable DataStore-backed difficulty preference boundary keyed independently by generated mode.
- Persist only explicit catalog-supported selections and resolve 4 Pairs Low / 8 Pairs Medium fallbacks without implicit writes.
- Isolate storage and corruption recovery from onboarding, personalization, sessions, and completion state.
- Cover defaults, invalid and future values, unknown modes, independence, corruption, recreation, and no-write fallback behavior.