### PR TITLE
[257] Restart How to play playback cleanly

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -1,6 +1,7 @@
 package org.cescfe.numpairs.feature.tutorial
 
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertContentDescriptionEquals
@@ -156,6 +157,54 @@ class TutorialRouteTest {
     }
 
     @Test
+    fun uninterruptedStepCompletionIsReportedExactlyOnce() {
+        val stepOneCompletionCount = AtomicInteger(0)
+        setContent(
+            onStepCompleted = { stepIndex ->
+                if (stepIndex == 0) {
+                    stepOneCompletionCount.incrementAndGet()
+                }
+            }
+        )
+
+        completeFocusedStepOne()
+        waitForStep(stepIndex = 1)
+        composeTestRule.mainClock.advanceTimeBy(TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS)
+
+        assertEquals(1, stepOneCompletionCount.get())
+    }
+
+    @Test
+    fun reopeningAfterClosingOnStepTwoAllowsStepOneToAdvanceAgain() {
+        val restartTutorial = setRestartableContent()
+        completeFocusedStepOne()
+        waitForStep(stepIndex = 1)
+
+        restartTutorial()
+        assertStepDisplayed(stepIndex = 0)
+        assertFocusedIntroductionStripDisplayed()
+        completeFocusedStepOne()
+
+        waitForStep(stepIndex = 1)
+        assertStepDisplayed(stepIndex = 1)
+    }
+
+    @Test
+    fun reopeningAfterCompletingAllStepsAllowsStepOneToAdvanceAgain() {
+        val restartTutorial = setRestartableContent()
+        completeFocusedTutorial()
+        composeTestRule.mainClock.advanceTimeBy(TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS)
+
+        restartTutorial()
+        assertStepDisplayed(stepIndex = 0)
+        assertFocusedIntroductionStripDisplayed()
+        completeFocusedStepOne()
+
+        waitForStep(stepIndex = 1)
+        assertStepDisplayed(stepIndex = 1)
+    }
+
+    @Test
     fun solvingTipsPracticeHighlightsExpectedActionsAndCompletesWithSuccessOverlay() {
         setSolvingTipsPracticeTutorialContent()
 
@@ -198,10 +247,13 @@ class TutorialRouteTest {
             .assertIsDisplayed()
     }
 
-    private fun setContent(onTutorialCompleted: (() -> Unit)? = null) {
+    private fun setContent(onStepCompleted: suspend (Int) -> Unit = {}, onTutorialCompleted: (() -> Unit)? = null) {
         composeTestRule.setContent {
             NumPairsTheme {
-                TutorialRoute(onTutorialCompleted = onTutorialCompleted)
+                TutorialRoute(
+                    onStepCompleted = onStepCompleted,
+                    onTutorialCompleted = onTutorialCompleted
+                )
             }
         }
 
@@ -220,6 +272,35 @@ class TutorialRouteTest {
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.SCREEN)
             .assertIsDisplayed()
+    }
+
+    private fun setRestartableContent(): () -> Unit {
+        val isTutorialVisible = mutableStateOf(true)
+        composeTestRule.setContent {
+            NumPairsTheme {
+                if (isTutorialVisible.value) {
+                    TutorialRoute()
+                }
+            }
+        }
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+
+        return {
+            composeTestRule.runOnUiThread {
+                isTutorialVisible.value = false
+            }
+            composeTestRule
+                .onNodeWithTag(GameScreenTestTags.SCREEN)
+                .assertDoesNotExist()
+            composeTestRule.runOnUiThread {
+                isTutorialVisible.value = true
+            }
+            composeTestRule
+                .onNodeWithTag(GameScreenTestTags.SCREEN)
+                .assertIsDisplayed()
+        }
     }
 
     private fun completeFocusedStepOne() {

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -94,8 +94,8 @@ fun TutorialRoute(
             return@LaunchedEffect
         }
 
-        lastReportedStepIndex = currentStepIndex
         delay(TUTORIAL_STEP_ADVANCE_DELAY)
+        lastReportedStepIndex = currentStepIndex
         currentOnStepCompleted(currentStepIndex)
         if (currentStepIndex < steps.lastIndex) {
             currentStepIndex += 1


### PR DESCRIPTION
## Related Issue

Resolves #536

## Summary

- Defer the completed-step marker until the cancellable Tutorial advance delay has finished.
- Allow a fresh How to play playback to advance after a previous partial or complete playback.
- Add Compose regression coverage for both reopen paths and exactly-once step reporting.