### PR TITLE
[259] Remove the obsolete third onboarding checkpoint

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
@@ -79,7 +79,7 @@ class AppNavigationLearningFlowTest {
     }
 
     private fun resolvedOnboardingState(outcome: FirstRunTutorialOutcome): OnboardingState = OnboardingState(
-        lastCompletedStage = OnboardingStageCheckpoint.STAGE_THREE,
+        lastCompletedStage = OnboardingStageCheckpoint.STAGE_TWO,
         firstRunTutorialOutcome = outcome
     )
 

--- a/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
@@ -185,17 +185,6 @@ class RequiredOnboardingNavigationTest {
         assertEquals(FirstRunTutorialOutcome.COMPLETED, repository.onboardingState.value.firstRunTutorialOutcome)
     }
 
-    @Test
-    fun completedFinalCheckpointUnlocksWithoutRestoringObsoleteValidation() {
-        val repository = FakeOnboardingRepository(
-            incompleteOnboardingState(OnboardingStageCheckpoint.STAGE_THREE)
-        )
-        setContent(repository)
-
-        waitForMenu()
-        assertEquals(FirstRunTutorialOutcome.COMPLETED, repository.onboardingState.value.firstRunTutorialOutcome)
-    }
-
     private fun openSkipConfirmation() {
         composeTestRule
             .onNodeWithTag(TutorialScreenTestTags.SKIP_ACTION)

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingState.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingState.kt
@@ -23,8 +23,7 @@ enum class FirstRunTutorialOutcome(internal val persistedValue: Int) {
 enum class OnboardingStageCheckpoint(internal val persistedValue: Int) {
     NONE(0),
     STAGE_ONE(1),
-    STAGE_TWO(2),
-    STAGE_THREE(3);
+    STAGE_TWO(2);
 
     internal companion object {
         fun fromPersistedValue(value: Int): OnboardingStageCheckpoint = entries

--- a/app/src/main/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRoute.kt
@@ -6,7 +6,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -21,7 +20,6 @@ import org.cescfe.numpairs.R
 import org.cescfe.numpairs.data.onboarding.OnboardingRepository
 import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
 import org.cescfe.numpairs.data.onboarding.OnboardingState
-import org.cescfe.numpairs.feature.tutorial.TutorialContent
 import org.cescfe.numpairs.feature.tutorial.TutorialRoute
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 
@@ -43,30 +41,23 @@ fun RequiredOnboardingRoute(
 
     BackHandler(enabled = true, onBack = requestSkipConfirmation)
 
-    if (startStepIndex >= TutorialContent.learnBasicsSteps.size) {
-        LaunchedEffect(onboardingRepository) {
-            onboardingRepository.markTutorialCompleted()
-        }
-        OnboardingLoadingScreen(modifier = modifier)
-    } else {
-        TutorialRoute(
-            modifier = modifier,
-            startStepIndex = startStepIndex,
-            saveProgressAcrossRecreation = false,
-            onStepCompleted = { completedStepIndex ->
-                completedStepIndex.toIntermediateCheckpointOrNull()?.let { checkpoint ->
-                    onboardingRepository.recordStageCompleted(checkpoint)
-                }
-            },
-            onTutorialCompleted = {
-                coroutineScope.launch {
-                    onboardingRepository.markTutorialCompleted()
-                }
-            },
-            onSkipTutorialRequested = requestSkipConfirmation,
-            onNavigateBack = requestSkipConfirmation
-        )
-    }
+    TutorialRoute(
+        modifier = modifier,
+        startStepIndex = startStepIndex,
+        saveProgressAcrossRecreation = false,
+        onStepCompleted = { completedStepIndex ->
+            completedStepIndex.toIntermediateCheckpointOrNull()?.let { checkpoint ->
+                onboardingRepository.recordStageCompleted(checkpoint)
+            }
+        },
+        onTutorialCompleted = {
+            coroutineScope.launch {
+                onboardingRepository.markTutorialCompleted()
+            }
+        },
+        onSkipTutorialRequested = requestSkipConfirmation,
+        onNavigateBack = requestSkipConfirmation
+    )
 
     if (isSkipConfirmationVisible) {
         SkipTutorialConfirmationDialog(
@@ -150,7 +141,6 @@ internal fun OnboardingState.nextRequiredTutorialStepIndex(): Int = when (lastCo
     OnboardingStageCheckpoint.NONE -> 0
     OnboardingStageCheckpoint.STAGE_ONE -> 1
     OnboardingStageCheckpoint.STAGE_TWO -> 2
-    OnboardingStageCheckpoint.STAGE_THREE -> 3
 }
 
 private fun Int.toIntermediateCheckpointOrNull(): OnboardingStageCheckpoint? = when (this) {

--- a/app/src/test/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepositoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepositoryTest.kt
@@ -135,7 +135,7 @@ class DataStoreOnboardingRepositoryTest {
     @Test
     fun `clearing all application data starts a new first run`() = runBlocking {
         val fixture = createRepository()
-        fixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_THREE)
+        fixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_TWO)
         fixture.repository.markTutorialCompleted()
 
         fixture.dataStore.edit { preferences -> preferences.clear() }
@@ -147,13 +147,13 @@ class DataStoreOnboardingRepositoryTest {
     fun `resolved state persists across repository instances`() = runBlocking {
         val dataStoreFile = createDataStoreFile()
         val firstFixture = createRepository(dataStoreFile)
-        firstFixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_THREE)
+        firstFixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_TWO)
         firstFixture.repository.markTutorialCompleted()
         firstFixture.close()
 
         val restoredState = createRepository(dataStoreFile).repository.onboardingState.first()
 
-        assertEquals(OnboardingStageCheckpoint.STAGE_THREE, restoredState.lastCompletedStage)
+        assertEquals(OnboardingStageCheckpoint.STAGE_TWO, restoredState.lastCompletedStage)
         assertEquals(FirstRunTutorialOutcome.COMPLETED, restoredState.firstRunTutorialOutcome)
     }
 

--- a/app/src/test/java/org/cescfe/numpairs/feature/onboarding/OnboardingStartupCoordinatorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/onboarding/OnboardingStartupCoordinatorTest.kt
@@ -105,7 +105,7 @@ class OnboardingStartupCoordinatorTest {
     )
 
     private fun completedState(outcome: FirstRunTutorialOutcome): OnboardingState = OnboardingState(
-        lastCompletedStage = OnboardingStageCheckpoint.STAGE_THREE,
+        lastCompletedStage = OnboardingStageCheckpoint.STAGE_TWO,
         firstRunTutorialOutcome = outcome
     )
 

--- a/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
@@ -11,7 +11,6 @@ class RequiredOnboardingRouteTest {
         assertEquals(0, state(OnboardingStageCheckpoint.NONE).nextRequiredTutorialStepIndex())
         assertEquals(1, state(OnboardingStageCheckpoint.STAGE_ONE).nextRequiredTutorialStepIndex())
         assertEquals(2, state(OnboardingStageCheckpoint.STAGE_TWO).nextRequiredTutorialStepIndex())
-        assertEquals(3, state(OnboardingStageCheckpoint.STAGE_THREE).nextRequiredTutorialStepIndex())
     }
 
     private fun state(checkpoint: OnboardingStageCheckpoint): OnboardingState = OnboardingState(


### PR DESCRIPTION
## Related Issue

Resolves #540

## Summary

- Remove the obsolete third onboarding checkpoint and its persisted value.
- Route every supported unresolved checkpoint directly into the current three-step Tutorial.
- Align persistence, startup, unit, and navigation tests with the supported checkpoint model.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew lintDebug`
