### PR TITLE
[252] Simplify the Learn basics Tutorial copy

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
@@ -27,6 +27,17 @@ class LocalizationResourceTest {
         )
         assertEquals("Serie", resources.getString(R.string.strip_content_description))
         assertEquals("Paso 1 de 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
+        assertTutorialCopy(
+            resources = resources,
+            stepOne = "La lista de números va de menor a mayor. " +
+                "Un mismo número puede aparecer más de una vez.",
+            stepOneGuidance = "Introduce 3 para completar la serie del tutorial.",
+            stepTwo = "Cada casilla muestra un resultado. " +
+                "Elige los números y el símbolo que dan ese resultado. " +
+                "Usa los mismos dos números una vez con + y otra con ×.",
+            stepThree = "Resuelve el puzle. Recuerda: la lista de números puede incluir " +
+                "el mismo número más de una vez."
+        )
         assertEquals("Saltar tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
         assertEquals("Continuar tutorial", resources.getString(R.string.onboarding_continue_tutorial_button))
         assertEquals("Saltar igualmente", resources.getString(R.string.onboarding_skip_anyway_button))
@@ -50,6 +61,17 @@ class LocalizationResourceTest {
         )
         assertEquals("Sèrie", resources.getString(R.string.strip_content_description))
         assertEquals("Pas 1 de 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
+        assertTutorialCopy(
+            resources = resources,
+            stepOne = "La llista de números va de menor a major. " +
+                "Un mateix número pot aparéixer més d’una vegada.",
+            stepOneGuidance = "Introdueix 3 per completar la sèrie del tutorial.",
+            stepTwo = "Cada casella mostra un resultat. " +
+                "Tria els números i el símbol que donen eixe resultat. " +
+                "Usa els mateixos dos números una vegada amb + i una altra amb ×.",
+            stepThree = "Resol el puzle. Recorda: la llista de números pot incloure " +
+                "el mateix número més d’una vegada."
+        )
         assertEquals("Omet el tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
         assertEquals("Continua el tutorial", resources.getString(R.string.onboarding_continue_tutorial_button))
         assertEquals("Omet-lo igualment", resources.getString(R.string.onboarding_skip_anyway_button))
@@ -73,11 +95,34 @@ class LocalizationResourceTest {
         )
         assertEquals("Strip", resources.getString(R.string.strip_content_description))
         assertEquals("Step 1 of 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
+        assertTutorialCopy(
+            resources = resources,
+            stepOne = "The number list goes from smallest to largest. " +
+                "The same number can appear more than once.",
+            stepOneGuidance = "Enter 3 to complete the Tutorial strip.",
+            stepTwo = "Each tile shows a result. Choose the numbers and symbol that make it. " +
+                "Use the same two numbers once with + and once with ×.",
+            stepThree = "Solve the puzzle. Remember: the number list can include " +
+                "the same number more than once."
+        )
         assertEquals("Skip tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
         assertEquals("Continue tutorial", resources.getString(R.string.onboarding_continue_tutorial_button))
         assertEquals("Skip anyway", resources.getString(R.string.onboarding_skip_anyway_button))
         assertEquals("Unable to open NumPairs", resources.getString(R.string.onboarding_startup_failure_title))
         assertEquals("Retry", resources.getString(R.string.onboarding_startup_retry_button))
+    }
+
+    private fun assertTutorialCopy(
+        resources: Resources,
+        stepOne: String,
+        stepOneGuidance: String,
+        stepTwo: String,
+        stepThree: String
+    ) {
+        assertEquals(stepOne, resources.getString(R.string.tutorial_strip_introduction_copy))
+        assertEquals(stepOneGuidance, resources.getString(R.string.tutorial_strip_entry_guidance))
+        assertEquals(stepTwo, resources.getString(R.string.tutorial_tiles_introduction_copy))
+        assertEquals(stepThree, resources.getString(R.string.tutorial_repeated_value_practice_copy))
     }
 
     private fun resourcesFor(languageTag: String): Resources {

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -61,10 +61,10 @@
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Pas %1$d de %2$d</string>
-    <string name="tutorial_strip_introduction_copy">La sèrie ordena enters positius de menor a major; els valors es poden repetir. Introdueix 3 per completar 2, ?, 4, 5.</string>
+    <string name="tutorial_strip_introduction_copy">La llista de números va de menor a major. Un mateix número pot aparéixer més d’una vegada.</string>
     <string name="tutorial_strip_entry_guidance">Introdueix 3 per completar la sèrie del tutorial.</string>
-    <string name="tutorial_tiles_introduction_copy">Una casella mostra un resultat i una expressió que has de formar. Emparella dos elements de la sèrie: cada parella ha de formar una casella de suma i una altra de producte. Completa 2 + 3 = 5.</string>
-    <string name="tutorial_repeated_value_practice_copy">Resol el puzle. Recorda: la sèrie pot contindre valors repetits.</string>
+    <string name="tutorial_tiles_introduction_copy">Cada casella mostra un resultat. Tria els números i el símbol que donen eixe resultat. Usa els mateixos dos números una vegada amb + i una altra amb ×.</string>
+    <string name="tutorial_repeated_value_practice_copy">Resol el puzle. Recorda: la llista de números pot incloure el mateix número més d’una vegada.</string>
     <string name="onboarding_skip_tutorial_action">Omet el tutorial</string>
     <string name="onboarding_skip_tutorial_title">Vols ometre el tutorial?</string>
     <string name="onboarding_skip_tutorial_message">Si és la primera vegada que jugues a NumPairs o a jocs similars, et recomanem continuar. Podràs tornar a obrir el tutorial més tard des de Com jugar.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -61,10 +61,10 @@
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Paso %1$d de %2$d</string>
-    <string name="tutorial_strip_introduction_copy">La serie ordena enteros positivos de menor a mayor; los valores pueden repetirse. Introduce 3 para completar 2, ?, 4, 5.</string>
+    <string name="tutorial_strip_introduction_copy">La lista de números va de menor a mayor. Un mismo número puede aparecer más de una vez.</string>
     <string name="tutorial_strip_entry_guidance">Introduce 3 para completar la serie del tutorial.</string>
-    <string name="tutorial_tiles_introduction_copy">Una casilla muestra un resultado y una expresión que debes formar. Empareja dos elementos de la serie: cada pareja debe formar una casilla de suma y otra de producto. Completa 2 + 3 = 5.</string>
-    <string name="tutorial_repeated_value_practice_copy">Resuelve el puzle. Recuerda: la serie puede contener valores repetidos.</string>
+    <string name="tutorial_tiles_introduction_copy">Cada casilla muestra un resultado. Elige los números y el símbolo que dan ese resultado. Usa los mismos dos números una vez con + y otra con ×.</string>
+    <string name="tutorial_repeated_value_practice_copy">Resuelve el puzle. Recuerda: la lista de números puede incluir el mismo número más de una vez.</string>
     <string name="onboarding_skip_tutorial_action">Saltar tutorial</string>
     <string name="onboarding_skip_tutorial_title">¿Saltar el tutorial?</string>
     <string name="onboarding_skip_tutorial_message">Si es la primera vez que juegas a NumPairs o a juegos similares, te recomendamos continuar. Podrás volver a abrir el tutorial más tarde desde Cómo jugar.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,10 +61,10 @@
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Step %1$d of %2$d</string>
-    <string name="tutorial_strip_introduction_copy">The strip lists positive integers from lowest to highest; values may repeat. Enter 3 to complete 2, ?, 4, 5.</string>
+    <string name="tutorial_strip_introduction_copy">The number list goes from smallest to largest. The same number can appear more than once.</string>
     <string name="tutorial_strip_entry_guidance">Enter 3 to complete the Tutorial strip.</string>
-    <string name="tutorial_tiles_introduction_copy">A tile shows a result and an expression to build. Pair two strip entries: each pair must make one sum tile and one product tile. Complete 2 + 3 = 5.</string>
-    <string name="tutorial_repeated_value_practice_copy">Solve the puzzle. Remember: the strip can contain repeated values.</string>
+    <string name="tutorial_tiles_introduction_copy">Each tile shows a result. Choose the numbers and symbol that make it. Use the same two numbers once with + and once with ×.</string>
+    <string name="tutorial_repeated_value_practice_copy">Solve the puzzle. Remember: the number list can include the same number more than once.</string>
     <string name="onboarding_skip_tutorial_action">Skip tutorial</string>
     <string name="onboarding_skip_tutorial_title">Skip the tutorial?</string>
     <string name="onboarding_skip_tutorial_message">If you’re new to NumPairs or similar games, we recommend continuing. You can open the Tutorial again later from How to play.</string>


### PR DESCRIPTION
## Related Issue

Resolves #528

## Summary

- Replace domain-oriented Learn basics copy with plain player-facing language.
- Remove the redundant Step 1 and Step 2 action examples.
- Keep the contextual Step 1 entry guidance and cover English, Spanish, and Valencian resources.

## UI Consistency

- Shared components or tokens reused: Existing Tutorial instruction surface, typography, and localized string resources remain unchanged.
- Intentional deviations from established visual roles: None.