### PR TITLE
[261] Remove the unused combined Tutorial step catalog

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContent.kt
@@ -6,7 +6,6 @@ object TutorialContent {
 
     val learnBasicsSteps: List<TutorialStep> = LearnBasicsTutorialContent.steps
     val solvingTipsPracticeSteps: List<TutorialStep> = SolvingTipsPracticeContent.steps
-    val steps: List<TutorialStep> = learnBasicsSteps + solvingTipsPracticeSteps
 
     fun stepsFor(mode: TutorialMode): List<TutorialStep> = when (mode) {
         TutorialMode.LEARN_BASICS -> learnBasicsSteps


### PR DESCRIPTION
## Related Issue

Resolves #542

## Summary

- Remove the unused aggregate that combined both Tutorial modes into one step list.
- Keep mode-specific lists and `stepsFor(mode)` unchanged as the supported playback API.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
