### PR TITLE
[260] Remove unused Tutorial step order metadata

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
@@ -18,7 +18,6 @@ internal object LearnBasicsTutorialContent {
 
     val steps: List<TutorialStep> = listOf(
         TutorialStep(
-            order = 1,
             scenarioId = TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
             playerFacingCopyResId = R.string.tutorial_strip_introduction_copy,
             highlightedTargets = listOf(
@@ -36,7 +35,6 @@ internal object LearnBasicsTutorialContent {
             stripEntryGuidanceResId = R.string.tutorial_strip_entry_guidance
         ),
         TutorialStep(
-            order = 2,
             scenarioId = TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
             playerFacingCopyResId = R.string.tutorial_tiles_introduction_copy,
             highlightedTargets = listOf(
@@ -58,7 +56,6 @@ internal object LearnBasicsTutorialContent {
             entryPuzzle = completedIntroductionStripPuzzle
         ),
         TutorialStep(
-            order = 3,
             scenarioId = TutorialScenarioId.REPEATED_VALUE_PRACTICE,
             playerFacingCopyResId = R.string.tutorial_repeated_value_practice_copy,
             highlightedTargets = listOf(

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/SolvingTipsPracticeContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/SolvingTipsPracticeContent.kt
@@ -9,7 +9,6 @@ internal object SolvingTipsPracticeContent {
 
     val steps: List<TutorialStep> = listOf(
         TutorialStep(
-            order = 6,
             scenarioId = TutorialScenarioId.SOLVING_TIPS_PRACTICE,
             playerFacingCopyResId = R.string.tutorial_solving_tips_step_one_copy,
             highlightedTargets = listOf(
@@ -50,7 +49,6 @@ internal object SolvingTipsPracticeContent {
             )
         ),
         TutorialStep(
-            order = 7,
             scenarioId = TutorialScenarioId.SOLVING_TIPS_PRACTICE,
             playerFacingCopyResId = R.string.tutorial_solving_tips_step_two_copy,
             highlightedTargets = listOf(

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
@@ -62,7 +62,6 @@ data class TutorialIntendedPair(val firstStripEntryId: Int, val secondStripEntry
 }
 
 data class TutorialStep(
-    val order: Int,
     val scenarioId: TutorialScenarioId,
     @param:StringRes val playerFacingCopyResId: Int,
     val highlightedTargets: List<TutorialHighlightTarget>,
@@ -73,9 +72,6 @@ data class TutorialStep(
     val entryPuzzle: Puzzle? = null
 ) {
     init {
-        require(order > 0) {
-            "Tutorial step order must be positive."
-        }
         require(playerFacingCopyResId != 0) {
             "Tutorial step copy string resource must be defined."
         }

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -83,7 +83,6 @@ class TutorialContentTest {
         val steps = TutorialContent.stepsFor(TutorialMode.LEARN_BASICS)
         val introductionWithCompletedStrip = introductionScenario.initialPuzzle.withStripValue(index = 1, value = 3)
 
-        assertEquals(listOf(1, 2, 3), steps.map(TutorialStep::order))
         assertEquals(
             listOf(
                 TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
@@ -199,8 +198,6 @@ class TutorialContentTest {
     fun solving_tips_practice_requires_the_first_pair_before_the_remaining_pair() {
         val scenario = TutorialContent.scenario(TutorialScenarioId.SOLVING_TIPS_PRACTICE)
         val steps = TutorialContent.stepsFor(TutorialMode.SOLVING_TIPS_PRACTICE)
-
-        assertEquals(listOf(6, 7), steps.map(TutorialStep::order))
 
         steps[0].assertGuidedAction(
             expectedHighlights = listOf(


### PR DESCRIPTION
## Related Issue

Resolves #541

## Summary

- Remove the unused numeric order from the Tutorial step model.
- Let each mode's authored step list remain the single source of playback sequence.
- Remove structural order assertions while retaining behavior-focused content checks.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
