### PR TITLE
[247] Persist explicit first-run tutorial outcomes

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
@@ -17,6 +17,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.cescfe.numpairs.data.generated.selection.FakeGeneratedDifficultySelectionRepository
 import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
 import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
+import org.cescfe.numpairs.data.onboarding.FirstRunTutorialOutcome
 import org.cescfe.numpairs.data.onboarding.OnboardingPostCorePath
 import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
 import org.cescfe.numpairs.data.onboarding.OnboardingState
@@ -53,7 +54,8 @@ class AppNavigationLearningFlowTest {
             isInitialized = true,
             completedVersion = REQUIRED_ONBOARDING_VERSION,
             lastCompletedStage = OnboardingStageCheckpoint.STAGE_THREE,
-            postCorePath = OnboardingPostCorePath.CONTINUE_GUIDED
+            postCorePath = OnboardingPostCorePath.CONTINUE_GUIDED,
+            firstRunTutorialOutcome = FirstRunTutorialOutcome.COMPLETED
         )
         val onboardingRepository = FakeOnboardingRepository(initialState = completedState)
         setContent(

--- a/app/src/androidTest/java/org/cescfe/numpairs/data/onboarding/FakeOnboardingRepository.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/data/onboarding/FakeOnboardingRepository.kt
@@ -16,6 +16,11 @@ class FakeOnboardingRepository(initialState: OnboardingState = completedOnboardi
                 REQUIRED_ONBOARDING_VERSION
             } else {
                 0
+            },
+            firstRunTutorialOutcome = if (installationKind == OnboardingInstallationKind.PRE_V6_UPGRADE) {
+                FirstRunTutorialOutcome.PRE_V6_UPGRADE
+            } else {
+                FirstRunTutorialOutcome.UNRESOLVED
             }
         )
     }
@@ -28,14 +33,28 @@ class FakeOnboardingRepository(initialState: OnboardingState = completedOnboardi
         onboardingState.value = onboardingState.value.copy(postCorePath = path)
     }
 
-    override suspend fun markRequiredVersionCompleted() {
-        onboardingState.value = onboardingState.value.copy(completedVersion = REQUIRED_ONBOARDING_VERSION)
+    override suspend fun markTutorialCompleted() {
+        resolveFirstRun(outcome = FirstRunTutorialOutcome.COMPLETED)
+    }
+
+    override suspend fun markTutorialSkipped() {
+        resolveFirstRun(outcome = FirstRunTutorialOutcome.SKIPPED)
+    }
+
+    private fun resolveFirstRun(outcome: FirstRunTutorialOutcome) {
+        if (!onboardingState.value.isRequiredVersionComplete()) {
+            onboardingState.value = onboardingState.value.copy(
+                completedVersion = REQUIRED_ONBOARDING_VERSION,
+                firstRunTutorialOutcome = outcome
+            )
+        }
     }
 }
 
 fun completedOnboardingState(): OnboardingState = OnboardingState(
     isInitialized = true,
-    completedVersion = REQUIRED_ONBOARDING_VERSION
+    completedVersion = REQUIRED_ONBOARDING_VERSION,
+    firstRunTutorialOutcome = FirstRunTutorialOutcome.LEGACY_COMPLETED
 )
 
 fun incompleteOnboardingState(

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepository.kt
@@ -21,14 +21,19 @@ class DataStoreOnboardingRepository(private val dataStore: DataStore<Preferences
             }
         }
         .map { preferences ->
+            val completedVersion = preferences[PreferenceKeys.COMPLETED_VERSION] ?: 0
             OnboardingState(
                 isInitialized = preferences[PreferenceKeys.IS_INITIALIZED] ?: false,
-                completedVersion = preferences[PreferenceKeys.COMPLETED_VERSION] ?: 0,
+                completedVersion = completedVersion,
                 lastCompletedStage = OnboardingStageCheckpoint.fromPersistedValue(
                     preferences[PreferenceKeys.LAST_COMPLETED_STAGE] ?: 0
                 ),
                 postCorePath = OnboardingPostCorePath.fromPersistedValue(
                     preferences[PreferenceKeys.POST_CORE_PATH] ?: 0
+                ),
+                firstRunTutorialOutcome = FirstRunTutorialOutcome.fromPersistedValue(
+                    value = preferences[PreferenceKeys.FIRST_RUN_TUTORIAL_OUTCOME],
+                    completedVersion = completedVersion
                 )
             )
         }
@@ -40,9 +45,17 @@ class DataStoreOnboardingRepository(private val dataStore: DataStore<Preferences
             }
 
             preferences[PreferenceKeys.IS_INITIALIZED] = true
-            preferences[PreferenceKeys.COMPLETED_VERSION] = when (installationKind) {
-                OnboardingInstallationKind.FRESH_INSTALL -> 0
-                OnboardingInstallationKind.PRE_V6_UPGRADE -> REQUIRED_ONBOARDING_VERSION
+            when (installationKind) {
+                OnboardingInstallationKind.FRESH_INSTALL -> {
+                    preferences[PreferenceKeys.COMPLETED_VERSION] = 0
+                    preferences[PreferenceKeys.FIRST_RUN_TUTORIAL_OUTCOME] =
+                        FirstRunTutorialOutcome.UNRESOLVED.persistedValue
+                }
+                OnboardingInstallationKind.PRE_V6_UPGRADE -> {
+                    preferences[PreferenceKeys.COMPLETED_VERSION] = REQUIRED_ONBOARDING_VERSION
+                    preferences[PreferenceKeys.FIRST_RUN_TUTORIAL_OUTCOME] =
+                        FirstRunTutorialOutcome.PRE_V6_UPGRADE.persistedValue
+                }
             }
             preferences[PreferenceKeys.LAST_COMPLETED_STAGE] = OnboardingStageCheckpoint.NONE.persistedValue
             preferences[PreferenceKeys.POST_CORE_PATH] = OnboardingPostCorePath.UNDECIDED.persistedValue
@@ -75,10 +88,25 @@ class DataStoreOnboardingRepository(private val dataStore: DataStore<Preferences
         }
     }
 
-    override suspend fun markRequiredVersionCompleted() {
+    override suspend fun markTutorialCompleted() {
+        resolveFirstRun(outcome = FirstRunTutorialOutcome.COMPLETED)
+    }
+
+    override suspend fun markTutorialSkipped() {
+        resolveFirstRun(outcome = FirstRunTutorialOutcome.SKIPPED)
+    }
+
+    private suspend fun resolveFirstRun(outcome: FirstRunTutorialOutcome) {
+        require(outcome == FirstRunTutorialOutcome.COMPLETED || outcome == FirstRunTutorialOutcome.SKIPPED) {
+            "First-run Tutorial can be resolved only by completion or explicit skip."
+        }
+
         dataStore.edit { preferences ->
             val currentVersion = preferences[PreferenceKeys.COMPLETED_VERSION] ?: 0
-            preferences[PreferenceKeys.COMPLETED_VERSION] = maxOf(currentVersion, REQUIRED_ONBOARDING_VERSION)
+            if (currentVersion < REQUIRED_ONBOARDING_VERSION) {
+                preferences[PreferenceKeys.COMPLETED_VERSION] = REQUIRED_ONBOARDING_VERSION
+                preferences[PreferenceKeys.FIRST_RUN_TUTORIAL_OUTCOME] = outcome.persistedValue
+            }
         }
     }
 
@@ -87,5 +115,6 @@ class DataStoreOnboardingRepository(private val dataStore: DataStore<Preferences
         val COMPLETED_VERSION = intPreferencesKey("onboarding_completed_version")
         val LAST_COMPLETED_STAGE = intPreferencesKey("onboarding_last_completed_stage")
         val POST_CORE_PATH = intPreferencesKey("onboarding_post_core_path")
+        val FIRST_RUN_TUTORIAL_OUTCOME = intPreferencesKey("onboarding_first_run_tutorial_outcome")
     }
 }

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingRepository.kt
@@ -11,7 +11,9 @@ interface OnboardingRepository {
 
     suspend fun selectPostCorePath(path: OnboardingPostCorePath)
 
-    suspend fun markRequiredVersionCompleted()
+    suspend fun markTutorialCompleted()
+
+    suspend fun markTutorialSkipped()
 }
 
 enum class OnboardingInstallationKind {

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingState.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingState.kt
@@ -6,9 +6,33 @@ data class OnboardingState(
     val isInitialized: Boolean = false,
     val completedVersion: Int = 0,
     val lastCompletedStage: OnboardingStageCheckpoint = OnboardingStageCheckpoint.NONE,
-    val postCorePath: OnboardingPostCorePath = OnboardingPostCorePath.UNDECIDED
+    val postCorePath: OnboardingPostCorePath = OnboardingPostCorePath.UNDECIDED,
+    val firstRunTutorialOutcome: FirstRunTutorialOutcome = FirstRunTutorialOutcome.UNRESOLVED
 ) {
     fun isRequiredVersionComplete(): Boolean = completedVersion >= REQUIRED_ONBOARDING_VERSION
+}
+
+enum class FirstRunTutorialOutcome(internal val persistedValue: Int) {
+    UNRESOLVED(0),
+    COMPLETED(1),
+    SKIPPED(2),
+    PRE_V6_UPGRADE(3),
+    LEGACY_COMPLETED(4);
+
+    val isResolved: Boolean
+        get() = this != UNRESOLVED
+
+    internal companion object {
+        fun fromPersistedValue(value: Int?, completedVersion: Int): FirstRunTutorialOutcome {
+            val persistedOutcome = entries.firstOrNull { outcome -> outcome.persistedValue == value }
+
+            return when {
+                completedVersion < REQUIRED_ONBOARDING_VERSION -> UNRESOLVED
+                persistedOutcome == null || persistedOutcome == UNRESOLVED -> LEGACY_COMPLETED
+                else -> persistedOutcome
+            }
+        }
+    }
 }
 
 enum class OnboardingPostCorePath(internal val persistedValue: Int) {

--- a/app/src/main/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRoute.kt
@@ -36,7 +36,7 @@ fun RequiredOnboardingRoute(
             },
             onIntroductionCompleted = {
                 coroutineScope.launch {
-                    onboardingRepository.markRequiredVersionCompleted()
+                    onboardingRepository.markTutorialCompleted()
                 }
             }
         )
@@ -57,7 +57,7 @@ fun RequiredOnboardingRoute(
             modifier = modifier,
             onValidationSolved = {
                 coroutineScope.launch {
-                    onboardingRepository.markRequiredVersionCompleted()
+                    onboardingRepository.markTutorialCompleted()
                 }
             },
             onNavigateBack = {},

--- a/app/src/test/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepositoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepositoryTest.kt
@@ -1,6 +1,11 @@
 package org.cescfe.numpairs.data.onboarding
 
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import java.io.File
 import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
@@ -46,6 +51,7 @@ class DataStoreOnboardingRepositoryTest {
         assertTrue(state.isInitialized)
         assertFalse(state.isRequiredVersionComplete())
         assertEquals(OnboardingStageCheckpoint.NONE, state.lastCompletedStage)
+        assertEquals(FirstRunTutorialOutcome.UNRESOLVED, state.firstRunTutorialOutcome)
     }
 
     @Test
@@ -58,6 +64,7 @@ class DataStoreOnboardingRepositoryTest {
         assertTrue(state.isInitialized)
         assertTrue(state.isRequiredVersionComplete())
         assertEquals(REQUIRED_ONBOARDING_VERSION, state.completedVersion)
+        assertEquals(FirstRunTutorialOutcome.PRE_V6_UPGRADE, state.firstRunTutorialOutcome)
     }
 
     @Test
@@ -71,6 +78,7 @@ class DataStoreOnboardingRepositoryTest {
         val state = fixture.repository.onboardingState.first()
         assertFalse(state.isRequiredVersionComplete())
         assertEquals(OnboardingStageCheckpoint.STAGE_TWO, state.lastCompletedStage)
+        assertEquals(FirstRunTutorialOutcome.UNRESOLVED, state.firstRunTutorialOutcome)
     }
 
     @Test
@@ -93,17 +101,74 @@ class DataStoreOnboardingRepositoryTest {
     }
 
     @Test
-    fun `final completion is versioned and independent from stage checkpoint`() = runBlocking {
+    fun `tutorial completion is versioned and independent from stage checkpoint`() = runBlocking {
         val fixture = createRepository()
         fixture.repository.initialize(OnboardingInstallationKind.FRESH_INSTALL)
         fixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_TWO)
 
-        fixture.repository.markRequiredVersionCompleted()
+        fixture.repository.markTutorialCompleted()
 
         val state = fixture.repository.onboardingState.first()
         assertTrue(state.isRequiredVersionComplete())
         assertEquals(REQUIRED_ONBOARDING_VERSION, state.completedVersion)
         assertEquals(OnboardingStageCheckpoint.STAGE_TWO, state.lastCompletedStage)
+        assertEquals(FirstRunTutorialOutcome.COMPLETED, state.firstRunTutorialOutcome)
+    }
+
+    @Test
+    fun `explicit skip resolves the version with a distinct outcome`() = runBlocking {
+        val fixture = createRepository()
+        fixture.repository.initialize(OnboardingInstallationKind.FRESH_INSTALL)
+
+        fixture.repository.markTutorialSkipped()
+
+        val state = fixture.repository.onboardingState.first()
+        assertTrue(state.isRequiredVersionComplete())
+        assertEquals(REQUIRED_ONBOARDING_VERSION, state.completedVersion)
+        assertEquals(FirstRunTutorialOutcome.SKIPPED, state.firstRunTutorialOutcome)
+    }
+
+    @Test
+    fun `resolved first-run outcome cannot be overwritten`() = runBlocking {
+        val fixture = createRepository()
+        fixture.repository.initialize(OnboardingInstallationKind.FRESH_INSTALL)
+        fixture.repository.markTutorialSkipped()
+
+        fixture.repository.markTutorialCompleted()
+
+        assertEquals(
+            FirstRunTutorialOutcome.SKIPPED,
+            fixture.repository.onboardingState.first().firstRunTutorialOutcome
+        )
+    }
+
+    @Test
+    fun `completed state without an outcome is recognized as legacy completion`() = runBlocking {
+        val fixture = createRepository()
+        fixture.dataStore.edit { preferences ->
+            preferences[booleanPreferencesKey("onboarding_is_initialized")] = true
+            preferences[intPreferencesKey("onboarding_completed_version")] = REQUIRED_ONBOARDING_VERSION
+        }
+
+        val state = fixture.repository.onboardingState.first()
+
+        assertTrue(state.isRequiredVersionComplete())
+        assertEquals(FirstRunTutorialOutcome.LEGACY_COMPLETED, state.firstRunTutorialOutcome)
+    }
+
+    @Test
+    fun `unknown persisted outcome falls back safely`() = runBlocking {
+        val fixture = createRepository()
+        fixture.dataStore.edit { preferences ->
+            preferences[booleanPreferencesKey("onboarding_is_initialized")] = true
+            preferences[intPreferencesKey("onboarding_completed_version")] = REQUIRED_ONBOARDING_VERSION
+            preferences[intPreferencesKey("onboarding_first_run_tutorial_outcome")] = Int.MAX_VALUE
+        }
+
+        val state = fixture.repository.onboardingState.first()
+
+        assertTrue(state.isRequiredVersionComplete())
+        assertEquals(FirstRunTutorialOutcome.LEGACY_COMPLETED, state.firstRunTutorialOutcome)
     }
 
     @Test
@@ -131,14 +196,14 @@ class DataStoreOnboardingRepositoryTest {
         val firstFixture = createRepository(dataStoreFile)
         firstFixture.repository.initialize(OnboardingInstallationKind.FRESH_INSTALL)
         firstFixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_THREE)
+        firstFixture.repository.markTutorialCompleted()
         firstFixture.close()
 
         val secondFixture = createRepository(dataStoreFile)
+        val restoredState = secondFixture.repository.onboardingState.first()
 
-        assertEquals(
-            OnboardingStageCheckpoint.STAGE_THREE,
-            secondFixture.repository.onboardingState.first().lastCompletedStage
-        )
+        assertEquals(OnboardingStageCheckpoint.STAGE_THREE, restoredState.lastCompletedStage)
+        assertEquals(FirstRunTutorialOutcome.COMPLETED, restoredState.firstRunTutorialOutcome)
     }
 
     private fun createRepository(dataStoreFile: File = createDataStoreFile()): RepositoryFixture {
@@ -151,6 +216,7 @@ class DataStoreOnboardingRepositoryTest {
 
         return RepositoryFixture(
             repository = DataStoreOnboardingRepository(dataStore),
+            dataStore = dataStore,
             job = job
         )
     }
@@ -160,7 +226,11 @@ class DataStoreOnboardingRepositoryTest {
         "${UUID.randomUUID()}.preferences_pb"
     )
 
-    private data class RepositoryFixture(val repository: OnboardingRepository, private val job: Job) {
+    private data class RepositoryFixture(
+        val repository: OnboardingRepository,
+        val dataStore: DataStore<Preferences>,
+        private val job: Job
+    ) {
         suspend fun close() {
             job.cancelAndJoin()
         }

--- a/app/src/test/java/org/cescfe/numpairs/data/onboarding/OnboardingInitializerTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/onboarding/OnboardingInitializerTest.kt
@@ -18,6 +18,10 @@ class OnboardingInitializerTest {
 
         assertEquals(OnboardingInstallationKind.FRESH_INSTALL, repository.initializationKind)
         assertFalse(repository.onboardingState.first().isRequiredVersionComplete())
+        assertEquals(
+            FirstRunTutorialOutcome.UNRESOLVED,
+            repository.onboardingState.first().firstRunTutorialOutcome
+        )
         assertFalse(marker.wasCleared)
     }
 
@@ -30,6 +34,10 @@ class OnboardingInitializerTest {
 
         assertEquals(OnboardingInstallationKind.PRE_V6_UPGRADE, repository.initializationKind)
         assertTrue(repository.onboardingState.first().isRequiredVersionComplete())
+        assertEquals(
+            FirstRunTutorialOutcome.PRE_V6_UPGRADE,
+            repository.onboardingState.first().firstRunTutorialOutcome
+        )
         assertTrue(marker.wasCleared)
     }
 
@@ -58,6 +66,11 @@ class OnboardingInitializerTest {
                     REQUIRED_ONBOARDING_VERSION
                 } else {
                     0
+                },
+                firstRunTutorialOutcome = if (installationKind == OnboardingInstallationKind.PRE_V6_UPGRADE) {
+                    FirstRunTutorialOutcome.PRE_V6_UPGRADE
+                } else {
+                    FirstRunTutorialOutcome.UNRESOLVED
                 }
             )
         }
@@ -66,7 +79,9 @@ class OnboardingInitializerTest {
 
         override suspend fun selectPostCorePath(path: OnboardingPostCorePath) = Unit
 
-        override suspend fun markRequiredVersionCompleted() = Unit
+        override suspend fun markTutorialCompleted() = Unit
+
+        override suspend fun markTutorialSkipped() = Unit
     }
 
     private class FakePreV6UpgradeMarker(isMarked: Boolean) : PreV6UpgradeMarker {


### PR DESCRIPTION
## Related Issue

Resolves #515

## Summary

- Persist explicit completed and skipped outcomes for the first-run Tutorial.
- Preserve safe routing for fresh installs, pre-v6 upgrades, and completed legacy state.
- Keep stage checkpoints independent and monotonic while preventing resolved outcomes from being overwritten.
- Add deterministic DataStore, initialization, persistence, and voluntary-replay coverage.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`