### PR TITLE
[254] Relocate the required Tutorial skip action

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
@@ -39,6 +39,7 @@ import org.cescfe.numpairs.feature.tutorial.ui.TutorialScreenTestTags
 import org.cescfe.numpairs.ui.navigation.AppNavigation
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -63,6 +64,7 @@ class RequiredOnboardingNavigationTest {
             .onNodeWithTag(TutorialScreenTestTags.STEP_COPY)
             .assert(hasText(string(R.string.tutorial_strip_introduction_copy)))
         assertRequiredSkipActionDisplayed()
+        assertRequiredSkipActionPositionedOutsideInstruction()
         composeTestRule
             .onNodeWithTag(MenuScreenTestTags.SCREEN)
             .assertDoesNotExist()
@@ -214,6 +216,26 @@ class RequiredOnboardingNavigationTest {
             .onNodeWithTag(TutorialScreenTestTags.SKIP_ACTION)
             .assertIsDisplayed()
             .assert(hasText(string(R.string.onboarding_skip_tutorial_action)))
+    }
+
+    private fun assertRequiredSkipActionPositionedOutsideInstruction() {
+        val screenBounds = composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val instructionBounds = composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.INSTRUCTION_SURFACE)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val skipBounds = composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.SKIP_ACTION)
+            .fetchSemanticsNode()
+            .boundsInRoot
+
+        assertTrue(skipBounds.top >= instructionBounds.bottom)
+        assertTrue(skipBounds.left >= screenBounds.center.x)
+        assertTrue(skipBounds.right <= screenBounds.right)
+        assertTrue(skipBounds.bottom < screenBounds.bottom)
     }
 
     private fun assertStillOnFirstStep(repository: FakeOnboardingRepository) {

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/GameRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/GameRoute.kt
@@ -44,6 +44,7 @@ fun GameRoute(
     interactionPolicy: GameInteractionPolicy = GameInteractionPolicy.AllowAll,
     highlightState: GameHighlightState = GameHighlightState.None,
     topBarActions: @Composable RowScope.() -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
     contentBeforePuzzle: @Composable ColumnScope.() -> Unit = {},
     onGameUiStateChanged: (GameUiState) -> Unit = {},
     onPuzzleChanged: (Puzzle) -> Unit = {},
@@ -179,6 +180,7 @@ fun GameRoute(
         correctTileFeedbackIdsByIndex = correctTileFeedbackIdsByIndex,
         completionFeedbackId = completionFeedbackId,
         topBarActions = topBarActions,
+        bottomBar = bottomBar,
         contentBeforePuzzle = contentBeforePuzzle
     )
 }

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreen.kt
@@ -81,6 +81,7 @@ fun GameScreen(
     correctTileFeedbackIdsByIndex: Map<Int, Long> = emptyMap(),
     completionFeedbackId: Long? = null,
     topBarActions: @Composable RowScope.() -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
     contentBeforePuzzle: @Composable ColumnScope.() -> Unit = {}
 ) {
     var isRulesHelperVisible by rememberSaveable { mutableStateOf(false) }
@@ -107,7 +108,8 @@ fun GameScreen(
                     isRulesHelperActionDiscoveryDotVisible = isRulesHelperActionDiscoveryDotVisible,
                     actions = topBarActions
                 )
-            }
+            },
+            bottomBar = bottomBar
         ) { innerPadding ->
             Column(
                 modifier = Modifier

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -2,8 +2,10 @@ package org.cescfe.numpairs.feature.tutorial
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -17,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -119,12 +122,16 @@ fun TutorialRoute(
             scenario = currentScenario,
             uiState = latestGameUiState
         ),
+        bottomBar = {
+            onSkipTutorialRequested?.let { onSkipRequested ->
+                TutorialSkipBottomBar(onSkipRequested = onSkipRequested)
+            }
+        },
         contentBeforePuzzle = {
             TutorialInstructionSurface(
                 currentStep = currentStep,
                 currentStepNumber = currentStepIndex + 1,
                 totalSteps = steps.size,
-                onSkipTutorialRequested = onSkipTutorialRequested,
                 modifier = Modifier.fillMaxWidth()
             )
         },
@@ -145,7 +152,6 @@ private fun TutorialInstructionSurface(
     currentStep: TutorialStep,
     currentStepNumber: Int,
     totalSteps: Int,
-    onSkipTutorialRequested: (() -> Unit)?,
     modifier: Modifier = Modifier
 ) {
     Surface(
@@ -175,21 +181,31 @@ private fun TutorialInstructionSurface(
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurface
             )
-            onSkipTutorialRequested?.let { onSkipRequested ->
-                Text(
-                    text = stringResource(R.string.onboarding_skip_tutorial_action),
-                    modifier = Modifier
-                        .testTag(TutorialScreenTestTags.SKIP_ACTION)
-                        .clickable(
-                            role = Role.Button,
-                            onClick = onSkipRequested
-                        )
-                        .padding(vertical = 4.dp),
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.primary
-                )
-            }
         }
+    }
+}
+
+@Composable
+private fun TutorialSkipBottomBar(onSkipRequested: () -> Unit, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        contentAlignment = Alignment.CenterEnd
+    ) {
+        Text(
+            text = stringResource(R.string.onboarding_skip_tutorial_action),
+            modifier = Modifier
+                .testTag(TutorialScreenTestTags.SKIP_ACTION)
+                .clickable(
+                    role = Role.Button,
+                    onClick = onSkipRequested
+                )
+                .padding(vertical = 4.dp),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary
+        )
     }
 }
 


### PR DESCRIPTION
## Related Issue

Resolves #525

## Summary

- Move the required first-run Skip tutorial action out of the instruction card.
- Anchor the low-emphasis action at the bottom end through the shared Scaffold bottom bar.
- Reserve content space, apply Android navigation-bar insets, and preserve the existing confirmation flow.

## UI Consistency

- Shared components or tokens reused: Existing Tutorial label typography and primary content color, plus the shared GameScreen Scaffold layout.
- Intentional deviations from established visual roles: None; the action keeps its existing low-emphasis text treatment.