### PR TITLE
[251] Reserve milestone closure for the repository owner

### DIFF
--- a/docs/technical/delivery-workflow.md
+++ b/docs/technical/delivery-workflow.md
@@ -188,7 +188,7 @@ For documentation-only changes, validate Markdown structure, relative links, con
 
 ## Milestone Completion
 
-Before closing a milestone:
+Before reporting a milestone ready for manual closure:
 
 - confirm every planned issue is closed or deliberately marked `not planned`
 - confirm every associated Pull Request is merged
@@ -197,4 +197,8 @@ Before closing a milestone:
 - run final formatting, unit-test, lint, and instrumented-test compilation checks
 - confirm the worktree is clean and synchronized with `origin/main`
 
-Close the milestone only when the user authorized completion and all required verification has passed.
+Agents must not close GitHub milestones. After every required verification passes, report the
+milestone as ready and leave the milestone open for the repository owner to close manually.
+
+End-to-end milestone delivery remains authorization to merge every in-scope Pull Request under the
+rules above. It does not authorize an agent to close the milestone.

--- a/docs/technical/delivery-workflow.md
+++ b/docs/technical/delivery-workflow.md
@@ -197,8 +197,4 @@ Before reporting a milestone ready for manual closure:
 - run final formatting, unit-test, lint, and instrumented-test compilation checks
 - confirm the worktree is clean and synchronized with `origin/main`
 
-Agents must not close GitHub milestones. After every required verification passes, report the
-milestone as ready and leave the milestone open for the repository owner to close manually.
-
-End-to-end milestone delivery remains authorization to merge every in-scope Pull Request under the
-rules above. It does not authorize an agent to close the milestone.
+Agents must not close GitHub milestones.


### PR DESCRIPTION
## Related Issue

Resolves #526

## Summary

- Reserve GitHub milestone closure for the repository owner.
- Keep the agent-owned readiness checks and reporting handoff.
- Clarify that end-to-end delivery authorizes in-scope merges, not milestone closure.