### PR TITLE
[250] Resolve first-run startup without indefinite loading

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
@@ -30,6 +30,8 @@ class LocalizationResourceTest {
         assertEquals("Saltar tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
         assertEquals("Continuar tutorial", resources.getString(R.string.onboarding_continue_tutorial_button))
         assertEquals("Saltar igualmente", resources.getString(R.string.onboarding_skip_anyway_button))
+        assertEquals("No se puede abrir NumPairs", resources.getString(R.string.onboarding_startup_failure_title))
+        assertEquals("Reintentar", resources.getString(R.string.onboarding_startup_retry_button))
     }
 
     @Test
@@ -51,6 +53,8 @@ class LocalizationResourceTest {
         assertEquals("Omet el tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
         assertEquals("Continua el tutorial", resources.getString(R.string.onboarding_continue_tutorial_button))
         assertEquals("Omet-lo igualment", resources.getString(R.string.onboarding_skip_anyway_button))
+        assertEquals("No es pot obrir NumPairs", resources.getString(R.string.onboarding_startup_failure_title))
+        assertEquals("Torna-ho a provar", resources.getString(R.string.onboarding_startup_retry_button))
     }
 
     @Test
@@ -72,6 +76,8 @@ class LocalizationResourceTest {
         assertEquals("Skip tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
         assertEquals("Continue tutorial", resources.getString(R.string.onboarding_continue_tutorial_button))
         assertEquals("Skip anyway", resources.getString(R.string.onboarding_skip_anyway_button))
+        assertEquals("Unable to open NumPairs", resources.getString(R.string.onboarding_startup_failure_title))
+        assertEquals("Retry", resources.getString(R.string.onboarding_startup_retry_button))
     }
 
     private fun resourcesFor(languageTag: String): Resources {

--- a/app/src/androidTest/java/org/cescfe/numpairs/OnboardingStartupFailureScreenTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/OnboardingStartupFailureScreenTest.kt
@@ -1,0 +1,68 @@
+package org.cescfe.numpairs
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.cescfe.numpairs.feature.onboarding.ONBOARDING_STARTUP_FAILURE_SCREEN_TEST_TAG
+import org.cescfe.numpairs.feature.onboarding.ONBOARDING_STARTUP_RETRY_BUTTON_TEST_TAG
+import org.cescfe.numpairs.feature.onboarding.OnboardingStartupFailureScreen
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class OnboardingStartupFailureScreenTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun storageFailureOffersAnExplicitRetry() {
+        var retryRequested = false
+        setContent(isRetrying = false) {
+            retryRequested = true
+        }
+
+        composeTestRule
+            .onNodeWithTag(ONBOARDING_STARTUP_FAILURE_SCREEN_TEST_TAG)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(string(R.string.onboarding_startup_failure_title))
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(string(R.string.onboarding_startup_failure_message))
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(ONBOARDING_STARTUP_RETRY_BUTTON_TEST_TAG)
+            .assertIsEnabled()
+            .performClick()
+
+        assertTrue(retryRequested)
+    }
+
+    @Test
+    fun retryActionIsDisabledWhileARequestIsInProgress() {
+        setContent(isRetrying = true)
+
+        composeTestRule
+            .onNodeWithTag(ONBOARDING_STARTUP_RETRY_BUTTON_TEST_TAG)
+            .assertIsNotEnabled()
+    }
+
+    private fun setContent(isRetrying: Boolean, onRetry: () -> Unit = {}) {
+        composeTestRule.setContent {
+            NumPairsTheme {
+                OnboardingStartupFailureScreen(
+                    isRetrying = isRetrying,
+                    onRetry = onRetry
+                )
+            }
+        }
+    }
+
+    private fun string(stringResId: Int): String = composeTestRule.activity.getString(stringResId)
+}

--- a/app/src/main/java/org/cescfe/numpairs/MainActivity.kt
+++ b/app/src/main/java/org/cescfe/numpairs/MainActivity.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.graphics.luminance
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.launch
 import org.cescfe.numpairs.data.generated.selection.createGeneratedDifficultySelectionRepository
 import org.cescfe.numpairs.data.generated.session.createGeneratedSessionRepository
 import org.cescfe.numpairs.data.onboarding.createOnboardingRuntime
@@ -23,15 +22,26 @@ import org.cescfe.numpairs.data.preferences.createPersonalizationPreferencesRepo
 import org.cescfe.numpairs.data.preferences.createTopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.feature.generated.ConfiguredGeneratedPuzzleGenerationUseCaseFactory
 import org.cescfe.numpairs.feature.generated.GeneratedModes
-import org.cescfe.numpairs.ui.navigation.AppNavigation
+import org.cescfe.numpairs.feature.onboarding.OnboardingStartupCoordinator
+import org.cescfe.numpairs.feature.onboarding.OnboardingStartupFailureScreen
+import org.cescfe.numpairs.feature.onboarding.OnboardingStartupState
+import org.cescfe.numpairs.ui.navigation.InitializedAppNavigation
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
-        installSplashScreen()
+        val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         val onboardingRuntime = createOnboardingRuntime(applicationContext)
+        val onboardingStartupCoordinator = OnboardingStartupCoordinator(
+            initializer = onboardingRuntime.initializer,
+            repository = onboardingRuntime.repository,
+            coroutineScope = lifecycleScope
+        )
+        splashScreen.setKeepOnScreenCondition {
+            onboardingStartupCoordinator.state.value is OnboardingStartupState.Loading
+        }
         val generatedSessionRepository = createGeneratedSessionRepository(applicationContext)
         val generatedDifficultySelectionRepository = createGeneratedDifficultySelectionRepository(applicationContext)
         val personalizationPreferencesRepository = createPersonalizationPreferencesRepository(applicationContext)
@@ -40,12 +50,9 @@ class MainActivity : ComponentActivity() {
         val generatedPuzzleGenerationUseCaseFactory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
             challengeCatalog = generatedChallengeCatalog
         )
-        lifecycleScope.launch {
-            onboardingRuntime.initializer.initialize()
-        }
-
         setContent {
             PersonalizationThemeProvider(personalizationPreferencesRepository) {
+                val onboardingStartupState by onboardingStartupCoordinator.state.collectAsState()
                 val useDarkSystemBarIcons = MaterialTheme.colorScheme.background.luminance() > 0.5f
                 SideEffect {
                     WindowCompat.getInsetsController(window, window.decorView).apply {
@@ -53,15 +60,23 @@ class MainActivity : ComponentActivity() {
                         isAppearanceLightNavigationBars = useDarkSystemBarIcons
                     }
                 }
-                AppNavigation(
-                    onboardingRepository = onboardingRuntime.repository,
-                    generatedSessionRepository = generatedSessionRepository,
-                    generatedDifficultySelectionRepository = generatedDifficultySelectionRepository,
-                    personalizationPreferencesRepository = personalizationPreferencesRepository,
-                    topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
-                    generatedChallengeCatalog = generatedChallengeCatalog,
-                    generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory
-                )
+                when (val state = onboardingStartupState) {
+                    OnboardingStartupState.Loading -> Unit
+                    is OnboardingStartupState.Failure -> OnboardingStartupFailureScreen(
+                        isRetrying = state.isRetrying,
+                        onRetry = onboardingStartupCoordinator::retry
+                    )
+                    is OnboardingStartupState.Ready -> InitializedAppNavigation(
+                        onboardingState = state.onboardingState,
+                        onboardingRepository = onboardingRuntime.repository,
+                        generatedSessionRepository = generatedSessionRepository,
+                        generatedDifficultySelectionRepository = generatedDifficultySelectionRepository,
+                        personalizationPreferencesRepository = personalizationPreferencesRepository,
+                        topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
+                        generatedChallengeCatalog = generatedChallengeCatalog,
+                        generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepository.kt
@@ -4,22 +4,12 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
-import java.io.IOException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 
 class DataStoreOnboardingRepository(private val dataStore: DataStore<Preferences>) : OnboardingRepository {
     override val onboardingState: Flow<OnboardingState> = dataStore.data
-        .catch { throwable ->
-            if (throwable is IOException) {
-                emit(emptyPreferences())
-            } else {
-                throw throwable
-            }
-        }
         .map { preferences ->
             val completedVersion = preferences[PreferenceKeys.COMPLETED_VERSION] ?: 0
             OnboardingState(

--- a/app/src/main/java/org/cescfe/numpairs/feature/onboarding/OnboardingStartupCoordinator.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/onboarding/OnboardingStartupCoordinator.kt
@@ -1,0 +1,77 @@
+package org.cescfe.numpairs.feature.onboarding
+
+import java.io.IOException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.launch
+import org.cescfe.numpairs.data.onboarding.OnboardingInitializer
+import org.cescfe.numpairs.data.onboarding.OnboardingRepository
+import org.cescfe.numpairs.data.onboarding.OnboardingState
+
+internal sealed interface OnboardingStartupState {
+    data object Loading : OnboardingStartupState
+
+    data class Ready(val onboardingState: OnboardingState) : OnboardingStartupState
+
+    data class Failure(val cause: Throwable, val isRetrying: Boolean = false) : OnboardingStartupState
+}
+
+internal class OnboardingStartupCoordinator(
+    private val initializer: OnboardingInitializer,
+    private val repository: OnboardingRepository,
+    private val coroutineScope: CoroutineScope
+) {
+    private val mutableState = MutableStateFlow<OnboardingStartupState>(OnboardingStartupState.Loading)
+    private var startupJob: Job? = null
+
+    val state = mutableState.asStateFlow()
+
+    init {
+        start()
+    }
+
+    fun retry() {
+        val failure = state.value as? OnboardingStartupState.Failure ?: return
+        mutableState.value = failure.copy(isRetrying = true)
+        start()
+    }
+
+    private fun start() {
+        startupJob?.cancel()
+        startupJob = coroutineScope.launch {
+            onboardingStartupStates(
+                initializer = initializer,
+                repository = repository
+            ).collect(mutableState::emit)
+        }
+    }
+}
+
+internal fun onboardingStartupStates(
+    initializer: OnboardingInitializer,
+    repository: OnboardingRepository
+): Flow<OnboardingStartupState> = flow<OnboardingStartupState> {
+    initializer.initialize()
+    emitAll(
+        repository.onboardingState.map { onboardingState ->
+            check(onboardingState.isInitialized) {
+                "Onboarding initialization completed without publishing initialized state."
+            }
+            OnboardingStartupState.Ready(onboardingState)
+        }
+    )
+}.retryWhen { cause, attempt ->
+    cause is IOException && attempt < AUTOMATIC_STARTUP_RETRY_COUNT
+}.catch { cause ->
+    emit(OnboardingStartupState.Failure(cause))
+}
+
+private const val AUTOMATIC_STARTUP_RETRY_COUNT = 2L

--- a/app/src/main/java/org/cescfe/numpairs/feature/onboarding/OnboardingStartupFailureScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/onboarding/OnboardingStartupFailureScreen.kt
@@ -1,0 +1,60 @@
+package org.cescfe.numpairs.feature.onboarding
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.ui.theme.NumPairsComponents
+
+@Composable
+internal fun OnboardingStartupFailureScreen(isRetrying: Boolean, onRetry: () -> Unit, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(24.dp)
+            .testTag(ONBOARDING_STARTUP_FAILURE_SCREEN_TEST_TAG),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = stringResource(R.string.onboarding_startup_failure_title),
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.headlineSmall
+        )
+        Text(
+            text = stringResource(R.string.onboarding_startup_failure_message),
+            modifier = Modifier.padding(top = 12.dp),
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge
+        )
+        NumPairsComponents.PrimaryCtaButton(
+            onClick = onRetry,
+            modifier = Modifier
+                .padding(top = 24.dp)
+                .testTag(ONBOARDING_STARTUP_RETRY_BUTTON_TEST_TAG),
+            enabled = !isRetrying
+        ) {
+            Text(
+                text = stringResource(R.string.onboarding_startup_retry_button),
+                style = MaterialTheme.typography.labelLarge
+            )
+        }
+    }
+}
+
+internal const val ONBOARDING_STARTUP_FAILURE_SCREEN_TEST_TAG = "onboarding_startup_failure_screen"
+internal const val ONBOARDING_STARTUP_RETRY_BUTTON_TEST_TAG = "onboarding_startup_retry_button"

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -57,14 +57,49 @@ fun AppNavigation(
 ) {
     val onboardingState by onboardingRepository.onboardingState.collectAsState(initial = OnboardingState())
 
-    when {
-        !onboardingState.isInitialized -> OnboardingLoadingScreen(modifier = modifier)
-        !onboardingState.isRequiredVersionComplete() -> RequiredOnboardingRoute(
+    if (!onboardingState.isInitialized) {
+        OnboardingLoadingScreen(modifier = modifier)
+    } else {
+        InitializedAppNavigation(
+            onboardingState = onboardingState,
+            onboardingRepository = onboardingRepository,
+            generatedSessionRepository = generatedSessionRepository,
+            generatedDifficultySelectionRepository = generatedDifficultySelectionRepository,
+            personalizationPreferencesRepository = personalizationPreferencesRepository,
+            topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
+            generatedChallengeCatalog = generatedChallengeCatalog,
+            generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory,
+            modifier = modifier,
+            startDestination = startDestination
+        )
+    }
+}
+
+@Composable
+internal fun InitializedAppNavigation(
+    onboardingState: OnboardingState,
+    onboardingRepository: OnboardingRepository,
+    generatedSessionRepository: GeneratedSessionRepository,
+    generatedDifficultySelectionRepository: GeneratedDifficultySelectionRepository,
+    personalizationPreferencesRepository: PersonalizationPreferencesRepository,
+    topAppBarActionDiscoveryRepository: TopAppBarActionDiscoveryRepository,
+    generatedChallengeCatalog: GeneratedChallengeCatalog,
+    generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory,
+    modifier: Modifier = Modifier,
+    startDestination: AppDestination = AppDestination.Menu
+) {
+    require(onboardingState.isInitialized) {
+        "Initialized app navigation requires initialized onboarding state."
+    }
+
+    if (!onboardingState.isRequiredVersionComplete()) {
+        RequiredOnboardingRoute(
             onboardingState = onboardingState,
             onboardingRepository = onboardingRepository,
             modifier = modifier
         )
-        else -> UnlockedAppNavigation(
+    } else {
+        UnlockedAppNavigation(
             generatedSessionRepository = generatedSessionRepository,
             generatedDifficultySelectionRepository = generatedDifficultySelectionRepository,
             personalizationPreferencesRepository = personalizationPreferencesRepository,

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -52,6 +52,9 @@
     <string name="generated_puzzle_failure_title">Puzle no disponible</string>
     <string name="generated_puzzle_failure_message">No s’ha pogut crear un puzle. Torna-ho a provar.</string>
     <string name="generated_puzzle_retry_button">Torna-ho a provar</string>
+    <string name="onboarding_startup_failure_title">No es pot obrir NumPairs</string>
+    <string name="onboarding_startup_failure_message">No s’ha pogut carregar el teu progrés local. Torna-ho a provar.</string>
+    <string name="onboarding_startup_retry_button">Torna-ho a provar</string>
     <string name="generated_puzzle_back_to_menu_button">Torna al menú</string>
     <string name="generated_session_resume_unavailable_message">Aquest puzle sense acabar ja no està disponible.</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -52,6 +52,9 @@
     <string name="generated_puzzle_failure_title">Puzle no disponible</string>
     <string name="generated_puzzle_failure_message">No se ha podido crear un puzle. Inténtalo de nuevo.</string>
     <string name="generated_puzzle_retry_button">Reintentar</string>
+    <string name="onboarding_startup_failure_title">No se puede abrir NumPairs</string>
+    <string name="onboarding_startup_failure_message">No se ha podido cargar tu progreso local. Inténtalo de nuevo.</string>
+    <string name="onboarding_startup_retry_button">Reintentar</string>
     <string name="generated_puzzle_back_to_menu_button">Volver al menú</string>
     <string name="generated_session_resume_unavailable_message">Este puzle sin terminar ya no está disponible.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,9 @@
     <string name="generated_puzzle_failure_title">Puzzle unavailable</string>
     <string name="generated_puzzle_failure_message">We could not create a puzzle. Please try again.</string>
     <string name="generated_puzzle_retry_button">Retry</string>
+    <string name="onboarding_startup_failure_title">Unable to open NumPairs</string>
+    <string name="onboarding_startup_failure_message">We couldn’t load your local progress. Please try again.</string>
+    <string name="onboarding_startup_retry_button">Retry</string>
     <string name="generated_puzzle_back_to_menu_button">Back to menu</string>
     <string name="generated_session_resume_unavailable_message">This unfinished puzzle is no longer available.</string>
 

--- a/app/src/test/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepositoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepositoryTest.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import java.io.File
+import java.io.IOException
 import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -14,10 +15,13 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -39,6 +43,25 @@ class DataStoreOnboardingRepositoryTest {
         val fixture = createRepository()
 
         assertEquals(OnboardingState(), fixture.repository.onboardingState.first())
+    }
+
+    @Test
+    fun `read failures remain observable for startup recovery`() {
+        val expectedFailure = IOException("Synthetic onboarding read failure.")
+        val repository = DataStoreOnboardingRepository(
+            object : DataStore<Preferences> {
+                override val data = flow<Preferences> { throw expectedFailure }
+
+                override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+                    error("No update is expected while testing a read failure.")
+            }
+        )
+
+        val actualFailure = assertThrows(IOException::class.java) {
+            runBlocking { repository.onboardingState.first() }
+        }
+
+        assertSame(expectedFailure, actualFailure)
     }
 
     @Test

--- a/app/src/test/java/org/cescfe/numpairs/feature/onboarding/OnboardingStartupCoordinatorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/onboarding/OnboardingStartupCoordinatorTest.kt
@@ -1,0 +1,205 @@
+package org.cescfe.numpairs.feature.onboarding
+
+import java.io.IOException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import org.cescfe.numpairs.data.onboarding.FirstRunTutorialOutcome
+import org.cescfe.numpairs.data.onboarding.OnboardingInitializer
+import org.cescfe.numpairs.data.onboarding.OnboardingInstallationKind
+import org.cescfe.numpairs.data.onboarding.OnboardingRepository
+import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
+import org.cescfe.numpairs.data.onboarding.OnboardingState
+import org.cescfe.numpairs.data.onboarding.PreV6UpgradeMarker
+import org.cescfe.numpairs.data.onboarding.REQUIRED_ONBOARDING_VERSION
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OnboardingStartupCoordinatorTest {
+    @Test
+    fun `fresh startup initializes before publishing required Tutorial state`() = runTest {
+        val repository = StartupOnboardingRepository()
+
+        val state = startupStates(repository = repository).first()
+
+        val ready = state as OnboardingStartupState.Ready
+        assertTrue(ready.onboardingState.isInitialized)
+        assertFalse(ready.onboardingState.isRequiredVersionComplete())
+        assertEquals(FirstRunTutorialOutcome.UNRESOLVED, ready.onboardingState.firstRunTutorialOutcome)
+        assertEquals(listOf(OnboardingInstallationKind.FRESH_INSTALL), repository.initializationKinds)
+    }
+
+    @Test
+    fun `resolved first-run outcomes remain unlocked on startup`() = runTest {
+        FirstRunTutorialOutcome.entries
+            .filter(FirstRunTutorialOutcome::isResolved)
+            .forEach { outcome ->
+                val expectedState = completedState(outcome)
+                val repository = StartupOnboardingRepository(initialState = expectedState)
+
+                val state = startupStates(repository = repository).first()
+
+                assertEquals(expectedState, (state as OnboardingStartupState.Ready).onboardingState)
+            }
+    }
+
+    @Test
+    fun `pre-v6 marker initializes upgraded users before publishing readiness`() = runTest {
+        val repository = StartupOnboardingRepository()
+        val marker = StartupUpgradeMarker(isMarked = true)
+
+        val state = startupStates(repository = repository, marker = marker).first()
+
+        val ready = state as OnboardingStartupState.Ready
+        assertTrue(ready.onboardingState.isRequiredVersionComplete())
+        assertEquals(FirstRunTutorialOutcome.PRE_V6_UPGRADE, ready.onboardingState.firstRunTutorialOutcome)
+        assertEquals(listOf(OnboardingInstallationKind.PRE_V6_UPGRADE), repository.initializationKinds)
+        assertTrue(marker.wasCleared)
+    }
+
+    @Test
+    fun `transient storage read failure is retried without process restart`() = runTest {
+        val repository = StartupOnboardingRepository(readFailuresRemaining = 1)
+
+        val state = startupStates(repository = repository).first()
+
+        assertTrue(state is OnboardingStartupState.Ready)
+        assertEquals(2, repository.initializationKinds.size)
+        assertEquals(2, repository.readAttempts)
+    }
+
+    @Test
+    fun `persistent storage read failure reaches recoverable failure state`() = runTest {
+        val repository = StartupOnboardingRepository(readFailuresRemaining = Int.MAX_VALUE)
+
+        val state = startupStates(repository = repository).first()
+
+        val failure = state as OnboardingStartupState.Failure
+        assertTrue(failure.cause is IOException)
+        assertFalse(failure.isRetrying)
+        assertEquals(3, repository.initializationKinds.size)
+        assertEquals(3, repository.readAttempts)
+    }
+
+    @Test
+    fun `explicit retry recovers after automatic storage retries are exhausted`() = runTest {
+        val repository = StartupOnboardingRepository(readFailuresRemaining = Int.MAX_VALUE)
+        val coordinator = coordinator(repository = repository, coroutineScope = backgroundScope)
+        testScheduler.runCurrent()
+        assertTrue(coordinator.state.value is OnboardingStartupState.Failure)
+
+        repository.readFailuresRemaining = 0
+        coordinator.retry()
+
+        val retrying = coordinator.state.value as OnboardingStartupState.Failure
+        assertTrue(retrying.isRetrying)
+        testScheduler.runCurrent()
+        assertTrue(coordinator.state.value is OnboardingStartupState.Ready)
+    }
+
+    @Test
+    fun `initial local resolution remains behind startup loading state`() = runTest {
+        val coordinator = coordinator(
+            repository = StartupOnboardingRepository(),
+            coroutineScope = backgroundScope
+        )
+
+        assertEquals(OnboardingStartupState.Loading, coordinator.state.value)
+
+        testScheduler.runCurrent()
+
+        assertTrue(coordinator.state.value is OnboardingStartupState.Ready)
+    }
+
+    private fun startupStates(
+        repository: StartupOnboardingRepository,
+        marker: StartupUpgradeMarker = StartupUpgradeMarker()
+    ): Flow<OnboardingStartupState> = onboardingStartupStates(
+        initializer = OnboardingInitializer(repository, marker),
+        repository = repository
+    )
+
+    private fun coordinator(
+        repository: StartupOnboardingRepository,
+        coroutineScope: CoroutineScope
+    ): OnboardingStartupCoordinator = OnboardingStartupCoordinator(
+        initializer = OnboardingInitializer(repository, StartupUpgradeMarker()),
+        repository = repository,
+        coroutineScope = coroutineScope
+    )
+
+    private fun completedState(outcome: FirstRunTutorialOutcome): OnboardingState = OnboardingState(
+        isInitialized = true,
+        completedVersion = REQUIRED_ONBOARDING_VERSION,
+        lastCompletedStage = OnboardingStageCheckpoint.STAGE_THREE,
+        firstRunTutorialOutcome = outcome
+    )
+
+    private class StartupOnboardingRepository(
+        initialState: OnboardingState = OnboardingState(),
+        var readFailuresRemaining: Int = 0
+    ) : OnboardingRepository {
+        private val persistedState = MutableStateFlow(initialState)
+
+        val initializationKinds = mutableListOf<OnboardingInstallationKind>()
+        var readAttempts = 0
+            private set
+
+        override val onboardingState: Flow<OnboardingState> = flow {
+            readAttempts += 1
+            if (readFailuresRemaining > 0) {
+                readFailuresRemaining -= 1
+                throw IOException("Synthetic onboarding read failure.")
+            }
+            emitAll(persistedState)
+        }
+
+        override suspend fun initialize(installationKind: OnboardingInstallationKind) {
+            initializationKinds += installationKind
+            if (persistedState.value.isInitialized) {
+                return
+            }
+
+            persistedState.value = when (installationKind) {
+                OnboardingInstallationKind.FRESH_INSTALL -> OnboardingState(isInitialized = true)
+                OnboardingInstallationKind.PRE_V6_UPGRADE -> OnboardingState(
+                    isInitialized = true,
+                    completedVersion = REQUIRED_ONBOARDING_VERSION,
+                    lastCompletedStage = OnboardingStageCheckpoint.STAGE_THREE,
+                    firstRunTutorialOutcome = FirstRunTutorialOutcome.PRE_V6_UPGRADE
+                )
+            }
+        }
+
+        override suspend fun recordStageCompleted(stage: OnboardingStageCheckpoint) = Unit
+
+        override suspend fun markTutorialCompleted() = Unit
+
+        override suspend fun markTutorialSkipped() = Unit
+    }
+
+    private class StartupUpgradeMarker(isMarked: Boolean = false) : PreV6UpgradeMarker {
+        private var marked = isMarked
+        var wasCleared = false
+            private set
+
+        override fun isMarked(): Boolean = marked
+
+        override fun mark() {
+            marked = true
+        }
+
+        override fun clear() {
+            marked = false
+            wasCleared = true
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue

Resolves #522

## Summary

- Resolve onboarding initialization and observation through one startup coordinator before publishing the first application route.
- Keep the native splash visible for the brief local read so fresh installations open Tutorial and resolved installations open Menu without a second loading screen.
- Retry transient onboarding I/O failures and provide an explicit localized retry screen when storage remains unavailable.
- Preserve pre-v6 upgrade initialization and cover fresh, resolved, upgraded, transient-failure, persistent-failure, retry, UI, and localization outcomes.

## UI Consistency

- Shared components or tokens reused: `NumPairsComponents.PrimaryCtaButton`, Material theme background/content colors, and established typography roles.
- Intentional deviations from established visual roles: None.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew lintDebug`
