### PR TITLE
[263] Align Tutorial Step 2 with normal tile interactions

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -128,6 +128,49 @@ class TutorialRouteTest {
     }
 
     @Test
+    fun stepTwoOffersNormalChoicesAndAcceptsReversedOperands() {
+        setContent(startStepIndex = 1)
+
+        openTileOperatorMenu(tileIndex = 0)
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileOperatorOption(Operator.ADDITION), useUnmergedTree = true)
+            .assertIsEnabled()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileOperatorOption(Operator.MULTIPLICATION), useUnmergedTree = true)
+            .assertIsEnabled()
+            .performClick()
+
+        chooseTileOperand(tileIndex = 0, isLeftOperand = true, stripEntryId = 1)
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileOperandOption(0), useUnmergedTree = true)
+            .assertIsEnabled()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileOperandOption(1), useUnmergedTree = true)
+            .assertIsEnabled()
+            .performClick()
+        chooseTileOperand(tileIndex = 0, isLeftOperand = false, stripEntryId = 0)
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileOperandOption(0), useUnmergedTree = true)
+            .performClick()
+
+        composeTestRule.mainClock.advanceTimeBy(TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS)
+        assertStepDisplayed(stepIndex = 1)
+        assertTileExpression(
+            tileIndex = 0,
+            operator = Operator.MULTIPLICATION,
+            leftValue = "3",
+            rightValue = "2"
+        )
+
+        openTileOperatorMenu(tileIndex = 0)
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileOperatorOption(Operator.ADDITION), useUnmergedTree = true)
+            .performClick()
+
+        waitForStep(stepIndex = 2)
+    }
+
+    @Test
     fun stepThreeUsesNormalPuzzleInteractionsAndCompletesLearnBasicsWithoutShowingSuccess() {
         setContent()
 
@@ -247,10 +290,15 @@ class TutorialRouteTest {
             .assertIsDisplayed()
     }
 
-    private fun setContent(onStepCompleted: suspend (Int) -> Unit = {}, onTutorialCompleted: (() -> Unit)? = null) {
+    private fun setContent(
+        startStepIndex: Int = 0,
+        onStepCompleted: suspend (Int) -> Unit = {},
+        onTutorialCompleted: (() -> Unit)? = null
+    ) {
         composeTestRule.setContent {
             NumPairsTheme {
                 TutorialRoute(
+                    startStepIndex = startStepIndex,
                     onStepCompleted = onStepCompleted,
                     onTutorialCompleted = onTutorialCompleted
                 )

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
@@ -41,12 +41,7 @@ internal object LearnBasicsTutorialContent {
                 TutorialHighlightTarget.TileExpressionSlots(tileIndex = 0),
                 TutorialHighlightTarget.WholeTile(tileIndex = 1)
             ),
-            requiredAction = TutorialRequiredAction.CompleteTileExpression(
-                tileIndex = 0,
-                leftStripEntryId = 0,
-                operator = Operator.ADDITION,
-                rightStripEntryId = 1
-            ),
+            requiredAction = TutorialRequiredAction.CompleteTileWithNormalInteractions(tileIndex = 0),
             completionPredicate = TutorialStepCompletionPredicate.TileExpressionCompleted(
                 tileIndex = 0,
                 leftValue = 2,

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
@@ -113,6 +113,14 @@ sealed interface TutorialRequiredAction {
         }
     }
 
+    data class CompleteTileWithNormalInteractions(val tileIndex: Int) : TutorialRequiredAction {
+        init {
+            require(tileIndex >= 0) {
+                "Tutorial tile action index must be non-negative."
+            }
+        }
+    }
+
     data class CompleteTileExpression(
         val tileIndex: Int,
         val leftStripEntryId: Int,
@@ -204,10 +212,14 @@ sealed interface TutorialStepCompletionPredicate {
 
         override fun isSatisfiedBy(uiState: GameUiState): Boolean {
             val tile = uiState.tiles.getOrNull(tileIndex) ?: return false
+            val expectedLeftValue = leftValue.toString()
+            val expectedRightValue = rightValue.toString()
+            val matchesAuthoredOrder =
+                tile.leftOperandLabel == expectedLeftValue && tile.rightOperandLabel == expectedRightValue
+            val matchesReversedOrder =
+                tile.leftOperandLabel == expectedRightValue && tile.rightOperandLabel == expectedLeftValue
 
-            return tile.leftOperandLabel == leftValue.toString() &&
-                tile.operatorLabel == operator.symbol &&
-                tile.rightOperandLabel == rightValue.toString()
+            return (matchesAuthoredOrder || matchesReversedOrder) && tile.operatorLabel == operator.symbol
         }
     }
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -256,6 +256,7 @@ private fun TutorialRequiredAction.toInteractionPolicy(
         scenario = scenario,
         highlightedStripEntryIds = highlightedStripEntryIds
     )
+    is TutorialRequiredAction.CompleteTileWithNormalInteractions -> toInteractionPolicy()
     is TutorialRequiredAction.CompleteTileExpressions -> toInteractionPolicy(
         scenario = scenario,
         highlightedStripEntryIds = highlightedStripEntryIds
@@ -266,6 +267,18 @@ private fun TutorialRequiredAction.toInteractionPolicy(
     )
     TutorialRequiredAction.CompleteScenario -> GameInteractionPolicy.AllowAll
 }
+
+private fun TutorialRequiredAction.CompleteTileWithNormalInteractions.toInteractionPolicy(): GameInteractionPolicy =
+    GameInteractionPolicy(
+        canTapStripItem = { false },
+        canConfirmStripItemEntry = { _, _ -> false },
+        canTapTileLeftOperand = { index -> index == tileIndex },
+        canTapTileRightOperand = { index -> index == tileIndex },
+        canTapTileOperator = { index -> index == tileIndex },
+        canTapTileReset = { index -> index == tileIndex },
+        canConfirmTileOperand = { index, _, _ -> index == tileIndex },
+        canConfirmTileOperator = { index, _ -> index == tileIndex }
+    )
 
 private fun TutorialRequiredAction.CompleteTileExpression.toInteractionPolicy(
     scenario: TutorialScenario,

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -3,6 +3,7 @@ package org.cescfe.numpairs.feature.tutorial
 import org.cescfe.numpairs.R
 import org.cescfe.numpairs.domain.puzzle.model.Board
 import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.OperandSlot
 import org.cescfe.numpairs.domain.puzzle.model.Operator
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.domain.puzzle.model.PuzzleCompletionState
@@ -11,6 +12,7 @@ import org.cescfe.numpairs.domain.puzzle.model.Tile
 import org.cescfe.numpairs.feature.game.GameTileExpressionSlot
 import org.cescfe.numpairs.feature.game.GameTileExpressionSlotHighlight
 import org.cescfe.numpairs.feature.game.presentation.GameUiState
+import org.cescfe.numpairs.feature.game.presentation.TileUiState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -108,12 +110,7 @@ class TutorialContentTest {
                 TutorialHighlightTarget.TileExpressionSlots(tileIndex = 0),
                 TutorialHighlightTarget.WholeTile(tileIndex = 1)
             ),
-            expectedAction = TutorialRequiredAction.CompleteTileExpression(
-                tileIndex = 0,
-                leftStripEntryId = 0,
-                operator = Operator.ADDITION,
-                rightStripEntryId = 1
-            ),
+            expectedAction = TutorialRequiredAction.CompleteTileWithNormalInteractions(tileIndex = 0),
             incompletePuzzle = introductionWithCompletedStrip,
             completePuzzle = introductionWithCompletedStrip.withSolvedScenarioTiles(introductionScenario, 0)
         )
@@ -149,6 +146,40 @@ class TutorialContentTest {
         assertFalse(highlightState.isTileHighlighted(index = 0))
         assertFalse(highlightState.isTileHighlighted(index = 2))
         assertFalse(highlightState.isTileHighlighted(index = 3))
+    }
+
+    @Test
+    fun learn_basics_step_two_keeps_normal_choices_for_the_target_tile() {
+        val scenario = TutorialContent.scenario(TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION)
+        val policy = TutorialContent.learnBasicsSteps[1].toInteractionPolicy(scenario = scenario, uiState = null)
+
+        OperandSlot.entries.forEach { slot ->
+            assertTrue(policy.canConfirmTileOperand(0, slot, 0))
+            assertTrue(policy.canConfirmTileOperand(0, slot, 1))
+            assertFalse(policy.canConfirmTileOperand(1, slot, 0))
+        }
+        assertTrue(policy.canTapTileLeftOperand(0))
+        assertTrue(policy.canTapTileRightOperand(0))
+        assertTrue(policy.canTapTileOperator(0))
+        assertTrue(policy.canTapTileReset(0))
+        assertTrue(policy.canConfirmTileOperator(0, Operator.ADDITION))
+        assertTrue(policy.canConfirmTileOperator(0, Operator.MULTIPLICATION))
+        assertFalse(policy.canTapStripItem(0))
+        assertFalse(policy.canTapTileLeftOperand(1))
+        assertFalse(policy.canTapTileRightOperand(1))
+        assertFalse(policy.canTapTileOperator(1))
+        assertFalse(policy.canTapTileReset(1))
+        assertFalse(policy.canConfirmTileOperator(1, Operator.ADDITION))
+    }
+
+    @Test
+    fun learn_basics_step_two_accepts_the_pair_in_either_operand_order() {
+        val step = TutorialContent.learnBasicsSteps[1]
+
+        assertTrue(step.isComplete(stepTwoUiState(leftValue = 2, operator = Operator.ADDITION, rightValue = 3)))
+        assertTrue(step.isComplete(stepTwoUiState(leftValue = 3, operator = Operator.ADDITION, rightValue = 2)))
+        assertFalse(step.isComplete(stepTwoUiState(leftValue = 3, operator = Operator.MULTIPLICATION, rightValue = 2)))
+        assertFalse(step.isComplete(stepTwoUiState(leftValue = 2, operator = Operator.ADDITION, rightValue = 4)))
     }
 
     @Test
@@ -255,7 +286,35 @@ class TutorialContentTest {
             completePuzzle = scenario.solvedPuzzle
         )
     }
+
+    @Test
+    fun solving_tips_practice_keeps_its_guided_expression_choices() {
+        val scenario = TutorialContent.scenario(TutorialScenarioId.SOLVING_TIPS_PRACTICE)
+        val policy = TutorialContent.solvingTipsPracticeSteps[0].toInteractionPolicy(
+            scenario = scenario,
+            uiState = null
+        )
+
+        assertTrue(policy.canConfirmTileOperand(0, OperandSlot.LEFT, 0))
+        assertFalse(policy.canConfirmTileOperand(0, OperandSlot.LEFT, 1))
+        assertTrue(policy.canConfirmTileOperand(0, OperandSlot.RIGHT, 1))
+        assertFalse(policy.canConfirmTileOperand(0, OperandSlot.RIGHT, 0))
+        assertTrue(policy.canConfirmTileOperator(0, Operator.ADDITION))
+        assertFalse(policy.canConfirmTileOperator(0, Operator.MULTIPLICATION))
+    }
 }
+
+private fun stepTwoUiState(leftValue: Int, operator: Operator, rightValue: Int): GameUiState = GameUiState(
+    stripItems = emptyList(),
+    tiles = listOf(
+        TileUiState(
+            leftOperandLabel = leftValue.toString(),
+            operatorLabel = operator.symbol,
+            rightOperandLabel = rightValue.toString(),
+            resultLabel = "5"
+        )
+    )
+)
 
 private fun assertAllTilesHaveHiddenExpressions(puzzle: Puzzle) {
     assertTrue(

--- a/docs/product/prd/prd-v6.md
+++ b/docs/product/prd/prd-v6.md
@@ -140,7 +140,9 @@ Explain that a tile has two operands, one operator, and a visible result. Explai
 
 Required action:
 
-- complete the unresolved tile as `2 + 3 = 5` using the normal operand and operator interactions
+- use the normal operand selector to place `2` and `3` in either operand slot
+- expose both supported operations in the operator selector so the player can explore the normal choice
+- complete the unresolved tile as either `2 + 3 = 5` or `3 + 2 = 5`
 
 The resolved `2 × 3 = 6` tile acts as the complementary example for the same pair.
 


### PR DESCRIPTION
## Related Issue

Resolves #548

## Summary

- Let Learn Basics Step 2 use the normal operand and operator choices on its unresolved tile.
- Accept both `2 + 3 = 5` and `3 + 2 = 5` while keeping incorrect expressions on the current step.
- Preserve the stricter Solving Tips policies and document the updated v6 behavior.

## UI Consistency

- Shared components or tokens reused: the existing `GameRoute`, operand selection sheet, operator selection menu, and NumPairs game styling.
- Intentional deviations from established visual roles: none.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew lintDebug`
