### PR TITLE
[265] Stabilize Tutorial progress checkpoints

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -200,11 +200,11 @@ class TutorialRouteTest {
     }
 
     @Test
-    fun uninterruptedStepCompletionIsReportedExactlyOnce() {
+    fun uninterruptedProgressCheckpointIsReportedExactlyOnce() {
         val stepOneCompletionCount = AtomicInteger(0)
         setContent(
-            onStepCompleted = { stepIndex ->
-                if (stepIndex == 0) {
+            onProgressCheckpointReached = { progressCheckpoint ->
+                if (progressCheckpoint == TutorialProgressCheckpoint.STRIP_INTRODUCTION_COMPLETED) {
                     stepOneCompletionCount.incrementAndGet()
                 }
             }
@@ -292,14 +292,14 @@ class TutorialRouteTest {
 
     private fun setContent(
         startStepIndex: Int = 0,
-        onStepCompleted: suspend (Int) -> Unit = {},
+        onProgressCheckpointReached: suspend (TutorialProgressCheckpoint) -> Unit = {},
         onTutorialCompleted: (() -> Unit)? = null
     ) {
         composeTestRule.setContent {
             NumPairsTheme {
                 TutorialRoute(
                     startStepIndex = startStepIndex,
-                    onStepCompleted = onStepCompleted,
+                    onProgressCheckpointReached = onProgressCheckpointReached,
                     onTutorialCompleted = onTutorialCompleted
                 )
             }

--- a/app/src/main/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRoute.kt
@@ -20,7 +20,10 @@ import org.cescfe.numpairs.R
 import org.cescfe.numpairs.data.onboarding.OnboardingRepository
 import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
 import org.cescfe.numpairs.data.onboarding.OnboardingState
+import org.cescfe.numpairs.feature.tutorial.TutorialContent
+import org.cescfe.numpairs.feature.tutorial.TutorialProgressCheckpoint
 import org.cescfe.numpairs.feature.tutorial.TutorialRoute
+import org.cescfe.numpairs.feature.tutorial.TutorialStep
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 
 @Composable
@@ -45,10 +48,8 @@ fun RequiredOnboardingRoute(
         modifier = modifier,
         startStepIndex = startStepIndex,
         saveProgressAcrossRecreation = false,
-        onStepCompleted = { completedStepIndex ->
-            completedStepIndex.toIntermediateCheckpointOrNull()?.let { checkpoint ->
-                onboardingRepository.recordStageCompleted(checkpoint)
-            }
+        onProgressCheckpointReached = { progressCheckpoint ->
+            onboardingRepository.recordStageCompleted(progressCheckpoint.toOnboardingStageCheckpoint())
         },
         onTutorialCompleted = {
             coroutineScope.launch {
@@ -137,16 +138,30 @@ private fun SkipTutorialConfirmationDialog(
     )
 }
 
-internal fun OnboardingState.nextRequiredTutorialStepIndex(): Int = when (lastCompletedStage) {
-    OnboardingStageCheckpoint.NONE -> 0
-    OnboardingStageCheckpoint.STAGE_ONE -> 1
-    OnboardingStageCheckpoint.STAGE_TWO -> 2
+internal fun OnboardingState.nextRequiredTutorialStepIndex(
+    steps: List<TutorialStep> = TutorialContent.learnBasicsSteps
+): Int {
+    val completedCheckpoint = lastCompletedStage.toTutorialProgressCheckpointOrNull() ?: return 0
+    val completedStepIndex = steps.indexOfFirst { step ->
+        step.progressCheckpoint == completedCheckpoint
+    }
+
+    require(completedStepIndex >= 0) {
+        "Persisted onboarding checkpoint must resolve to Learn Basics content."
+    }
+
+    return completedStepIndex + 1
 }
 
-private fun Int.toIntermediateCheckpointOrNull(): OnboardingStageCheckpoint? = when (this) {
-    0 -> OnboardingStageCheckpoint.STAGE_ONE
-    1 -> OnboardingStageCheckpoint.STAGE_TWO
-    else -> null
+private fun OnboardingStageCheckpoint.toTutorialProgressCheckpointOrNull(): TutorialProgressCheckpoint? = when (this) {
+    OnboardingStageCheckpoint.NONE -> null
+    OnboardingStageCheckpoint.STAGE_ONE -> TutorialProgressCheckpoint.STRIP_INTRODUCTION_COMPLETED
+    OnboardingStageCheckpoint.STAGE_TWO -> TutorialProgressCheckpoint.TILES_INTRODUCTION_COMPLETED
+}
+
+private fun TutorialProgressCheckpoint.toOnboardingStageCheckpoint(): OnboardingStageCheckpoint = when (this) {
+    TutorialProgressCheckpoint.STRIP_INTRODUCTION_COMPLETED -> OnboardingStageCheckpoint.STAGE_ONE
+    TutorialProgressCheckpoint.TILES_INTRODUCTION_COMPLETED -> OnboardingStageCheckpoint.STAGE_TWO
 }
 
 object RequiredOnboardingTestTags {

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
@@ -31,6 +31,7 @@ internal object LearnBasicsTutorialContent {
                 stripEntryIndex = 1,
                 value = 3
             ),
+            progressCheckpoint = TutorialProgressCheckpoint.STRIP_INTRODUCTION_COMPLETED,
             isBoardVisible = false,
             stripEntryGuidanceResId = R.string.tutorial_strip_entry_guidance
         ),
@@ -48,6 +49,7 @@ internal object LearnBasicsTutorialContent {
                 operator = Operator.ADDITION,
                 rightValue = 3
             ),
+            progressCheckpoint = TutorialProgressCheckpoint.TILES_INTRODUCTION_COMPLETED,
             entryPuzzle = completedIntroductionStripPuzzle
         ),
         TutorialStep(

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
@@ -15,6 +15,11 @@ enum class TutorialMode {
     SOLVING_TIPS_PRACTICE
 }
 
+enum class TutorialProgressCheckpoint {
+    STRIP_INTRODUCTION_COMPLETED,
+    TILES_INTRODUCTION_COMPLETED
+}
+
 data class TutorialScenario(
     val id: TutorialScenarioId,
     val stripValues: List<Int>,
@@ -52,6 +57,7 @@ data class TutorialStep(
     val highlightedTargets: List<TutorialHighlightTarget>,
     val requiredAction: TutorialRequiredAction,
     val completionPredicate: TutorialStepCompletionPredicate,
+    val progressCheckpoint: TutorialProgressCheckpoint? = null,
     val isBoardVisible: Boolean = true,
     @param:StringRes val stripEntryGuidanceResId: Int? = null,
     val entryPuzzle: Puzzle? = null

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -46,7 +46,7 @@ fun TutorialRoute(
     mode: TutorialMode = TutorialMode.LEARN_BASICS,
     startStepIndex: Int = 0,
     saveProgressAcrossRecreation: Boolean = true,
-    onStepCompleted: suspend (Int) -> Unit = {},
+    onProgressCheckpointReached: suspend (TutorialProgressCheckpoint) -> Unit = {},
     onTutorialCompleted: (() -> Unit)? = null,
     onSkipTutorialRequested: (() -> Unit)? = null,
     onNavigateBack: () -> Unit = {}
@@ -72,7 +72,7 @@ fun TutorialRoute(
         mutableIntStateOf(startStepIndex - 1)
     }
     var latestGameUiSnapshot by remember(playbackKey) { mutableStateOf<TutorialGameUiSnapshot?>(null) }
-    val currentOnStepCompleted by rememberUpdatedState(onStepCompleted)
+    val currentOnProgressCheckpointReached by rememberUpdatedState(onProgressCheckpointReached)
     val currentOnTutorialCompleted by rememberUpdatedState(onTutorialCompleted)
     val currentStep = steps[currentStepIndex]
     val currentScenario = TutorialContent.scenario(currentStep.scenarioId)
@@ -96,7 +96,9 @@ fun TutorialRoute(
 
         delay(TUTORIAL_STEP_ADVANCE_DELAY)
         lastReportedStepIndex = currentStepIndex
-        currentOnStepCompleted(currentStepIndex)
+        currentStep.progressCheckpoint?.let { checkpoint ->
+            currentOnProgressCheckpointReached(checkpoint)
+        }
         if (currentStepIndex < steps.lastIndex) {
             currentStepIndex += 1
         } else if (!hasReportedCompletion && currentOnTutorialCompleted != null) {

--- a/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
@@ -2,6 +2,7 @@ package org.cescfe.numpairs.feature.onboarding
 
 import org.cescfe.numpairs.data.onboarding.OnboardingStageCheckpoint
 import org.cescfe.numpairs.data.onboarding.OnboardingState
+import org.cescfe.numpairs.feature.tutorial.TutorialContent
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -11,6 +12,29 @@ class RequiredOnboardingRouteTest {
         assertEquals(0, state(OnboardingStageCheckpoint.NONE).nextRequiredTutorialStepIndex())
         assertEquals(1, state(OnboardingStageCheckpoint.STAGE_ONE).nextRequiredTutorialStepIndex())
         assertEquals(2, state(OnboardingStageCheckpoint.STAGE_TWO).nextRequiredTutorialStepIndex())
+    }
+
+    @Test
+    fun `resume meaning survives a non-checkpoint step insertion`() {
+        val stepsWithInsertedOrientation = TutorialContent.learnBasicsSteps.toMutableList().apply {
+            add(
+                index = 0,
+                element = first().copy(progressCheckpoint = null)
+            )
+        }
+
+        assertEquals(
+            2,
+            state(OnboardingStageCheckpoint.STAGE_ONE).nextRequiredTutorialStepIndex(
+                steps = stepsWithInsertedOrientation
+            )
+        )
+        assertEquals(
+            3,
+            state(OnboardingStageCheckpoint.STAGE_TWO).nextRequiredTutorialStepIndex(
+                steps = stepsWithInsertedOrientation
+            )
+        )
     }
 
     private fun state(checkpoint: OnboardingStageCheckpoint): OnboardingState = OnboardingState(

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -93,6 +93,14 @@ class TutorialContentTest {
             ),
             steps.map(TutorialStep::scenarioId)
         )
+        assertEquals(
+            listOf(
+                TutorialProgressCheckpoint.STRIP_INTRODUCTION_COMPLETED,
+                TutorialProgressCheckpoint.TILES_INTRODUCTION_COMPLETED,
+                null
+            ),
+            steps.map(TutorialStep::progressCheckpoint)
+        )
 
         steps[0].assertGuidedAction(
             expectedHighlights = listOf(


### PR DESCRIPTION
## Related Issue

Resolves #551

## Summary

- Give resumable Learn Basics boundaries stable semantic checkpoint identities.
- Map persisted onboarding stages to checkpoint-bearing content instead of raw list indexes.
- Prove that inserting a non-checkpoint step does not change resume meaning.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- `git diff --check`