### PR TITLE
[266] Add a manually paced Tutorial explanation

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
@@ -66,7 +66,7 @@ class AppNavigationLearningFlowTest {
                     .assert(hasText(string(R.string.menu_tutorial_button)))
                     .performClick()
                 composeTestRule
-                    .onNodeWithText(string(R.string.tutorial_strip_introduction_copy))
+                    .onNodeWithText(string(R.string.tutorial_objective_explanation_copy))
                     .assertIsDisplayed()
 
                 pressBackUnconditionally()

--- a/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
@@ -27,6 +27,18 @@ class LocalizationResourceTest {
         )
         assertEquals("Serie", resources.getString(R.string.strip_content_description))
         assertEquals("Paso 1 de 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
+        assertTutorialExplanationCopy(
+            resources = resources,
+            objective = "Bienvenido a NumPairs. Tu objetivo es descubrir todos los números y símbolos ocultos.",
+            strip = "Esta es la serie. Sus números están ordenados de menor a mayor, " +
+                "pueden repetirse y algunos están ocultos.",
+            tile = "Cada casilla muestra un resultado. Completa la parte superior con los dos números " +
+                "y el signo que producen ese resultado.",
+            pair = "Agrupa los números de la serie por parejas. Cada pareja completa dos casillas: " +
+                "una suma y una multiplicación.",
+            previous = "Atrás",
+            next = "Siguiente"
+        )
         assertTutorialCopy(
             resources = resources,
             stepOne = "La lista de números va de menor a mayor. " +
@@ -61,6 +73,18 @@ class LocalizationResourceTest {
         )
         assertEquals("Sèrie", resources.getString(R.string.strip_content_description))
         assertEquals("Pas 1 de 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
+        assertTutorialExplanationCopy(
+            resources = resources,
+            objective = "Benvingut a NumPairs. L’objectiu és descobrir tots els nombres i símbols ocults.",
+            strip = "Aquesta és la sèrie. Els nombres estan ordenats de menor a major, " +
+                "es poden repetir i alguns estan ocults.",
+            tile = "Cada casella mostra un resultat. Completa la part superior amb els dos nombres " +
+                "i el signe que produeixen aquest resultat.",
+            pair = "Agrupa els nombres de la sèrie per parelles. Cada parella completa dues caselles: " +
+                "una suma i una multiplicació.",
+            previous = "Enrere",
+            next = "Següent"
+        )
         assertTutorialCopy(
             resources = resources,
             stepOne = "La llista de números va de menor a major. " +
@@ -95,6 +119,18 @@ class LocalizationResourceTest {
         )
         assertEquals("Strip", resources.getString(R.string.strip_content_description))
         assertEquals("Step 1 of 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
+        assertTutorialExplanationCopy(
+            resources = resources,
+            objective = "Welcome to NumPairs. Your goal is to discover every hidden number and symbol.",
+            strip = "This is the number strip. Its numbers are ordered from lowest to highest, " +
+                "may repeat, and some are hidden.",
+            tile = "Each tile shows a result. Complete its top row with the two numbers and symbol " +
+                "that produce that result.",
+            pair = "Group the strip numbers into pairs. Each pair completes two tiles: " +
+                "one addition and one multiplication.",
+            previous = "Back",
+            next = "Next"
+        )
         assertTutorialCopy(
             resources = resources,
             stepOne = "The number list goes from smallest to largest. " +
@@ -123,6 +159,23 @@ class LocalizationResourceTest {
         assertEquals(stepOneGuidance, resources.getString(R.string.tutorial_strip_entry_guidance))
         assertEquals(stepTwo, resources.getString(R.string.tutorial_tiles_introduction_copy))
         assertEquals(stepThree, resources.getString(R.string.tutorial_repeated_value_practice_copy))
+    }
+
+    private fun assertTutorialExplanationCopy(
+        resources: Resources,
+        objective: String,
+        strip: String,
+        tile: String,
+        pair: String,
+        previous: String,
+        next: String
+    ) {
+        assertEquals(objective, resources.getString(R.string.tutorial_objective_explanation_copy))
+        assertEquals(strip, resources.getString(R.string.tutorial_strip_explanation_copy))
+        assertEquals(tile, resources.getString(R.string.tutorial_tile_explanation_copy))
+        assertEquals(pair, resources.getString(R.string.tutorial_pair_explanation_copy))
+        assertEquals(previous, resources.getString(R.string.tutorial_previous_step_action))
+        assertEquals(next, resources.getString(R.string.tutorial_next_step_action))
     }
 
     private fun resourcesFor(languageTag: String): Resources {

--- a/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
@@ -62,7 +62,7 @@ class RequiredOnboardingNavigationTest {
 
         composeTestRule
             .onNodeWithTag(TutorialScreenTestTags.STEP_COPY)
-            .assert(hasText(string(R.string.tutorial_strip_introduction_copy)))
+            .assert(hasText(string(R.string.tutorial_objective_explanation_copy)))
         assertRequiredSkipActionDisplayed()
         assertRequiredSkipActionPositionedOutsideInstruction()
         composeTestRule
@@ -112,6 +112,7 @@ class RequiredOnboardingNavigationTest {
         val repository = FakeOnboardingRepository(incompleteOnboardingState())
         setContent(repository)
 
+        advanceThroughExplanation()
         enterStripValue(index = 1, value = "3")
         waitForTutorialCopy(R.string.tutorial_tiles_introduction_copy)
         assertEquals(OnboardingStageCheckpoint.STAGE_ONE, repository.onboardingState.value.lastCompletedStage)
@@ -233,7 +234,7 @@ class RequiredOnboardingNavigationTest {
             .assertDoesNotExist()
         composeTestRule
             .onNodeWithTag(TutorialScreenTestTags.STEP_COPY)
-            .assert(hasText(string(R.string.tutorial_strip_introduction_copy)))
+            .assert(hasText(string(R.string.tutorial_objective_explanation_copy)))
         composeTestRule
             .onNodeWithTag(MenuScreenTestTags.SCREEN)
             .assertDoesNotExist()
@@ -251,6 +252,15 @@ class RequiredOnboardingNavigationTest {
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.STRIP_ENTRY_INPUT)
             .performImeAction()
+    }
+
+    private fun advanceThroughExplanation() {
+        repeat(4) {
+            composeTestRule
+                .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+                .performScrollTo()
+                .performClick()
+        }
     }
 
     private fun completeTile(tileIndex: Int, leftStripEntryId: Int, operator: Operator, rightStripEntryId: Int) {

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
@@ -16,6 +17,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.util.concurrent.atomic.AtomicInteger
 import org.cescfe.numpairs.R
@@ -25,6 +27,7 @@ import org.cescfe.numpairs.feature.game.ui.semantics.GameHighlightedKey
 import org.cescfe.numpairs.feature.tutorial.ui.TutorialScreenTestTags
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -41,14 +44,33 @@ class TutorialRouteTest {
         composeTestRule
             .onNodeWithTag(TutorialScreenTestTags.INSTRUCTION_SURFACE)
             .assertIsDisplayed()
-        assertStepDisplayed(stepIndex = 0)
+        assertStepDisplayed(stepIndex = OBJECTIVE_EXPLANATION_STEP_INDEX)
         assertFocusedIntroductionStripDisplayed()
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.BOARD)
-            .assertDoesNotExist()
+            .assertIsDisplayed()
         assertNoRequiredSkipAction()
-        assertHighlighted(testTag = GameScreenTestTags.stripItem(1))
-        assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(0))
+        repeat(4) { index ->
+            assertHighlighted(testTag = GameScreenTestTags.stripItem(index))
+            assertHighlighted(testTag = GameScreenTestTags.tile(index), useUnmergedTree = true)
+            assertTileExpressionHidden(tileIndex = index)
+        }
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.PREVIOUS_STEP_ACTION)
+            .assertIsDisplayed()
+            .assertIsNotEnabled()
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .assertIsDisplayed()
+            .assertIsEnabled()
+        val minimumTouchTargetHeight = with(composeTestRule.density) { 48.dp.toPx() }
+        assertTrue(
+            composeTestRule
+                .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+                .fetchSemanticsNode()
+                .boundsInRoot
+                .height >= minimumTouchTargetHeight
+        )
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.RULES_HELPER_ACTION)
             .assertDoesNotExist()
@@ -58,20 +80,48 @@ class TutorialRouteTest {
     }
 
     @Test
-    fun tutorialDoesNotAdvanceBeforeTheRequiredActionIsCompleted() {
+    fun explanationUsesManualForwardAndBackwardNavigation() {
         setContent()
 
         composeTestRule
-            .onNodeWithTag(GameScreenTestTags.stripItem(0))
-            .assertHasNoClickAction()
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .performClick()
+        assertStepDisplayed(stepIndex = STRIP_EXPLANATION_STEP_INDEX)
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.PREVIOUS_STEP_ACTION)
+            .assertIsEnabled()
+            .performClick()
+        assertStepDisplayed(stepIndex = OBJECTIVE_EXPLANATION_STEP_INDEX)
         composeTestRule.mainClock.advanceTimeBy(TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS)
 
-        assertStepDisplayed(stepIndex = 0)
+        assertStepDisplayed(stepIndex = OBJECTIVE_EXPLANATION_STEP_INDEX)
+    }
+
+    @Test
+    fun explanationFreezesPuzzleInteractionsAndFocusesOneConceptAtATime() {
+        setContent()
+
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.stripItem(1))
+            .assertHasNoClickAction()
+        assertTileExpressionSlotsHaveNoClickAction(tileIndex = 0)
+
+        navigateToExplanationStep(PAIR_EXPLANATION_STEP_INDEX)
+
+        assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(0))
+        assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(1))
+        assertHighlighted(testTag = GameScreenTestTags.stripItem(2))
+        assertHighlighted(testTag = GameScreenTestTags.stripItem(3))
+        assertUnmergedNodeNotHighlighted(testTag = GameScreenTestTags.tile(0))
+        assertUnmergedNodeNotHighlighted(testTag = GameScreenTestTags.tile(1))
+        assertHighlighted(testTag = GameScreenTestTags.tile(2), useUnmergedTree = true)
+        assertHighlighted(testTag = GameScreenTestTags.tile(3), useUnmergedTree = true)
     }
 
     @Test
     fun stepOneShowsTutorialGuidanceAndKeepsInvalidRangeFeedbackTruthful() {
         setContent()
+        advanceThroughExplanation()
 
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.stripItem(1))
@@ -86,17 +136,18 @@ class TutorialRouteTest {
             .onNodeWithTag(GameScreenTestTags.STRIP_ENTRY_RANGE)
             .assert(hasText(string(R.string.strip_entry_invalid_range_bounded, 2, 4)))
 
-        assertStepDisplayed(stepIndex = 0)
+        assertStepDisplayed(stepIndex = GUIDED_STRIP_STEP_INDEX)
     }
 
     @Test
     fun stepOnePreservesTheEnteredStripWhenStepTwoRevealsTheAuthoredTiles() {
         setContent()
+        advanceThroughExplanation()
 
         completeFocusedStepOne()
 
-        waitForStep(stepIndex = 1)
-        assertStepDisplayed(stepIndex = 1)
+        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
+        assertStepDisplayed(stepIndex = GUIDED_TILE_STEP_INDEX)
         assertFocusedIntroductionStripDisplayed(expectedSecondValue = "3", isSecondValuePlayerEntered = true)
         assertTileResult(tileIndex = 0, result = 5)
         assertTileExpressionHidden(tileIndex = 0)
@@ -114,13 +165,14 @@ class TutorialRouteTest {
     @Test
     fun completingStepTwoStartsTheCleanRepeatedValuePuzzle() {
         setContent()
+        advanceThroughExplanation()
 
         completeFocusedStepOne()
-        waitForStep(stepIndex = 1)
+        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
         completeTile(tileIndex = 0, leftStripEntryId = 0, operator = Operator.ADDITION, rightStripEntryId = 1)
-        waitForStep(stepIndex = 2)
+        waitForStep(stepIndex = PRACTICE_STEP_INDEX)
 
-        assertStepDisplayed(stepIndex = 2)
+        assertStepDisplayed(stepIndex = PRACTICE_STEP_INDEX)
         assertRepeatedValuePracticeScenarioDisplayed()
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY)
@@ -129,7 +181,7 @@ class TutorialRouteTest {
 
     @Test
     fun stepTwoOffersNormalChoicesAndAcceptsReversedOperands() {
-        setContent(startStepIndex = 1)
+        setContent(startStepIndex = GUIDED_TILE_STEP_INDEX)
 
         openTileOperatorMenu(tileIndex = 0)
         composeTestRule
@@ -154,7 +206,7 @@ class TutorialRouteTest {
             .performClick()
 
         composeTestRule.mainClock.advanceTimeBy(TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS)
-        assertStepDisplayed(stepIndex = 1)
+        assertStepDisplayed(stepIndex = GUIDED_TILE_STEP_INDEX)
         assertTileExpression(
             tileIndex = 0,
             operator = Operator.MULTIPLICATION,
@@ -167,7 +219,7 @@ class TutorialRouteTest {
             .onNodeWithTag(GameScreenTestTags.tileOperatorOption(Operator.ADDITION), useUnmergedTree = true)
             .performClick()
 
-        waitForStep(stepIndex = 2)
+        waitForStep(stepIndex = PRACTICE_STEP_INDEX)
     }
 
     @Test
@@ -210,8 +262,9 @@ class TutorialRouteTest {
             }
         )
 
+        advanceThroughExplanation()
         completeFocusedStepOne()
-        waitForStep(stepIndex = 1)
+        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
         composeTestRule.mainClock.advanceTimeBy(TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS)
 
         assertEquals(1, stepOneCompletionCount.get())
@@ -220,16 +273,18 @@ class TutorialRouteTest {
     @Test
     fun reopeningAfterClosingOnStepTwoAllowsStepOneToAdvanceAgain() {
         val restartTutorial = setRestartableContent()
+        advanceThroughExplanation()
         completeFocusedStepOne()
-        waitForStep(stepIndex = 1)
+        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
 
         restartTutorial()
-        assertStepDisplayed(stepIndex = 0)
+        assertStepDisplayed(stepIndex = OBJECTIVE_EXPLANATION_STEP_INDEX)
         assertFocusedIntroductionStripDisplayed()
+        advanceThroughExplanation()
         completeFocusedStepOne()
 
-        waitForStep(stepIndex = 1)
-        assertStepDisplayed(stepIndex = 1)
+        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
+        assertStepDisplayed(stepIndex = GUIDED_TILE_STEP_INDEX)
     }
 
     @Test
@@ -239,12 +294,13 @@ class TutorialRouteTest {
         composeTestRule.mainClock.advanceTimeBy(TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS)
 
         restartTutorial()
-        assertStepDisplayed(stepIndex = 0)
+        assertStepDisplayed(stepIndex = OBJECTIVE_EXPLANATION_STEP_INDEX)
         assertFocusedIntroductionStripDisplayed()
+        advanceThroughExplanation()
         completeFocusedStepOne()
 
-        waitForStep(stepIndex = 1)
-        assertStepDisplayed(stepIndex = 1)
+        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
+        assertStepDisplayed(stepIndex = GUIDED_TILE_STEP_INDEX)
     }
 
     @Test
@@ -356,10 +412,11 @@ class TutorialRouteTest {
     }
 
     private fun completeFocusedTutorial() {
+        advanceThroughExplanation()
         completeFocusedStepOne()
-        waitForStep(stepIndex = 1)
+        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
         completeTile(tileIndex = 0, leftStripEntryId = 0, operator = Operator.ADDITION, rightStripEntryId = 1)
-        waitForStep(stepIndex = 2)
+        waitForStep(stepIndex = PRACTICE_STEP_INDEX)
 
         enterStripValue(index = 0, value = "1")
         enterStripValue(index = 1, value = "2")
@@ -367,6 +424,28 @@ class TutorialRouteTest {
         completeTile(tileIndex = 1, leftStripEntryId = 0, operator = Operator.MULTIPLICATION, rightStripEntryId = 1)
         completeTile(tileIndex = 2, leftStripEntryId = 2, operator = Operator.ADDITION, rightStripEntryId = 3)
         completeTile(tileIndex = 3, leftStripEntryId = 2, operator = Operator.MULTIPLICATION, rightStripEntryId = 3)
+    }
+
+    private fun advanceThroughExplanation() {
+        repeat(GUIDED_STRIP_STEP_INDEX) {
+            composeTestRule
+                .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+                .performScrollTo()
+                .performClick()
+        }
+        assertStepDisplayed(stepIndex = GUIDED_STRIP_STEP_INDEX)
+    }
+
+    private fun navigateToExplanationStep(stepIndex: Int) {
+        require(stepIndex in OBJECTIVE_EXPLANATION_STEP_INDEX..PAIR_EXPLANATION_STEP_INDEX)
+
+        repeat(stepIndex) {
+            composeTestRule
+                .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+                .performScrollTo()
+                .performClick()
+        }
+        assertStepDisplayed(stepIndex = stepIndex)
     }
 
     private fun enterStripValue(index: Int, value: String) {
@@ -616,6 +695,18 @@ class TutorialRouteTest {
         assertNodeNotHighlighted(testTag = GameScreenTestTags.tileRightOperand(tileIndex), useUnmergedTree = true)
     }
 
+    private fun assertTileExpressionSlotsHaveNoClickAction(tileIndex: Int) {
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileLeftOperand(tileIndex), useUnmergedTree = true)
+            .assertHasNoClickAction()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileOperator(tileIndex), useUnmergedTree = true)
+            .assertHasNoClickAction()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileRightOperand(tileIndex), useUnmergedTree = true)
+            .assertHasNoClickAction()
+    }
+
     private fun assertNodeNotHighlighted(testTag: String, useUnmergedTree: Boolean = false) {
         composeTestRule
             .onNodeWithTag(testTag, useUnmergedTree = useUnmergedTree)
@@ -648,6 +739,12 @@ class TutorialRouteTest {
     }
 
     private companion object {
+        const val OBJECTIVE_EXPLANATION_STEP_INDEX = 0
+        const val STRIP_EXPLANATION_STEP_INDEX = 1
+        const val PAIR_EXPLANATION_STEP_INDEX = 3
+        const val GUIDED_STRIP_STEP_INDEX = 4
+        const val GUIDED_TILE_STEP_INDEX = 5
+        const val PRACTICE_STEP_INDEX = 6
         const val TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS = 1_000L
         const val TUTORIAL_STEP_WAIT_TIMEOUT_MS = 5_000L
     }

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
@@ -7,7 +7,12 @@ import org.cescfe.numpairs.domain.puzzle.model.StripItem
 internal object LearnBasicsTutorialContent {
     private val stripAndTilesIntroductionScenario = stripAndTilesIntroductionScenario()
     private val repeatedValuePracticeScenario = repeatedValuePracticeScenario()
-    private val completedIntroductionStripPuzzle = stripAndTilesIntroductionScenario.initialPuzzle.copy(
+    private val guidedIntroductionPuzzle = stripAndTilesIntroductionScenario.initialPuzzle.copy(
+        board = stripAndTilesIntroductionScenario.initialPuzzle.board.copy(
+            tiles = listOf(hiddenTile(result = 5)) + stripAndTilesIntroductionScenario.solvedPuzzle.board.tiles.drop(1)
+        )
+    )
+    private val completedIntroductionStripPuzzle = guidedIntroductionPuzzle.copy(
         strip = stripAndTilesIntroductionScenario.initialPuzzle.strip.withUpdatedEntry(index = 1, value = 3)
     )
 
@@ -16,7 +21,7 @@ internal object LearnBasicsTutorialContent {
         repeatedValuePracticeScenario
     )
 
-    val steps: List<TutorialStep> = listOf(
+    val steps: List<TutorialStep> = explanationSteps() + listOf(
         TutorialStep(
             scenarioId = TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
             playerFacingCopyResId = R.string.tutorial_strip_introduction_copy,
@@ -33,7 +38,8 @@ internal object LearnBasicsTutorialContent {
             ),
             progressCheckpoint = TutorialProgressCheckpoint.STRIP_INTRODUCTION_COMPLETED,
             isBoardVisible = false,
-            stripEntryGuidanceResId = R.string.tutorial_strip_entry_guidance
+            stripEntryGuidanceResId = R.string.tutorial_strip_entry_guidance,
+            entryPuzzle = guidedIntroductionPuzzle
         ),
         TutorialStep(
             scenarioId = TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
@@ -64,6 +70,48 @@ internal object LearnBasicsTutorialContent {
         )
     )
 
+    private fun explanationSteps(): List<TutorialStep> = listOf(
+        manualExplanationStep(
+            copyResId = R.string.tutorial_objective_explanation_copy,
+            highlightedTargets = listOf(
+                TutorialHighlightTarget.StripEntries(indexes = listOf(0, 1, 2, 3)),
+                TutorialHighlightTarget.WholeTile(tileIndex = 0),
+                TutorialHighlightTarget.WholeTile(tileIndex = 1),
+                TutorialHighlightTarget.WholeTile(tileIndex = 2),
+                TutorialHighlightTarget.WholeTile(tileIndex = 3)
+            )
+        ),
+        manualExplanationStep(
+            copyResId = R.string.tutorial_strip_explanation_copy,
+            highlightedTargets = listOf(
+                TutorialHighlightTarget.StripEntries(indexes = listOf(0, 1, 2, 3))
+            )
+        ),
+        manualExplanationStep(
+            copyResId = R.string.tutorial_tile_explanation_copy,
+            highlightedTargets = listOf(
+                TutorialHighlightTarget.WholeTile(tileIndex = 0)
+            )
+        ),
+        manualExplanationStep(
+            copyResId = R.string.tutorial_pair_explanation_copy,
+            highlightedTargets = listOf(
+                TutorialHighlightTarget.StripEntries(indexes = listOf(2, 3)),
+                TutorialHighlightTarget.WholeTile(tileIndex = 2),
+                TutorialHighlightTarget.WholeTile(tileIndex = 3)
+            )
+        )
+    )
+
+    private fun manualExplanationStep(copyResId: Int, highlightedTargets: List<TutorialHighlightTarget>): TutorialStep =
+        TutorialStep(
+            scenarioId = TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
+            playerFacingCopyResId = copyResId,
+            highlightedTargets = highlightedTargets,
+            requiredAction = TutorialRequiredAction.NoInteraction,
+            completionPredicate = TutorialStepCompletionPredicate.ManualAdvance
+        )
+
     private fun stripAndTilesIntroductionScenario(): TutorialScenario {
         val stripValues = listOf(2, 3, 4, 5)
         val solvedPuzzle = solvedPuzzle(
@@ -86,7 +134,7 @@ internal object LearnBasicsTutorialContent {
                     StripItem.Known(4),
                     StripItem.Known(5)
                 ),
-                tiles = listOf(hiddenTile(result = 5)) + solvedPuzzle.board.tiles.drop(1)
+                tiles = hiddenTiles(results = listOf(5, 6, 9, 20))
             ),
             solvedPuzzle = solvedPuzzle
         )

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
@@ -108,6 +108,8 @@ sealed interface TutorialHighlightTarget {
 }
 
 sealed interface TutorialRequiredAction {
+    data object NoInteraction : TutorialRequiredAction
+
     data class EnterStripValue(val stripEntryIndex: Int, val value: Int) : TutorialRequiredAction {
         init {
             require(stripEntryIndex >= 0) {
@@ -176,6 +178,10 @@ sealed interface TutorialRequiredAction {
 
 sealed interface TutorialStepCompletionPredicate {
     fun isSatisfiedBy(uiState: GameUiState): Boolean
+
+    data object ManualAdvance : TutorialStepCompletionPredicate {
+        override fun isSatisfiedBy(uiState: GameUiState): Boolean = false
+    }
 
     data class StripValueEntered(val stripEntryIndex: Int, val value: Int) : TutorialStepCompletionPredicate {
         init {

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -4,12 +4,15 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -112,7 +115,7 @@ fun TutorialRoute(
         initialPuzzle = currentEntryPuzzle,
         modifier = modifier,
         gameSessionKey = "$TUTORIAL_GAME_SESSION_KEY:$playbackKey:${currentScenario.id}",
-        puzzleResetKey = playbackKey to currentScenario.id,
+        puzzleResetKey = playbackKey to currentEntryPuzzle,
         isSuccessOverlayEnabled = isTutorialSuccessOverlayEnabled(
             mode = mode,
             isFinalStep = currentStepIndex == steps.lastIndex,
@@ -140,6 +143,15 @@ fun TutorialRoute(
                 currentStep = currentStep,
                 currentStepNumber = currentStepIndex + 1,
                 totalSteps = steps.size,
+                canNavigateBack = currentStepIndex > 0,
+                onNavigateBack = {
+                    currentStepIndex -= 1
+                },
+                onNavigateNext = {
+                    if (currentStepIndex < steps.lastIndex) {
+                        currentStepIndex += 1
+                    }
+                },
                 modifier = Modifier.fillMaxWidth()
             )
         },
@@ -171,6 +183,9 @@ private fun TutorialInstructionSurface(
     currentStep: TutorialStep,
     currentStepNumber: Int,
     totalSteps: Int,
+    canNavigateBack: Boolean,
+    onNavigateBack: () -> Unit,
+    onNavigateNext: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Surface(
@@ -199,6 +214,51 @@ private fun TutorialInstructionSurface(
                 modifier = Modifier.testTag(TutorialScreenTestTags.STEP_COPY),
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurface
+            )
+            if (currentStep.completionPredicate == TutorialStepCompletionPredicate.ManualAdvance) {
+                TutorialStepNavigation(
+                    canNavigateBack = canNavigateBack,
+                    onNavigateBack = onNavigateBack,
+                    onNavigateNext = onNavigateNext
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TutorialStepNavigation(
+    canNavigateBack: Boolean,
+    onNavigateBack: () -> Unit,
+    onNavigateNext: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        TextButton(
+            onClick = onNavigateBack,
+            enabled = canNavigateBack,
+            modifier = Modifier
+                .heightIn(min = 48.dp)
+                .testTag(TutorialScreenTestTags.PREVIOUS_STEP_ACTION)
+        ) {
+            Text(
+                text = stringResource(R.string.tutorial_previous_step_action),
+                style = MaterialTheme.typography.labelLarge
+            )
+        }
+        TextButton(
+            onClick = onNavigateNext,
+            modifier = Modifier
+                .heightIn(min = 48.dp)
+                .testTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+        ) {
+            Text(
+                text = stringResource(R.string.tutorial_next_step_action),
+                style = MaterialTheme.typography.labelLarge
             )
         }
     }
@@ -242,6 +302,16 @@ private fun TutorialRequiredAction.toInteractionPolicy(
     uiState: GameUiState?,
     highlightedStripEntryIds: Set<Int>
 ): GameInteractionPolicy = when (this) {
+    TutorialRequiredAction.NoInteraction -> GameInteractionPolicy(
+        canTapStripItem = { false },
+        canConfirmStripItemEntry = { _, _ -> false },
+        canTapTileLeftOperand = { false },
+        canTapTileRightOperand = { false },
+        canTapTileOperator = { false },
+        canTapTileReset = { false },
+        canConfirmTileOperand = { _, _, _ -> false },
+        canConfirmTileOperator = { _, _ -> false }
+    )
     is TutorialRequiredAction.EnterStripValue -> GameInteractionPolicy(
         canTapStripItem = { index -> index == stripEntryIndex },
         canConfirmStripItemEntry = { index, value ->

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/ui/TutorialScreenTestTags.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/ui/TutorialScreenTestTags.kt
@@ -5,5 +5,7 @@ object TutorialScreenTestTags {
     const val INSTRUCTION_SURFACE = "tutorial_instruction_surface"
     const val STEP_INDICATOR = "tutorial_step_indicator"
     const val STEP_COPY = "tutorial_step_copy"
+    const val PREVIOUS_STEP_ACTION = "tutorial_previous_step_action"
+    const val NEXT_STEP_ACTION = "tutorial_next_step_action"
     const val SKIP_ACTION = "tutorial_skip_action"
 }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -61,6 +61,12 @@
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Pas %1$d de %2$d</string>
+    <string name="tutorial_objective_explanation_copy">Benvingut a NumPairs. L’objectiu és descobrir tots els nombres i símbols ocults.</string>
+    <string name="tutorial_strip_explanation_copy">Aquesta és la sèrie. Els nombres estan ordenats de menor a major, es poden repetir i alguns estan ocults.</string>
+    <string name="tutorial_tile_explanation_copy">Cada casella mostra un resultat. Completa la part superior amb els dos nombres i el signe que produeixen aquest resultat.</string>
+    <string name="tutorial_pair_explanation_copy">Agrupa els nombres de la sèrie per parelles. Cada parella completa dues caselles: una suma i una multiplicació.</string>
+    <string name="tutorial_previous_step_action">Enrere</string>
+    <string name="tutorial_next_step_action">Següent</string>
     <string name="tutorial_strip_introduction_copy">La llista de números va de menor a major. Un mateix número pot aparéixer més d’una vegada.</string>
     <string name="tutorial_strip_entry_guidance">Introdueix 3 per completar la sèrie del tutorial.</string>
     <string name="tutorial_tiles_introduction_copy">Cada casella mostra un resultat. Tria els números i el símbol que donen eixe resultat. Usa els mateixos dos números una vegada amb + i una altra amb ×.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -61,6 +61,12 @@
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Paso %1$d de %2$d</string>
+    <string name="tutorial_objective_explanation_copy">Bienvenido a NumPairs. Tu objetivo es descubrir todos los números y símbolos ocultos.</string>
+    <string name="tutorial_strip_explanation_copy">Esta es la serie. Sus números están ordenados de menor a mayor, pueden repetirse y algunos están ocultos.</string>
+    <string name="tutorial_tile_explanation_copy">Cada casilla muestra un resultado. Completa la parte superior con los dos números y el signo que producen ese resultado.</string>
+    <string name="tutorial_pair_explanation_copy">Agrupa los números de la serie por parejas. Cada pareja completa dos casillas: una suma y una multiplicación.</string>
+    <string name="tutorial_previous_step_action">Atrás</string>
+    <string name="tutorial_next_step_action">Siguiente</string>
     <string name="tutorial_strip_introduction_copy">La lista de números va de menor a mayor. Un mismo número puede aparecer más de una vez.</string>
     <string name="tutorial_strip_entry_guidance">Introduce 3 para completar la serie del tutorial.</string>
     <string name="tutorial_tiles_introduction_copy">Cada casilla muestra un resultado. Elige los números y el símbolo que dan ese resultado. Usa los mismos dos números una vez con + y otra con ×.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,12 @@
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Step %1$d of %2$d</string>
+    <string name="tutorial_objective_explanation_copy">Welcome to NumPairs. Your goal is to discover every hidden number and symbol.</string>
+    <string name="tutorial_strip_explanation_copy">This is the number strip. Its numbers are ordered from lowest to highest, may repeat, and some are hidden.</string>
+    <string name="tutorial_tile_explanation_copy">Each tile shows a result. Complete its top row with the two numbers and symbol that produce that result.</string>
+    <string name="tutorial_pair_explanation_copy">Group the strip numbers into pairs. Each pair completes two tiles: one addition and one multiplication.</string>
+    <string name="tutorial_previous_step_action">Back</string>
+    <string name="tutorial_next_step_action">Next</string>
     <string name="tutorial_strip_introduction_copy">The number list goes from smallest to largest. The same number can appear more than once.</string>
     <string name="tutorial_strip_entry_guidance">Enter 3 to complete the Tutorial strip.</string>
     <string name="tutorial_tiles_introduction_copy">Each tile shows a result. Choose the numbers and symbol that make it. Use the same two numbers once with + and once with ×.</string>

--- a/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
@@ -10,8 +10,8 @@ class RequiredOnboardingRouteTest {
     @Test
     fun `checkpoints resume after the last completed Tutorial step`() {
         assertEquals(0, state(OnboardingStageCheckpoint.NONE).nextRequiredTutorialStepIndex())
-        assertEquals(1, state(OnboardingStageCheckpoint.STAGE_ONE).nextRequiredTutorialStepIndex())
-        assertEquals(2, state(OnboardingStageCheckpoint.STAGE_TWO).nextRequiredTutorialStepIndex())
+        assertEquals(5, state(OnboardingStageCheckpoint.STAGE_ONE).nextRequiredTutorialStepIndex())
+        assertEquals(6, state(OnboardingStageCheckpoint.STAGE_TWO).nextRequiredTutorialStepIndex())
     }
 
     @Test
@@ -24,13 +24,13 @@ class RequiredOnboardingRouteTest {
         }
 
         assertEquals(
-            2,
+            6,
             state(OnboardingStageCheckpoint.STAGE_ONE).nextRequiredTutorialStepIndex(
                 steps = stepsWithInsertedOrientation
             )
         )
         assertEquals(
-            3,
+            7,
             state(OnboardingStageCheckpoint.STAGE_TWO).nextRequiredTutorialStepIndex(
                 steps = stepsWithInsertedOrientation
             )

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -79,14 +79,19 @@ class TutorialContentTest {
     }
 
     @Test
-    fun learn_basics_contains_the_exact_three_step_curriculum() {
+    fun learn_basics_adds_manual_explanation_before_the_existing_guided_curriculum() {
         val introductionScenario = TutorialContent.scenario(TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION)
         val repeatedValueScenario = TutorialContent.scenario(TutorialScenarioId.REPEATED_VALUE_PRACTICE)
         val steps = TutorialContent.stepsFor(TutorialMode.LEARN_BASICS)
-        val introductionWithCompletedStrip = introductionScenario.initialPuzzle.withStripValue(index = 1, value = 3)
+        val guidedIntroductionPuzzle = requireNotNull(steps[4].entryPuzzle)
+        val introductionWithCompletedStrip = guidedIntroductionPuzzle.withStripValue(index = 1, value = 3)
 
         assertEquals(
             listOf(
+                TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
+                TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
+                TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
+                TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
                 TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
                 TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
                 TutorialScenarioId.REPEATED_VALUE_PRACTICE
@@ -95,6 +100,10 @@ class TutorialContentTest {
         )
         assertEquals(
             listOf(
+                null,
+                null,
+                null,
+                null,
                 TutorialProgressCheckpoint.STRIP_INTRODUCTION_COMPLETED,
                 TutorialProgressCheckpoint.TILES_INTRODUCTION_COMPLETED,
                 null
@@ -102,18 +111,57 @@ class TutorialContentTest {
             steps.map(TutorialStep::progressCheckpoint)
         )
 
-        steps[0].assertGuidedAction(
+        assertEquals(
+            listOf(
+                R.string.tutorial_objective_explanation_copy,
+                R.string.tutorial_strip_explanation_copy,
+                R.string.tutorial_tile_explanation_copy,
+                R.string.tutorial_pair_explanation_copy
+            ),
+            steps.take(4).map(TutorialStep::playerFacingCopyResId)
+        )
+        assertEquals(
+            listOf(
+                listOf(
+                    TutorialHighlightTarget.StripEntries(indexes = listOf(0, 1, 2, 3)),
+                    TutorialHighlightTarget.WholeTile(tileIndex = 0),
+                    TutorialHighlightTarget.WholeTile(tileIndex = 1),
+                    TutorialHighlightTarget.WholeTile(tileIndex = 2),
+                    TutorialHighlightTarget.WholeTile(tileIndex = 3)
+                ),
+                listOf(
+                    TutorialHighlightTarget.StripEntries(indexes = listOf(0, 1, 2, 3))
+                ),
+                listOf(
+                    TutorialHighlightTarget.WholeTile(tileIndex = 0)
+                ),
+                listOf(
+                    TutorialHighlightTarget.StripEntries(indexes = listOf(2, 3)),
+                    TutorialHighlightTarget.WholeTile(tileIndex = 2),
+                    TutorialHighlightTarget.WholeTile(tileIndex = 3)
+                )
+            ),
+            steps.take(4).map(TutorialStep::highlightedTargets)
+        )
+        steps.take(4).forEach { step ->
+            assertEquals(TutorialRequiredAction.NoInteraction, step.requiredAction)
+            assertEquals(TutorialStepCompletionPredicate.ManualAdvance, step.completionPredicate)
+            assertTrue(step.isBoardVisible)
+            assertEquals(introductionScenario.initialPuzzle, step.entryPuzzle ?: introductionScenario.initialPuzzle)
+        }
+
+        steps[4].assertGuidedAction(
             expectedHighlights = listOf(
                 TutorialHighlightTarget.StripEntries(indexes = listOf(1))
             ),
             expectedAction = TutorialRequiredAction.EnterStripValue(stripEntryIndex = 1, value = 3),
-            incompletePuzzle = introductionScenario.initialPuzzle,
+            incompletePuzzle = guidedIntroductionPuzzle,
             completePuzzle = introductionWithCompletedStrip
         )
-        assertFalse(steps[0].isBoardVisible)
-        assertEquals(R.string.tutorial_strip_entry_guidance, steps[0].stripEntryGuidanceResId)
+        assertFalse(steps[4].isBoardVisible)
+        assertEquals(R.string.tutorial_strip_entry_guidance, steps[4].stripEntryGuidanceResId)
 
-        steps[1].assertGuidedAction(
+        steps[5].assertGuidedAction(
             expectedHighlights = listOf(
                 TutorialHighlightTarget.TileExpressionSlots(tileIndex = 0),
                 TutorialHighlightTarget.WholeTile(tileIndex = 1)
@@ -122,11 +170,11 @@ class TutorialContentTest {
             incompletePuzzle = introductionWithCompletedStrip,
             completePuzzle = introductionWithCompletedStrip.withSolvedScenarioTiles(introductionScenario, 0)
         )
-        assertTrue(steps[1].isBoardVisible)
-        assertEquals(null, steps[1].stripEntryGuidanceResId)
-        assertEquals(introductionWithCompletedStrip, steps[1].entryPuzzle)
+        assertTrue(steps[5].isBoardVisible)
+        assertEquals(null, steps[5].stripEntryGuidanceResId)
+        assertEquals(introductionWithCompletedStrip, steps[5].entryPuzzle)
 
-        steps[2].assertGuidedAction(
+        steps[6].assertGuidedAction(
             expectedHighlights = listOf(
                 TutorialHighlightTarget.HiddenStripEntries,
                 TutorialHighlightTarget.HiddenTileExpressions
@@ -138,9 +186,28 @@ class TutorialContentTest {
     }
 
     @Test
+    fun manual_explanation_freezes_every_puzzle_interaction() {
+        val scenario = TutorialContent.scenario(TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION)
+
+        TutorialContent.learnBasicsSteps.take(4).forEach { step ->
+            val policy = step.toInteractionPolicy(scenario = scenario, uiState = null)
+
+            scenario.stripValues.indices.forEach { index ->
+                assertFalse(policy.canTapStripItem(index))
+            }
+            scenario.initialPuzzle.board.tiles.indices.forEach { index ->
+                assertFalse(policy.canTapTileLeftOperand(index))
+                assertFalse(policy.canTapTileRightOperand(index))
+                assertFalse(policy.canTapTileOperator(index))
+                assertFalse(policy.canTapTileReset(index))
+            }
+        }
+    }
+
+    @Test
     fun learn_basics_step_two_highlights_the_editable_slots_and_complementary_product_tile() {
         val scenario = TutorialContent.scenario(TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION)
-        val step = TutorialContent.learnBasicsSteps[1]
+        val step = TutorialContent.learnBasicsSteps[5]
 
         val highlightState = step.toHighlightState(scenario = scenario, uiState = null)
 
@@ -159,7 +226,7 @@ class TutorialContentTest {
     @Test
     fun learn_basics_step_two_keeps_normal_choices_for_the_target_tile() {
         val scenario = TutorialContent.scenario(TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION)
-        val policy = TutorialContent.learnBasicsSteps[1].toInteractionPolicy(scenario = scenario, uiState = null)
+        val policy = TutorialContent.learnBasicsSteps[5].toInteractionPolicy(scenario = scenario, uiState = null)
 
         OperandSlot.entries.forEach { slot ->
             assertTrue(policy.canConfirmTileOperand(0, slot, 0))
@@ -182,7 +249,7 @@ class TutorialContentTest {
 
     @Test
     fun learn_basics_step_two_accepts_the_pair_in_either_operand_order() {
-        val step = TutorialContent.learnBasicsSteps[1]
+        val step = TutorialContent.learnBasicsSteps[5]
 
         assertTrue(step.isComplete(stepTwoUiState(leftValue = 2, operator = Operator.ADDITION, rightValue = 3)))
         assertTrue(step.isComplete(stepTwoUiState(leftValue = 3, operator = Operator.ADDITION, rightValue = 2)))
@@ -200,11 +267,23 @@ class TutorialContentTest {
             listOf(StripItem.Known(2), StripItem.Hidden, StripItem.Known(4), StripItem.Known(5)),
             scenario.initialPuzzle.strip.items
         )
-        assertTrue(tiles[0].hasHiddenExpression())
-        assertEquals(Expression(2, Operator.MULTIPLICATION, 3), tiles[1].expression.withoutEntryIds())
-        assertEquals(Expression(4, Operator.ADDITION, 5), tiles[2].expression.withoutEntryIds())
-        assertEquals(Expression(4, Operator.MULTIPLICATION, 5), tiles[3].expression.withoutEntryIds())
+        assertAllTilesHaveHiddenExpressions(scenario.initialPuzzle)
         assertEquals(listOf(5, 6, 9, 20), tiles.map(Tile::result))
+
+        val guidedEntryPuzzle = requireNotNull(TutorialContent.learnBasicsSteps[4].entryPuzzle)
+        assertTrue(guidedEntryPuzzle.board.tiles[0].hasHiddenExpression())
+        assertEquals(
+            Expression(2, Operator.MULTIPLICATION, 3),
+            guidedEntryPuzzle.board.tiles[1].expression.withoutEntryIds()
+        )
+        assertEquals(
+            Expression(4, Operator.ADDITION, 5),
+            guidedEntryPuzzle.board.tiles[2].expression.withoutEntryIds()
+        )
+        assertEquals(
+            Expression(4, Operator.MULTIPLICATION, 5),
+            guidedEntryPuzzle.board.tiles[3].expression.withoutEntryIds()
+        )
     }
 
     @Test


### PR DESCRIPTION
## Related Issue

Resolves #552

## Summary

- Add four manually paced explanation steps over one fully unresolved authored Tutorial puzzle.
- Freeze puzzle interactions and focus objective, strip, tile anatomy, and pair relationships with matching highlights.
- Add accessible Back/Next controls and concise English, Spanish, and Catalan copy.
- Preserve the existing guided strip, tile, and repeated-value actions after the new explanation.

## UI Consistency

- Shared components or tokens reused: `NumPairsComponents.LargeShape`, raised surface color, subtle border, Material theme typography/colors, and the existing Tutorial highlight system.
- Intentional deviations from established visual roles: direct Material `TextButton` is used for low-emphasis inline step navigation because NumPairs has no shared component for this role; the primary CTA component would overstate both actions.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew lintDebug`
- `git diff --check`