### PR TITLE
[256] Suppress the final Learn basics success overlay

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -127,14 +127,14 @@ class TutorialRouteTest {
     }
 
     @Test
-    fun stepThreeUsesNormalPuzzleInteractionsAndCompletesLearnBasics() {
+    fun stepThreeUsesNormalPuzzleInteractionsAndCompletesLearnBasicsWithoutShowingSuccess() {
         setContent()
 
         completeFocusedTutorial()
 
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY)
-            .assertIsDisplayed()
+            .assertDoesNotExist()
     }
 
     @Test

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -112,6 +112,7 @@ fun TutorialRoute(
         gameSessionKey = "$TUTORIAL_GAME_SESSION_KEY:$playbackKey:${currentScenario.id}",
         puzzleResetKey = playbackKey to currentScenario.id,
         isSuccessOverlayEnabled = isTutorialSuccessOverlayEnabled(
+            mode = mode,
             isFinalStep = currentStepIndex == steps.lastIndex,
             currentScenarioId = currentScenario.id,
             observedScenarioId = latestGameUiSnapshot?.scenarioId,
@@ -153,11 +154,13 @@ fun TutorialRoute(
 private data class TutorialGameUiSnapshot(val scenarioId: TutorialScenarioId, val uiState: GameUiState)
 
 internal fun isTutorialSuccessOverlayEnabled(
+    mode: TutorialMode,
     isFinalStep: Boolean,
     currentScenarioId: TutorialScenarioId,
     observedScenarioId: TutorialScenarioId?,
     isRequiredPlayback: Boolean
-): Boolean = isFinalStep &&
+): Boolean = mode == TutorialMode.SOLVING_TIPS_PRACTICE &&
+    isFinalStep &&
     observedScenarioId == currentScenarioId &&
     !isRequiredPlayback
 

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialSuccessOverlayPolicyTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialSuccessOverlayPolicyTest.kt
@@ -6,11 +6,12 @@ import org.junit.Test
 
 class TutorialSuccessOverlayPolicyTest {
     @Test
-    fun `final step waits for its own scenario state before enabling success`() {
-        val finalScenarioId = TutorialScenarioId.REPEATED_VALUE_PRACTICE
+    fun `solving tips waits for its own scenario state before enabling success`() {
+        val finalScenarioId = TutorialScenarioId.SOLVING_TIPS_PRACTICE
 
         assertFalse(
             isTutorialSuccessOverlayEnabled(
+                mode = TutorialMode.SOLVING_TIPS_PRACTICE,
                 isFinalStep = true,
                 currentScenarioId = finalScenarioId,
                 observedScenarioId = TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
@@ -19,6 +20,22 @@ class TutorialSuccessOverlayPolicyTest {
         )
         assertTrue(
             isTutorialSuccessOverlayEnabled(
+                mode = TutorialMode.SOLVING_TIPS_PRACTICE,
+                isFinalStep = true,
+                currentScenarioId = finalScenarioId,
+                observedScenarioId = finalScenarioId,
+                isRequiredPlayback = false
+            )
+        )
+    }
+
+    @Test
+    fun `learn basics never enables the success overlay`() {
+        val finalScenarioId = TutorialScenarioId.REPEATED_VALUE_PRACTICE
+
+        assertFalse(
+            isTutorialSuccessOverlayEnabled(
+                mode = TutorialMode.LEARN_BASICS,
                 isFinalStep = true,
                 currentScenarioId = finalScenarioId,
                 observedScenarioId = finalScenarioId,
@@ -29,10 +46,11 @@ class TutorialSuccessOverlayPolicyTest {
 
     @Test
     fun `required playback never enables the success overlay`() {
-        val finalScenarioId = TutorialScenarioId.REPEATED_VALUE_PRACTICE
+        val finalScenarioId = TutorialScenarioId.SOLVING_TIPS_PRACTICE
 
         assertFalse(
             isTutorialSuccessOverlayEnabled(
+                mode = TutorialMode.SOLVING_TIPS_PRACTICE,
                 isFinalStep = true,
                 currentScenarioId = finalScenarioId,
                 observedScenarioId = finalScenarioId,


### PR DESCRIPTION
## Related Issue

Resolves #534

## Summary

- Disable the success overlay after the final Learn basics step in required and voluntary playback.
- Preserve the final success overlay for Solving Tips Practice.
- Add unit and Compose regression coverage that distinguishes both tutorial modes.

## UI Consistency

- Shared components or tokens reused: Existing tutorial success-overlay policy and SuccessOverlay behavior.
- Intentional deviations from established visual roles: None.