### PR TITLE
[253] Highlight the complementary Tutorial tile

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
@@ -40,7 +40,8 @@ internal object LearnBasicsTutorialContent {
             scenarioId = TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
             playerFacingCopyResId = R.string.tutorial_tiles_introduction_copy,
             highlightedTargets = listOf(
-                TutorialHighlightTarget.TileExpressionSlots(tileIndex = 0)
+                TutorialHighlightTarget.TileExpressionSlots(tileIndex = 0),
+                TutorialHighlightTarget.WholeTile(tileIndex = 1)
             ),
             requiredAction = TutorialRequiredAction.CompleteTileExpression(
                 tileIndex = 0,

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
@@ -110,6 +110,14 @@ sealed interface TutorialHighlightTarget {
             }
         }
     }
+
+    data class WholeTile(val tileIndex: Int) : TutorialHighlightTarget {
+        init {
+            require(tileIndex >= 0) {
+                "Tutorial whole tile highlight index must be non-negative."
+            }
+        }
+    }
 }
 
 sealed interface TutorialRequiredAction {

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -368,7 +368,8 @@ private fun TutorialStep.highlightedStripEntryIds(scenario: TutorialScenario): S
             }
             is TutorialHighlightTarget.StripEntries -> addAll(target.indexes)
             TutorialHighlightTarget.HiddenTileExpressions,
-            is TutorialHighlightTarget.TileExpressionSlots -> Unit
+            is TutorialHighlightTarget.TileExpressionSlots,
+            is TutorialHighlightTarget.WholeTile -> Unit
         }
     }
 }
@@ -389,6 +390,7 @@ internal fun TutorialStep.toHighlightState(scenario: TutorialScenario, uiState: 
     }
 
     val stripEntryIndexes = mutableSetOf<Int>()
+    val tileIndexes = mutableSetOf<Int>()
     val tileExpressionSlots = mutableSetOf<GameTileExpressionSlotHighlight>()
 
     highlightedTargets.forEach { target ->
@@ -413,11 +415,15 @@ internal fun TutorialStep.toHighlightState(scenario: TutorialScenario, uiState: 
             is TutorialHighlightTarget.TileExpressionSlots -> {
                 tileExpressionSlots += expressionSlotHighlights(target.tileIndex)
             }
+            is TutorialHighlightTarget.WholeTile -> {
+                tileIndexes += target.tileIndex
+            }
         }
     }
 
     return GameHighlightState(
         stripEntryIndexes = stripEntryIndexes,
+        tileIndexes = tileIndexes,
         tileExpressionSlots = tileExpressionSlots
     )
 }

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -8,6 +8,8 @@ import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.domain.puzzle.model.PuzzleCompletionState
 import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.cescfe.numpairs.domain.puzzle.model.Tile
+import org.cescfe.numpairs.feature.game.GameTileExpressionSlot
+import org.cescfe.numpairs.feature.game.GameTileExpressionSlotHighlight
 import org.cescfe.numpairs.feature.game.presentation.GameUiState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -104,7 +106,8 @@ class TutorialContentTest {
 
         steps[1].assertGuidedAction(
             expectedHighlights = listOf(
-                TutorialHighlightTarget.TileExpressionSlots(tileIndex = 0)
+                TutorialHighlightTarget.TileExpressionSlots(tileIndex = 0),
+                TutorialHighlightTarget.WholeTile(tileIndex = 1)
             ),
             expectedAction = TutorialRequiredAction.CompleteTileExpression(
                 tileIndex = 0,
@@ -128,6 +131,25 @@ class TutorialContentTest {
             incompletePuzzle = repeatedValueScenario.initialPuzzle,
             completePuzzle = repeatedValueScenario.solvedPuzzle
         )
+    }
+
+    @Test
+    fun learn_basics_step_two_highlights_the_editable_slots_and_complementary_product_tile() {
+        val scenario = TutorialContent.scenario(TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION)
+        val step = TutorialContent.learnBasicsSteps[1]
+
+        val highlightState = step.toHighlightState(scenario = scenario, uiState = null)
+
+        assertEquals(setOf(1), highlightState.tileIndexes)
+        assertEquals(
+            GameTileExpressionSlot.entries.mapTo(mutableSetOf()) { slot ->
+                GameTileExpressionSlotHighlight(tileIndex = 0, slot = slot)
+            },
+            highlightState.tileExpressionSlots
+        )
+        assertFalse(highlightState.isTileHighlighted(index = 0))
+        assertFalse(highlightState.isTileHighlighted(index = 2))
+        assertFalse(highlightState.isTileHighlighted(index = 3))
     }
 
     @Test


### PR DESCRIPTION
## Related Issue

Resolves #527

## Summary

- Add a whole-tile Tutorial highlight target backed by the existing game highlight state.
- Highlight the solved 2 × 3 = 6 tile as a whole during Learn basics Step 2.
- Keep slot-level highlighting only on the editable 2 + 3 = 5 tile and cover the mapping with unit tests.

## UI Consistency

- Shared components or tokens reused: Existing PuzzleTile whole-tile border and tutorialHighlight semantic color.
- Intentional deviations from established visual roles: None.