### PR TITLE
[262] Remove unused intended Tutorial pair metadata

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
@@ -91,11 +91,7 @@ internal object LearnBasicsTutorialContent {
                 ),
                 tiles = listOf(hiddenTile(result = 5)) + solvedPuzzle.board.tiles.drop(1)
             ),
-            solvedPuzzle = solvedPuzzle,
-            intendedPairs = listOf(
-                TutorialIntendedPair(firstStripEntryId = 0, secondStripEntryId = 1),
-                TutorialIntendedPair(firstStripEntryId = 2, secondStripEntryId = 3)
-            )
+            solvedPuzzle = solvedPuzzle
         )
     }
 
@@ -122,10 +118,6 @@ internal object LearnBasicsTutorialContent {
                     TileDefinition(leftStripEntryId = 2, operator = Operator.ADDITION, rightStripEntryId = 3),
                     TileDefinition(leftStripEntryId = 2, operator = Operator.MULTIPLICATION, rightStripEntryId = 3)
                 )
-            ),
-            intendedPairs = listOf(
-                TutorialIntendedPair(firstStripEntryId = 0, secondStripEntryId = 1),
-                TutorialIntendedPair(firstStripEntryId = 2, secondStripEntryId = 3)
             )
         )
     }

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/SolvingTipsPracticeContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/SolvingTipsPracticeContent.kt
@@ -105,11 +105,7 @@ internal object SolvingTipsPracticeContent {
                     hiddenTile(result = 12)
                 )
             ),
-            solvedPuzzle = solvedPuzzle,
-            intendedPairs = listOf(
-                TutorialIntendedPair(firstStripEntryId = 0, secondStripEntryId = 1),
-                TutorialIntendedPair(firstStripEntryId = 2, secondStripEntryId = 3)
-            )
+            solvedPuzzle = solvedPuzzle
         )
     }
 }

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
@@ -19,8 +19,7 @@ data class TutorialScenario(
     val id: TutorialScenarioId,
     val stripValues: List<Int>,
     val initialPuzzle: Puzzle,
-    val solvedPuzzle: Puzzle,
-    val intendedPairs: List<TutorialIntendedPair>
+    val solvedPuzzle: Puzzle
 ) {
     init {
         require(initialPuzzle.strip.entries.size == stripValues.size) {
@@ -45,20 +44,6 @@ enum class TutorialScenarioId {
     STRIP_AND_TILES_INTRODUCTION,
     REPEATED_VALUE_PRACTICE,
     SOLVING_TIPS_PRACTICE
-}
-
-data class TutorialIntendedPair(val firstStripEntryId: Int, val secondStripEntryId: Int) {
-    init {
-        require(firstStripEntryId >= 0) {
-            "First tutorial pair strip entry id must be non-negative."
-        }
-        require(secondStripEntryId >= 0) {
-            "Second tutorial pair strip entry id must be non-negative."
-        }
-        require(firstStripEntryId != secondStripEntryId) {
-            "Tutorial pairs must use two different strip entries."
-        }
-    }
 }
 
 data class TutorialStep(


### PR DESCRIPTION
## Related Issue

Resolves #543

## Summary

- Remove the unread `TutorialScenario.intendedPairs` metadata.
- Delete `TutorialIntendedPair` and its now-unused local invariants.
- Keep each scenario's solved puzzle as the authoritative representation of pair relationships.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
