### PR TITLE
[244] Add the generated difficulty selector UI

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/selector/ui/GeneratedDifficultySelectorScreenTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/generated/selector/ui/GeneratedDifficultySelectorScreenTest.kt
@@ -1,0 +1,272 @@
+package org.cescfe.numpairs.feature.generated.selector.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GeneratedDifficultySelectorScreenTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun four_pairs_presents_only_low_and_medium_with_an_identified_primary_action() {
+        setContent(state = fourPairsState)
+
+        composeTestRule
+            .onNodeWithTag(GeneratedDifficultySelectorTestTags.MODE_NAME)
+            .assertTextEquals("4 pairs")
+        composeTestRule.onNodeWithTag(optionTag(lowId)).assertIsSelected()
+        composeTestRule.onNodeWithTag(optionTag(mediumId)).assertIsNotSelected()
+        composeTestRule.onNodeWithTag(optionTag(hardId)).assertDoesNotExist()
+        composeTestRule
+            .onNodeWithTag(GeneratedDifficultySelectorTestTags.PLAY_BUTTON)
+            .assertTextContains("4 pairs", substring = true)
+            .assertTextContains("Low", substring = true)
+    }
+
+    @Test
+    fun eight_pairs_presents_only_medium_and_hard_with_every_option_enabled() {
+        setContent(state = eightPairsState)
+
+        composeTestRule
+            .onNodeWithTag(GeneratedDifficultySelectorTestTags.MODE_NAME)
+            .assertTextEquals("8 pairs")
+        composeTestRule.onNodeWithTag(optionTag(lowId)).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(optionTag(mediumId)).assertIsNotSelected().assertIsEnabled()
+        composeTestRule.onNodeWithTag(optionTag(hardId)).assertIsSelected().assertIsEnabled()
+        composeTestRule
+            .onNodeWithTag(GeneratedDifficultySelectorTestTags.PLAY_BUTTON)
+            .assertTextContains("8 pairs", substring = true)
+            .assertTextContains("Hard", substring = true)
+    }
+
+    @Test
+    fun selection_play_and_back_emit_explicit_events_from_state_driven_content() {
+        var selectedId: GeneratedDifficultyOptionId? = null
+        var playedId: GeneratedDifficultyOptionId? = null
+        var backCount = 0
+        var state by mutableStateOf(fourPairsState)
+        setContent(
+            stateProvider = { state },
+            onDifficultySelected = { optionId ->
+                selectedId = optionId
+                state = state.copy(selectedOptionId = optionId)
+            },
+            onPlay = { optionId -> playedId = optionId },
+            onNavigateBack = { backCount += 1 }
+        )
+
+        composeTestRule.onNodeWithTag(optionTag(mediumId)).performClick().assertIsSelected()
+        composeTestRule.onNodeWithTag(GeneratedDifficultySelectorTestTags.PLAY_BUTTON).performClick()
+        composeTestRule.onNodeWithTag(GeneratedDifficultySelectorTestTags.BACK_BUTTON).performClick()
+
+        composeTestRule.runOnIdle {
+            assertEquals(mediumId, selectedId)
+            assertEquals(mediumId, playedId)
+            assertEquals(1, backCount)
+        }
+    }
+
+    @Test
+    fun selected_option_exposes_radio_semantics_and_a_non_color_selected_label() {
+        setContent(state = fourPairsState)
+        val selectedText = composeTestRule.activity.getString(R.string.difficulty_selector_selected)
+
+        composeTestRule
+            .onNodeWithTag(optionTag(lowId))
+            .assertIsSelected()
+            .assertHasClickAction()
+            .assert(
+                SemanticsMatcher.expectValue(
+                    SemanticsProperties.Role,
+                    Role.RadioButton
+                )
+            ).assert(
+                SemanticsMatcher.expectValue(
+                    SemanticsProperties.StateDescription,
+                    selectedText
+                )
+            )
+        composeTestRule
+            .onNodeWithTag(
+                GeneratedDifficultySelectorTestTags.SELECTED_LABEL,
+                useUnmergedTree = true
+            )
+            .assertIsDisplayed()
+            .assertTextEquals(selectedText)
+        composeTestRule
+            .onNodeWithContentDescription(
+                composeTestRule.activity.getString(R.string.back_button_content_description)
+            )
+            .assertHasClickAction()
+    }
+
+    @Test
+    fun controls_meet_minimum_touch_targets() {
+        setContent(state = fourPairsState)
+        val minimumTouchTargetPx = 48 * composeTestRule.activity.resources.displayMetrics.density
+
+        listOf(lowId, mediumId).forEach { optionId ->
+            val bounds = composeTestRule
+                .onNodeWithTag(optionTag(optionId))
+                .assertIsDisplayed()
+                .fetchSemanticsNode()
+                .boundsInRoot
+            assertTrue("${optionId.value} option was too short", bounds.height >= minimumTouchTargetPx)
+            assertTrue("${optionId.value} option was too narrow", bounds.width >= minimumTouchTargetPx)
+        }
+        val playBounds = composeTestRule
+            .onNodeWithTag(GeneratedDifficultySelectorTestTags.PLAY_BUTTON)
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+            .boundsInRoot
+        assertTrue(playBounds.height >= minimumTouchTargetPx)
+        assertTrue(playBounds.width >= minimumTouchTargetPx)
+    }
+
+    @Test
+    fun compact_width_and_increased_text_scale_keep_options_and_primary_action_reachable() {
+        setContent(
+            state = eightPairsState,
+            width = 320.dp,
+            height = 480.dp,
+            fontScale = 2f
+        )
+
+        val screenBounds = composeTestRule
+            .onNodeWithTag(GeneratedDifficultySelectorTestTags.SCREEN)
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val hardBounds = composeTestRule
+            .onNodeWithTag(optionTag(hardId))
+            .performScrollTo()
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val playBounds = composeTestRule
+            .onNodeWithTag(GeneratedDifficultySelectorTestTags.PLAY_BUTTON)
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+            .boundsInRoot
+
+        assertTrue(hardBounds.left >= screenBounds.left)
+        assertTrue(hardBounds.right <= screenBounds.right)
+        assertTrue(playBounds.left >= screenBounds.left)
+        assertTrue(playBounds.right <= screenBounds.right)
+    }
+
+    private fun setContent(
+        state: GeneratedDifficultySelectorUiState,
+        width: Dp? = null,
+        height: Dp? = null,
+        fontScale: Float = 1f
+    ) {
+        setContent(
+            stateProvider = { state },
+            width = width,
+            height = height,
+            fontScale = fontScale
+        )
+    }
+
+    private fun setContent(
+        stateProvider: () -> GeneratedDifficultySelectorUiState,
+        onDifficultySelected: (GeneratedDifficultyOptionId) -> Unit = {},
+        onPlay: (GeneratedDifficultyOptionId) -> Unit = {},
+        onNavigateBack: () -> Unit = {},
+        width: Dp? = null,
+        height: Dp? = null,
+        fontScale: Float = 1f
+    ) {
+        composeTestRule.setContent {
+            val currentDensity = LocalDensity.current
+            CompositionLocalProvider(
+                LocalDensity provides Density(
+                    density = currentDensity.density,
+                    fontScale = fontScale
+                )
+            ) {
+                NumPairsTheme {
+                    if (width != null && height != null) {
+                        Box(modifier = Modifier.size(width = width, height = height)) {
+                            GeneratedDifficultySelectorScreen(
+                                state = stateProvider(),
+                                onDifficultySelected = onDifficultySelected,
+                                onPlay = onPlay,
+                                onNavigateBack = onNavigateBack
+                            )
+                        }
+                    } else {
+                        GeneratedDifficultySelectorScreen(
+                            state = stateProvider(),
+                            onDifficultySelected = onDifficultySelected,
+                            onPlay = onPlay,
+                            onNavigateBack = onNavigateBack
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun optionTag(id: GeneratedDifficultyOptionId): String = GeneratedDifficultySelectorTestTags.option(id)
+
+    private companion object {
+        val lowId = GeneratedDifficultyOptionId("low")
+        val mediumId = GeneratedDifficultyOptionId("medium")
+        val hardId = GeneratedDifficultyOptionId("hard")
+
+        val fourPairsState = GeneratedDifficultySelectorUiState(
+            modeName = "4 pairs",
+            options = listOf(
+                GeneratedDifficultyOptionUiState(lowId, "Low"),
+                GeneratedDifficultyOptionUiState(mediumId, "Medium")
+            ),
+            selectedOptionId = lowId
+        )
+
+        val eightPairsState = GeneratedDifficultySelectorUiState(
+            modeName = "8 pairs",
+            options = listOf(
+                GeneratedDifficultyOptionUiState(mediumId, "Medium"),
+                GeneratedDifficultyOptionUiState(hardId, "Hard")
+            ),
+            selectedOptionId = hardId
+        )
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/selector/ui/GeneratedDifficultySelectorScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/selector/ui/GeneratedDifficultySelectorScreen.kt
@@ -1,0 +1,296 @@
+package org.cescfe.numpairs.feature.generated.selector.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.ui.theme.NumPairsComponents
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.cescfe.numpairs.ui.theme.numPairsSemanticColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GeneratedDifficultySelectorScreen(
+    state: GeneratedDifficultySelectorUiState,
+    onDifficultySelected: (GeneratedDifficultyOptionId) -> Unit,
+    onPlay: (GeneratedDifficultyOptionId) -> Unit,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        modifier = modifier
+            .fillMaxSize()
+            .testTag(GeneratedDifficultySelectorTestTags.SCREEN),
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
+        topBar = {
+            TopAppBar(
+                colors = NumPairsComponents.topAppBarColors(),
+                navigationIcon = {
+                    IconButton(
+                        onClick = onNavigateBack,
+                        modifier = Modifier.testTag(GeneratedDifficultySelectorTestTags.BACK_BUTTON)
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_chevron_left),
+                            contentDescription = stringResource(R.string.back_button_content_description)
+                        )
+                    }
+                },
+                title = {
+                    Text(text = stringResource(R.string.difficulty_selector_screen_title))
+                }
+            )
+        },
+        bottomBar = {
+            DifficultySelectorBottomBar(
+                state = state,
+                onPlay = onPlay
+            )
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 20.dp),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            Column(
+                modifier = Modifier
+                    .widthIn(max = DIFFICULTY_SELECTOR_CONTENT_MAX_WIDTH)
+                    .fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Text(
+                    text = state.modeName,
+                    modifier = Modifier.testTag(GeneratedDifficultySelectorTestTags.MODE_NAME),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = stringResource(R.string.difficulty_selector_supporting_text),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .selectableGroup()
+                        .testTag(GeneratedDifficultySelectorTestTags.OPTION_GROUP),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    state.options.forEach { option ->
+                        DifficultyOption(
+                            option = option,
+                            selected = option.id == state.selectedOptionId,
+                            onClick = { onDifficultySelected(option.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DifficultyOption(option: GeneratedDifficultyOptionUiState, selected: Boolean, onClick: () -> Unit) {
+    val semanticColors = MaterialTheme.numPairsSemanticColors
+    val selectedDescription = stringResource(R.string.difficulty_selector_selected)
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = DIFFICULTY_OPTION_MIN_HEIGHT)
+            .selectable(
+                selected = selected,
+                onClick = onClick,
+                role = Role.RadioButton
+            )
+            .semantics {
+                if (selected) {
+                    stateDescription = selectedDescription
+                }
+            }
+            .testTag(GeneratedDifficultySelectorTestTags.option(option.id)),
+        color = if (selected) {
+            semanticColors.selectionContainer
+        } else {
+            MaterialTheme.colorScheme.surface
+        },
+        contentColor = if (selected) {
+            semanticColors.onSelectionContainer
+        } else {
+            MaterialTheme.colorScheme.onSurface
+        },
+        shape = NumPairsComponents.MediumShape,
+        border = if (selected) {
+            BorderStroke(NumPairsComponents.StrongBorderWidth, semanticColors.selection)
+        } else {
+            NumPairsComponents.subtleBorder()
+        }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                Text(
+                    text = option.label,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                if (selected) {
+                    Text(
+                        text = selectedDescription,
+                        modifier = Modifier.testTag(GeneratedDifficultySelectorTestTags.SELECTED_LABEL),
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+            RadioButton(
+                selected = selected,
+                onClick = null,
+                modifier = Modifier
+                    .size(DIFFICULTY_RADIO_SIZE)
+                    .clearAndSetSemantics {}
+            )
+        }
+    }
+}
+
+@Composable
+private fun DifficultySelectorBottomBar(
+    state: GeneratedDifficultySelectorUiState,
+    onPlay: (GeneratedDifficultyOptionId) -> Unit
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            NumPairsComponents.PrimaryCtaButton(
+                onClick = { onPlay(state.selectedOptionId) },
+                modifier = Modifier
+                    .widthIn(max = DIFFICULTY_SELECTOR_CONTENT_MAX_WIDTH)
+                    .fillMaxWidth()
+                    .testTag(GeneratedDifficultySelectorTestTags.PLAY_BUTTON)
+            ) {
+                Text(
+                    text = stringResource(
+                        R.string.difficulty_selector_play_button,
+                        state.modeName,
+                        state.selectedOption.label
+                    ),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}
+
+@Preview(name = "4 Pairs · Low", showBackground = true)
+@Composable
+private fun FourPairsDifficultySelectorPreview() {
+    NumPairsTheme {
+        GeneratedDifficultySelectorScreen(
+            state = fourPairsPreviewState,
+            onDifficultySelected = {},
+            onPlay = {},
+            onNavigateBack = {}
+        )
+    }
+}
+
+@Preview(name = "8 Pairs · Hard", showBackground = true)
+@Composable
+private fun EightPairsDifficultySelectorPreview() {
+    NumPairsTheme {
+        GeneratedDifficultySelectorScreen(
+            state = eightPairsPreviewState,
+            onDifficultySelected = {},
+            onPlay = {},
+            onNavigateBack = {}
+        )
+    }
+}
+
+object GeneratedDifficultySelectorTestTags {
+    const val SCREEN = "generated_difficulty_selector_screen"
+    const val BACK_BUTTON = "generated_difficulty_selector_back"
+    const val MODE_NAME = "generated_difficulty_selector_mode"
+    const val OPTION_GROUP = "generated_difficulty_selector_options"
+    const val SELECTED_LABEL = "generated_difficulty_selector_selected_label"
+    const val PLAY_BUTTON = "generated_difficulty_selector_play"
+
+    fun option(id: GeneratedDifficultyOptionId): String = "generated_difficulty_option_${id.value}"
+}
+
+private val fourPairsPreviewState = GeneratedDifficultySelectorUiState(
+    modeName = "4 pairs",
+    options = listOf(
+        GeneratedDifficultyOptionUiState(GeneratedDifficultyOptionId("low"), "Low"),
+        GeneratedDifficultyOptionUiState(GeneratedDifficultyOptionId("medium"), "Medium")
+    ),
+    selectedOptionId = GeneratedDifficultyOptionId("low")
+)
+
+private val eightPairsPreviewState = GeneratedDifficultySelectorUiState(
+    modeName = "8 pairs",
+    options = listOf(
+        GeneratedDifficultyOptionUiState(GeneratedDifficultyOptionId("medium"), "Medium"),
+        GeneratedDifficultyOptionUiState(GeneratedDifficultyOptionId("hard"), "Hard")
+    ),
+    selectedOptionId = GeneratedDifficultyOptionId("hard")
+)
+
+private val DIFFICULTY_SELECTOR_CONTENT_MAX_WIDTH = 520.dp
+private val DIFFICULTY_OPTION_MIN_HEIGHT = 72.dp
+private val DIFFICULTY_RADIO_SIZE = 48.dp

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/selector/ui/GeneratedDifficultySelectorUiState.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/selector/ui/GeneratedDifficultySelectorUiState.kt
@@ -1,0 +1,42 @@
+package org.cescfe.numpairs.feature.generated.selector.ui
+
+@JvmInline
+value class GeneratedDifficultyOptionId(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "Generated difficulty option id must not be blank."
+        }
+    }
+}
+
+data class GeneratedDifficultyOptionUiState(val id: GeneratedDifficultyOptionId, val label: String) {
+    init {
+        require(label.isNotBlank()) {
+            "Generated difficulty option label must not be blank."
+        }
+    }
+}
+
+data class GeneratedDifficultySelectorUiState(
+    val modeName: String,
+    val options: List<GeneratedDifficultyOptionUiState>,
+    val selectedOptionId: GeneratedDifficultyOptionId
+) {
+    init {
+        require(modeName.isNotBlank()) {
+            "Generated difficulty selector mode name must not be blank."
+        }
+        require(options.isNotEmpty()) {
+            "Generated difficulty selector must expose at least one option."
+        }
+        require(options.map { option -> option.id }.distinct().size == options.size) {
+            "Generated difficulty selector option ids must be unique."
+        }
+        require(options.any { option -> option.id == selectedOptionId }) {
+            "Selected generated difficulty must be present in the selector options."
+        }
+    }
+
+    val selectedOption: GeneratedDifficultyOptionUiState
+        get() = options.single { option -> option.id == selectedOptionId }
+}

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -14,6 +14,15 @@
     <string name="generated_session_choice_mode_message">Tens un puzle de %1$s sense acabar.</string>
     <string name="generated_session_choice_new_mode_button">Puzle nou de %1$s</string>
 
+    <!-- Difficulty selector -->
+    <string name="difficulty_selector_screen_title">Tria la dificultat</string>
+    <string name="difficulty_selector_supporting_text">Tria el repte que vols jugar. Totes les opcions estan disponibles.</string>
+    <string name="difficulty_selector_selected">Seleccionada</string>
+    <string name="difficulty_selector_play_button">Juga a %1$s · %2$s</string>
+    <string name="generated_difficulty_low">Baixa</string>
+    <string name="generated_difficulty_medium">Mitjana</string>
+    <string name="generated_difficulty_hard">Alta</string>
+
     <!-- Personalization screen -->
     <string name="personalization_screen_title">Personalització</string>
     <string name="personalization_brand_content_description">Logotip de NumPairs</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -14,6 +14,15 @@
     <string name="generated_session_choice_mode_message">Tienes un puzle de %1$s sin terminar.</string>
     <string name="generated_session_choice_new_mode_button">Nuevo puzle de %1$s</string>
 
+    <!-- Difficulty selector -->
+    <string name="difficulty_selector_screen_title">Elige la dificultad</string>
+    <string name="difficulty_selector_supporting_text">Elige el reto que quieres jugar. Todas las opciones están disponibles.</string>
+    <string name="difficulty_selector_selected">Seleccionada</string>
+    <string name="difficulty_selector_play_button">Jugar %1$s · %2$s</string>
+    <string name="generated_difficulty_low">Baja</string>
+    <string name="generated_difficulty_medium">Media</string>
+    <string name="generated_difficulty_hard">Alta</string>
+
     <!-- Personalization screen -->
     <string name="personalization_screen_title">Personalización</string>
     <string name="personalization_brand_content_description">Logotipo de NumPairs</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,15 @@
     <string name="generated_session_choice_mode_message">You have an unfinished %1$s puzzle.</string>
     <string name="generated_session_choice_new_mode_button">New %1$s</string>
 
+    <!-- Difficulty selector -->
+    <string name="difficulty_selector_screen_title">Choose difficulty</string>
+    <string name="difficulty_selector_supporting_text">Choose the challenge you want to play. Every option is available.</string>
+    <string name="difficulty_selector_selected">Selected</string>
+    <string name="difficulty_selector_play_button">Play %1$s · %2$s</string>
+    <string name="generated_difficulty_low">Low</string>
+    <string name="generated_difficulty_medium">Medium</string>
+    <string name="generated_difficulty_hard">Hard</string>
+
     <!-- Personalization screen -->
     <string name="personalization_screen_title">Personalization</string>
     <string name="personalization_brand_content_description">NumPairs logo</string>


### PR DESCRIPTION
## Related Issue

Resolves #498

## Summary

- Add reusable state-driven Compose content for a generated mode difficulty selector.
- Present enabled radio-style options, explicit selected text, and a primary action that names the exact mode and difficulty.
- Emit selection, play, and back events while keeping persistence, navigation, sessions, and generation outside the content.
- Add localized copy, previews for both modes, and Compose coverage for the sparse matrices, events, accessibility, touch targets, compact width, and increased text scale.

## UI Consistency

- Shared components or tokens reused: NumPairs top-app-bar colors, primary CTA, medium shape, semantic selection colors, border widths, typography, surface hierarchy, and 4dp spacing rhythm.
- Intentional deviations from established visual roles: None.