### PR TITLE
[255] Prevent the intermediate Tutorial success overlay

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -108,7 +108,12 @@ fun TutorialRoute(
         modifier = modifier,
         gameSessionKey = "$TUTORIAL_GAME_SESSION_KEY:$playbackKey:${currentScenario.id}",
         puzzleResetKey = playbackKey to currentScenario.id,
-        isSuccessOverlayEnabled = currentStepIndex == steps.lastIndex && onTutorialCompleted == null,
+        isSuccessOverlayEnabled = isTutorialSuccessOverlayEnabled(
+            isFinalStep = currentStepIndex == steps.lastIndex,
+            currentScenarioId = currentScenario.id,
+            observedScenarioId = latestGameUiSnapshot?.scenarioId,
+            isRequiredPlayback = onTutorialCompleted != null
+        ),
         isBoardVisible = currentStep.isBoardVisible,
         stripItemEntryGuidance = stripItemEntryGuidance,
         interactionPolicy = currentStep.toInteractionPolicy(
@@ -139,6 +144,15 @@ fun TutorialRoute(
 }
 
 private data class TutorialGameUiSnapshot(val scenarioId: TutorialScenarioId, val uiState: GameUiState)
+
+internal fun isTutorialSuccessOverlayEnabled(
+    isFinalStep: Boolean,
+    currentScenarioId: TutorialScenarioId,
+    observedScenarioId: TutorialScenarioId?,
+    isRequiredPlayback: Boolean
+): Boolean = isFinalStep &&
+    observedScenarioId == currentScenarioId &&
+    !isRequiredPlayback
 
 @Composable
 private fun TutorialInstructionSurface(

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialSuccessOverlayPolicyTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialSuccessOverlayPolicyTest.kt
@@ -1,0 +1,43 @@
+package org.cescfe.numpairs.feature.tutorial
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TutorialSuccessOverlayPolicyTest {
+    @Test
+    fun `final step waits for its own scenario state before enabling success`() {
+        val finalScenarioId = TutorialScenarioId.REPEATED_VALUE_PRACTICE
+
+        assertFalse(
+            isTutorialSuccessOverlayEnabled(
+                isFinalStep = true,
+                currentScenarioId = finalScenarioId,
+                observedScenarioId = TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
+                isRequiredPlayback = false
+            )
+        )
+        assertTrue(
+            isTutorialSuccessOverlayEnabled(
+                isFinalStep = true,
+                currentScenarioId = finalScenarioId,
+                observedScenarioId = finalScenarioId,
+                isRequiredPlayback = false
+            )
+        )
+    }
+
+    @Test
+    fun `required playback never enables the success overlay`() {
+        val finalScenarioId = TutorialScenarioId.REPEATED_VALUE_PRACTICE
+
+        assertFalse(
+            isTutorialSuccessOverlayEnabled(
+                isFinalStep = true,
+                currentScenarioId = finalScenarioId,
+                observedScenarioId = finalScenarioId,
+                isRequiredPlayback = true
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Related Issue

Resolves #524

## Summary

- Keep the success overlay disabled until the observed game UI belongs to the current Tutorial scenario.
- Prevent the solved Step 2 state from leaking into the Step 3 transition.
- Preserve final success for voluntary playback and keep required onboarding completion overlay-free.

## UI Consistency

- Shared components or tokens reused: Existing SuccessOverlay behavior and Tutorial transition timing remain unchanged.
- Intentional deviations from established visual roles: None.