### PR TITLE
[267] Play a reasoned Tutorial worked example

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/AppNavigationLearningFlowTest.kt
@@ -79,7 +79,7 @@ class AppNavigationLearningFlowTest {
     }
 
     private fun resolvedOnboardingState(outcome: FirstRunTutorialOutcome): OnboardingState = OnboardingState(
-        lastCompletedStage = OnboardingStageCheckpoint.STAGE_TWO,
+        lastCompletedStage = OnboardingStageCheckpoint.EXPLANATION_COMPLETED,
         firstRunTutorialOutcome = outcome
     )
 

--- a/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
@@ -41,14 +41,17 @@ class LocalizationResourceTest {
         )
         assertTutorialCopy(
             resources = resources,
-            stepOne = "La lista de números va de menor a mayor. " +
-                "Un mismo número puede aparecer más de una vez.",
-            stepOneGuidance = "Introduce 3 para completar la serie del tutorial.",
-            stepTwo = "Cada casilla muestra un resultado. " +
-                "Elige los números y el símbolo que dan ese resultado. " +
-                "Usa los mismos dos números una vez con + y otra con ×.",
-            stepThree = "Resuelve el puzle. Recuerda: la lista de números puede incluir " +
-                "el mismo número más de una vez."
+            expectedCopy = listOf(
+                "Presta atención: vamos a resolver este puzle por ti una sola vez.",
+                "4 × 5 = 20, así que 20 es la casilla de multiplicación de esta pareja.",
+                "La misma pareja también da 4 + 5 = 9.",
+                "Quedan los resultados 5 y 6. Junto al 2, el número oculto tiene que ser 3.",
+                "2 × 3 = 6 completa la multiplicación que falta.",
+                "2 + 3 = 5 completa el puzle.",
+                "Resolviendo ejemplo…",
+                "Resuelve el puzle. Recuerda: la lista de números puede incluir " +
+                    "el mismo número más de una vez."
+            )
         )
         assertEquals("Saltar tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
         assertEquals("Continuar tutorial", resources.getString(R.string.onboarding_continue_tutorial_button))
@@ -87,14 +90,17 @@ class LocalizationResourceTest {
         )
         assertTutorialCopy(
             resources = resources,
-            stepOne = "La llista de números va de menor a major. " +
-                "Un mateix número pot aparéixer més d’una vegada.",
-            stepOneGuidance = "Introdueix 3 per completar la sèrie del tutorial.",
-            stepTwo = "Cada casella mostra un resultat. " +
-                "Tria els números i el símbol que donen eixe resultat. " +
-                "Usa els mateixos dos números una vegada amb + i una altra amb ×.",
-            stepThree = "Resol el puzle. Recorda: la llista de números pot incloure " +
-                "el mateix número més d’una vegada."
+            expectedCopy = listOf(
+                "Para atenció: resoldrem este puzle per tu una sola vegada.",
+                "4 × 5 = 20, així que 20 és la casella de multiplicació d’esta parella.",
+                "La mateixa parella també dona 4 + 5 = 9.",
+                "Queden els resultats 5 i 6. Junt amb el 2, el nombre ocult ha de ser 3.",
+                "2 × 3 = 6 completa la multiplicació que falta.",
+                "2 + 3 = 5 completa el puzle.",
+                "Resolent l’exemple…",
+                "Resol el puzle. Recorda: la llista de números pot incloure " +
+                    "el mateix número més d’una vegada."
+            )
         )
         assertEquals("Omet el tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
         assertEquals("Continua el tutorial", resources.getString(R.string.onboarding_continue_tutorial_button))
@@ -133,13 +139,17 @@ class LocalizationResourceTest {
         )
         assertTutorialCopy(
             resources = resources,
-            stepOne = "The number list goes from smallest to largest. " +
-                "The same number can appear more than once.",
-            stepOneGuidance = "Enter 3 to complete the Tutorial strip.",
-            stepTwo = "Each tile shows a result. Choose the numbers and symbol that make it. " +
-                "Use the same two numbers once with + and once with ×.",
-            stepThree = "Solve the puzzle. Remember: the number list can include " +
-                "the same number more than once."
+            expectedCopy = listOf(
+                "Watch closely: we’ll solve this puzzle for you once.",
+                "4 × 5 = 20, so 20 is this pair’s multiplication tile.",
+                "The same pair also gives 4 + 5 = 9.",
+                "The remaining results are 5 and 6. Paired with 2, the hidden number must be 3.",
+                "2 × 3 = 6 completes the remaining multiplication.",
+                "2 + 3 = 5 completes the puzzle.",
+                "Resolving example…",
+                "Solve the puzzle. Remember: the number list can include " +
+                    "the same number more than once."
+            )
         )
         assertEquals("Skip tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
         assertEquals("Continue tutorial", resources.getString(R.string.onboarding_continue_tutorial_button))
@@ -148,17 +158,19 @@ class LocalizationResourceTest {
         assertEquals("Retry", resources.getString(R.string.onboarding_startup_retry_button))
     }
 
-    private fun assertTutorialCopy(
-        resources: Resources,
-        stepOne: String,
-        stepOneGuidance: String,
-        stepTwo: String,
-        stepThree: String
-    ) {
-        assertEquals(stepOne, resources.getString(R.string.tutorial_strip_introduction_copy))
-        assertEquals(stepOneGuidance, resources.getString(R.string.tutorial_strip_entry_guidance))
-        assertEquals(stepTwo, resources.getString(R.string.tutorial_tiles_introduction_copy))
-        assertEquals(stepThree, resources.getString(R.string.tutorial_repeated_value_practice_copy))
+    private fun assertTutorialCopy(resources: Resources, expectedCopy: List<String>) {
+        val copyResIds = listOf(
+            R.string.tutorial_worked_example_introduction_copy,
+            R.string.tutorial_worked_example_product_four_five_copy,
+            R.string.tutorial_worked_example_sum_four_five_copy,
+            R.string.tutorial_worked_example_reveal_three_copy,
+            R.string.tutorial_worked_example_product_two_three_copy,
+            R.string.tutorial_worked_example_sum_two_three_copy,
+            R.string.tutorial_worked_example_progress,
+            R.string.tutorial_repeated_value_practice_copy
+        )
+
+        assertEquals(expectedCopy, copyResIds.map(resources::getString))
     }
 
     private fun assertTutorialExplanationCopy(

--- a/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
@@ -80,23 +80,11 @@ class RequiredOnboardingNavigationTest {
     }
 
     @Test
-    fun interruptedFirstRunResumesAfterEachCompletedCheckpoint() {
+    fun interruptedFirstRunResumesAtIndependentPracticeAfterTheWorkedExample() {
         val repository = FakeOnboardingRepository(
-            incompleteOnboardingState(OnboardingStageCheckpoint.STAGE_ONE)
+            incompleteOnboardingState(OnboardingStageCheckpoint.EXPLANATION_COMPLETED)
         )
         setContent(repository)
-
-        composeTestRule
-            .onNodeWithTag(TutorialScreenTestTags.STEP_COPY)
-            .assert(hasText(string(R.string.tutorial_tiles_introduction_copy)))
-        composeTestRule
-            .onNodeWithTag(GameScreenTestTags.stripItem(1))
-            .assertContentDescriptionEquals(
-                string(R.string.strip_item_player_entered_content_description, "3")
-            )
-        assertRequiredSkipActionDisplayed()
-
-        repository.onboardingState.value = incompleteOnboardingState(OnboardingStageCheckpoint.STAGE_TWO)
 
         composeTestRule
             .onNodeWithTag(TutorialScreenTestTags.STEP_COPY)
@@ -108,18 +96,21 @@ class RequiredOnboardingNavigationTest {
     }
 
     @Test
-    fun completedTutorialStepsPersistMonotonicResumeCheckpoints() {
+    fun completingTheWorkedExamplePersistsThePracticeResumeCheckpoint() {
         val repository = FakeOnboardingRepository(incompleteOnboardingState())
         setContent(repository)
 
         advanceThroughExplanation()
-        enterStripValue(index = 1, value = "3")
-        waitForTutorialCopy(R.string.tutorial_tiles_introduction_copy)
-        assertEquals(OnboardingStageCheckpoint.STAGE_ONE, repository.onboardingState.value.lastCompletedStage)
-
-        completeTile(tileIndex = 0, leftStripEntryId = 0, operator = Operator.ADDITION, rightStripEntryId = 1)
+        waitForTutorialCopy(R.string.tutorial_worked_example_sum_two_three_copy)
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .performScrollTo()
+            .performClick()
         waitForTutorialCopy(R.string.tutorial_repeated_value_practice_copy)
-        assertEquals(OnboardingStageCheckpoint.STAGE_TWO, repository.onboardingState.value.lastCompletedStage)
+        assertEquals(
+            OnboardingStageCheckpoint.EXPLANATION_COMPLETED,
+            repository.onboardingState.value.lastCompletedStage
+        )
     }
 
     @Test
@@ -169,9 +160,9 @@ class RequiredOnboardingNavigationTest {
     }
 
     @Test
-    fun completingStepThreePersistsCompletedOutcomeAndOpensMenuDirectly() {
+    fun completingIndependentPracticePersistsCompletedOutcomeAndOpensMenuDirectly() {
         val repository = FakeOnboardingRepository(
-            incompleteOnboardingState(OnboardingStageCheckpoint.STAGE_TWO)
+            incompleteOnboardingState(OnboardingStageCheckpoint.EXPLANATION_COMPLETED)
         )
         setContent(repository)
 
@@ -349,6 +340,6 @@ class RequiredOnboardingNavigationTest {
     }
 
     private companion object {
-        const val ONBOARDING_WAIT_TIMEOUT_MILLIS = 5_000L
+        const val ONBOARDING_WAIT_TIMEOUT_MILLIS = 10_000L
     }
 }

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -119,60 +119,78 @@ class TutorialRouteTest {
     }
 
     @Test
-    fun stepOneShowsTutorialGuidanceAndKeepsInvalidRangeFeedbackTruthful() {
-        setContent()
+    fun workedExamplePlaysInOrderWhileNavigationAndPuzzleInteractionsAreLocked() {
+        composeTestRule.mainClock.autoAdvance = false
+        setContent(sequentialWorkedExamplePlayback = true)
         advanceThroughExplanation()
 
+        assertWorkedExampleFrame(R.string.tutorial_worked_example_introduction_copy)
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.WORKED_EXAMPLE_PROGRESS)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.PREVIOUS_STEP_ACTION)
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .assertDoesNotExist()
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.stripItem(1))
-            .performClick()
-        composeTestRule
-            .onNodeWithTag(GameScreenTestTags.STRIP_ENTRY_RANGE)
-            .assert(hasText(string(R.string.tutorial_strip_entry_guidance)))
-        composeTestRule
-            .onNodeWithTag(GameScreenTestTags.STRIP_ENTRY_INPUT)
-            .performTextInput("5")
-        composeTestRule
-            .onNodeWithTag(GameScreenTestTags.STRIP_ENTRY_RANGE)
-            .assert(hasText(string(R.string.strip_entry_invalid_range_bounded, 2, 4)))
+            .assertHasNoClickAction()
+        assertTileExpressionSlotsHaveNoClickAction(tileIndex = 3)
 
-        assertStepDisplayed(stepIndex = GUIDED_STRIP_STEP_INDEX)
+        advanceWorkedExampleFrame(R.string.tutorial_worked_example_product_four_five_copy)
+        assertTileExpression(tileIndex = 3, operator = Operator.MULTIPLICATION, leftValue = "4", rightValue = "5")
+        advanceWorkedExampleFrame(R.string.tutorial_worked_example_sum_four_five_copy)
+        assertTileExpression(tileIndex = 2, operator = Operator.ADDITION, leftValue = "4", rightValue = "5")
+        advanceWorkedExampleFrame(R.string.tutorial_worked_example_reveal_three_copy)
+        assertFocusedIntroductionStripDisplayed(expectedSecondValue = "3", isSecondValuePlayerEntered = true)
+        advanceWorkedExampleFrame(R.string.tutorial_worked_example_product_two_three_copy)
+        assertTileExpression(tileIndex = 1, operator = Operator.MULTIPLICATION)
+        advanceWorkedExampleFrame(R.string.tutorial_worked_example_sum_two_three_copy)
+        assertTileExpression(tileIndex = 0, operator = Operator.ADDITION)
+
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.WORKED_EXAMPLE_PROGRESS)
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.PREVIOUS_STEP_ACTION)
+            .assertIsDisplayed()
+            .assertIsEnabled()
+            .performClick()
+        assertStepDisplayed(stepIndex = PAIR_EXPLANATION_STEP_INDEX)
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .performClick()
+        assertWorkedExampleFrame(R.string.tutorial_worked_example_introduction_copy)
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.WORKED_EXAMPLE_PROGRESS)
+            .assertIsDisplayed()
     }
 
     @Test
-    fun stepOnePreservesTheEnteredStripWhenStepTwoRevealsTheAuthoredTiles() {
-        setContent()
-        advanceThroughExplanation()
+    fun reducedMotionShowsTheSolvedExampleImmediatelyAndRestoresNavigation() {
+        setContent(
+            startStepIndex = WORKED_EXAMPLE_STEP_INDEX,
+            sequentialWorkedExamplePlayback = false
+        )
+        waitForTutorialCopy(R.string.tutorial_worked_example_sum_two_three_copy)
 
-        completeFocusedStepOne()
-
-        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
-        assertStepDisplayed(stepIndex = GUIDED_TILE_STEP_INDEX)
         assertFocusedIntroductionStripDisplayed(expectedSecondValue = "3", isSecondValuePlayerEntered = true)
-        assertTileResult(tileIndex = 0, result = 5)
-        assertTileExpressionHidden(tileIndex = 0)
-        assertTileExpression(tileIndex = 1, operator = Operator.MULTIPLICATION, leftValue = "2", rightValue = "3")
+        assertTileExpression(tileIndex = 0, operator = Operator.ADDITION)
+        assertTileExpression(tileIndex = 1, operator = Operator.MULTIPLICATION)
         assertTileExpression(tileIndex = 2, operator = Operator.ADDITION, leftValue = "4", rightValue = "5")
         assertTileExpression(tileIndex = 3, operator = Operator.MULTIPLICATION, leftValue = "4", rightValue = "5")
         composeTestRule
-            .onNodeWithTag(GameScreenTestTags.BOARD)
-            .assertIsDisplayed()
-        composeTestRule
-            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY)
+            .onNodeWithTag(TutorialScreenTestTags.WORKED_EXAMPLE_PROGRESS)
             .assertDoesNotExist()
-    }
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .assertIsDisplayed()
+            .assertIsEnabled()
+            .performClick()
 
-    @Test
-    fun completingStepTwoStartsTheCleanRepeatedValuePuzzle() {
-        setContent()
-        advanceThroughExplanation()
-
-        completeFocusedStepOne()
-        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
-        completeTile(tileIndex = 0, leftStripEntryId = 0, operator = Operator.ADDITION, rightStripEntryId = 1)
         waitForStep(stepIndex = PRACTICE_STEP_INDEX)
-
-        assertStepDisplayed(stepIndex = PRACTICE_STEP_INDEX)
         assertRepeatedValuePracticeScenarioDisplayed()
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY)
@@ -180,50 +198,7 @@ class TutorialRouteTest {
     }
 
     @Test
-    fun stepTwoOffersNormalChoicesAndAcceptsReversedOperands() {
-        setContent(startStepIndex = GUIDED_TILE_STEP_INDEX)
-
-        openTileOperatorMenu(tileIndex = 0)
-        composeTestRule
-            .onNodeWithTag(GameScreenTestTags.tileOperatorOption(Operator.ADDITION), useUnmergedTree = true)
-            .assertIsEnabled()
-        composeTestRule
-            .onNodeWithTag(GameScreenTestTags.tileOperatorOption(Operator.MULTIPLICATION), useUnmergedTree = true)
-            .assertIsEnabled()
-            .performClick()
-
-        chooseTileOperand(tileIndex = 0, isLeftOperand = true, stripEntryId = 1)
-        composeTestRule
-            .onNodeWithTag(GameScreenTestTags.tileOperandOption(0), useUnmergedTree = true)
-            .assertIsEnabled()
-        composeTestRule
-            .onNodeWithTag(GameScreenTestTags.tileOperandOption(1), useUnmergedTree = true)
-            .assertIsEnabled()
-            .performClick()
-        chooseTileOperand(tileIndex = 0, isLeftOperand = false, stripEntryId = 0)
-        composeTestRule
-            .onNodeWithTag(GameScreenTestTags.tileOperandOption(0), useUnmergedTree = true)
-            .performClick()
-
-        composeTestRule.mainClock.advanceTimeBy(TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS)
-        assertStepDisplayed(stepIndex = GUIDED_TILE_STEP_INDEX)
-        assertTileExpression(
-            tileIndex = 0,
-            operator = Operator.MULTIPLICATION,
-            leftValue = "3",
-            rightValue = "2"
-        )
-
-        openTileOperatorMenu(tileIndex = 0)
-        composeTestRule
-            .onNodeWithTag(GameScreenTestTags.tileOperatorOption(Operator.ADDITION), useUnmergedTree = true)
-            .performClick()
-
-        waitForStep(stepIndex = PRACTICE_STEP_INDEX)
-    }
-
-    @Test
-    fun stepThreeUsesNormalPuzzleInteractionsAndCompletesLearnBasicsWithoutShowingSuccess() {
+    fun independentPracticeUsesNormalInteractionsAndCompletesLearnBasicsWithoutShowingSuccess() {
         setContent()
 
         completeFocusedTutorial()
@@ -234,7 +209,7 @@ class TutorialRouteTest {
     }
 
     @Test
-    fun focusedTutorialReportsGuidedCompletionExactlyOnceWithoutShowingSuccess() {
+    fun focusedTutorialReportsCompletionExactlyOnceWithoutShowingSuccess() {
         val completionCount = AtomicInteger(0)
         setContent(onTutorialCompleted = { completionCount.incrementAndGet() })
 
@@ -252,55 +227,39 @@ class TutorialRouteTest {
     }
 
     @Test
-    fun uninterruptedProgressCheckpointIsReportedExactlyOnce() {
-        val stepOneCompletionCount = AtomicInteger(0)
+    fun workedExampleCheckpointIsReportedExactlyOnce() {
+        val checkpointCount = AtomicInteger(0)
         setContent(
             onProgressCheckpointReached = { progressCheckpoint ->
-                if (progressCheckpoint == TutorialProgressCheckpoint.STRIP_INTRODUCTION_COMPLETED) {
-                    stepOneCompletionCount.incrementAndGet()
+                if (progressCheckpoint == TutorialProgressCheckpoint.WORKED_EXAMPLE_COMPLETED) {
+                    checkpointCount.incrementAndGet()
                 }
             }
         )
 
         advanceThroughExplanation()
-        completeFocusedStepOne()
-        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
-        composeTestRule.mainClock.advanceTimeBy(TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS)
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .performClick()
+        waitForStep(stepIndex = PRACTICE_STEP_INDEX)
 
-        assertEquals(1, stepOneCompletionCount.get())
+        assertEquals(1, checkpointCount.get())
     }
 
     @Test
-    fun reopeningAfterClosingOnStepTwoAllowsStepOneToAdvanceAgain() {
+    fun reopeningAfterTheWorkedExampleStartsTheTutorialFromTheBeginning() {
         val restartTutorial = setRestartableContent()
         advanceThroughExplanation()
-        completeFocusedStepOne()
-        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .performClick()
+        waitForStep(stepIndex = PRACTICE_STEP_INDEX)
 
         restartTutorial()
         assertStepDisplayed(stepIndex = OBJECTIVE_EXPLANATION_STEP_INDEX)
         assertFocusedIntroductionStripDisplayed()
         advanceThroughExplanation()
-        completeFocusedStepOne()
-
-        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
-        assertStepDisplayed(stepIndex = GUIDED_TILE_STEP_INDEX)
-    }
-
-    @Test
-    fun reopeningAfterCompletingAllStepsAllowsStepOneToAdvanceAgain() {
-        val restartTutorial = setRestartableContent()
-        completeFocusedTutorial()
-        composeTestRule.mainClock.advanceTimeBy(TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS)
-
-        restartTutorial()
-        assertStepDisplayed(stepIndex = OBJECTIVE_EXPLANATION_STEP_INDEX)
-        assertFocusedIntroductionStripDisplayed()
-        advanceThroughExplanation()
-        completeFocusedStepOne()
-
-        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
-        assertStepDisplayed(stepIndex = GUIDED_TILE_STEP_INDEX)
+        assertStepIndicator(stepIndex = WORKED_EXAMPLE_STEP_INDEX)
     }
 
     @Test
@@ -348,6 +307,7 @@ class TutorialRouteTest {
 
     private fun setContent(
         startStepIndex: Int = 0,
+        sequentialWorkedExamplePlayback: Boolean = false,
         onProgressCheckpointReached: suspend (TutorialProgressCheckpoint) -> Unit = {},
         onTutorialCompleted: (() -> Unit)? = null
     ) {
@@ -355,6 +315,7 @@ class TutorialRouteTest {
             NumPairsTheme {
                 TutorialRoute(
                     startStepIndex = startStepIndex,
+                    sequentialWorkedExamplePlaybackOverride = sequentialWorkedExamplePlayback,
                     onProgressCheckpointReached = onProgressCheckpointReached,
                     onTutorialCompleted = onTutorialCompleted
                 )
@@ -383,7 +344,7 @@ class TutorialRouteTest {
         composeTestRule.setContent {
             NumPairsTheme {
                 if (isTutorialVisible.value) {
-                    TutorialRoute()
+                    TutorialRoute(sequentialWorkedExamplePlaybackOverride = false)
                 }
             }
         }
@@ -407,15 +368,11 @@ class TutorialRouteTest {
         }
     }
 
-    private fun completeFocusedStepOne() {
-        enterStripValue(index = 1, value = "3")
-    }
-
     private fun completeFocusedTutorial() {
         advanceThroughExplanation()
-        completeFocusedStepOne()
-        waitForStep(stepIndex = GUIDED_TILE_STEP_INDEX)
-        completeTile(tileIndex = 0, leftStripEntryId = 0, operator = Operator.ADDITION, rightStripEntryId = 1)
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .performClick()
         waitForStep(stepIndex = PRACTICE_STEP_INDEX)
 
         enterStripValue(index = 0, value = "1")
@@ -427,13 +384,25 @@ class TutorialRouteTest {
     }
 
     private fun advanceThroughExplanation() {
-        repeat(GUIDED_STRIP_STEP_INDEX) {
+        repeat(WORKED_EXAMPLE_STEP_INDEX) {
             composeTestRule
                 .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
                 .performScrollTo()
                 .performClick()
         }
-        assertStepDisplayed(stepIndex = GUIDED_STRIP_STEP_INDEX)
+        assertStepIndicator(stepIndex = WORKED_EXAMPLE_STEP_INDEX)
+    }
+
+    private fun advanceWorkedExampleFrame(expectedCopyResId: Int) {
+        composeTestRule.mainClock.advanceTimeBy(WORKED_EXAMPLE_FRAME_WAIT_MS)
+        assertWorkedExampleFrame(expectedCopyResId)
+    }
+
+    private fun assertWorkedExampleFrame(copyResId: Int) {
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.STEP_COPY)
+            .performScrollTo()
+            .assert(hasText(string(copyResId)))
     }
 
     private fun navigateToExplanationStep(stepIndex: Int) {
@@ -565,6 +534,16 @@ class TutorialRouteTest {
         val steps = TutorialContent.stepsFor(mode)
         val step = steps[stepIndex]
 
+        assertStepIndicator(stepIndex = stepIndex, mode = mode)
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.STEP_COPY)
+            .performScrollTo()
+            .assert(hasText(string(step.playerFacingCopyResId)))
+    }
+
+    private fun assertStepIndicator(stepIndex: Int, mode: TutorialMode = TutorialMode.LEARN_BASICS) {
+        val steps = TutorialContent.stepsFor(mode)
+
         composeTestRule
             .onNodeWithTag(TutorialScreenTestTags.STEP_INDICATOR)
             .performScrollTo()
@@ -577,10 +556,6 @@ class TutorialRouteTest {
                     )
                 )
             )
-        composeTestRule
-            .onNodeWithTag(TutorialScreenTestTags.STEP_COPY)
-            .performScrollTo()
-            .assert(hasText(string(step.playerFacingCopyResId)))
     }
 
     private fun assertNoRequiredSkipAction() {
@@ -726,6 +701,15 @@ class TutorialRouteTest {
         }
     }
 
+    private fun waitForTutorialCopy(copyResId: Int) {
+        composeTestRule.waitUntil(timeoutMillis = TUTORIAL_STEP_WAIT_TIMEOUT_MS) {
+            composeTestRule
+                .onAllNodes(hasText(string(copyResId)))
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+    }
+
     private fun string(stringResId: Int, vararg formatArgs: Any): String = if (formatArgs.isEmpty()) {
         composeTestRule.activity.getString(stringResId)
     } else {
@@ -742,9 +726,9 @@ class TutorialRouteTest {
         const val OBJECTIVE_EXPLANATION_STEP_INDEX = 0
         const val STRIP_EXPLANATION_STEP_INDEX = 1
         const val PAIR_EXPLANATION_STEP_INDEX = 3
-        const val GUIDED_STRIP_STEP_INDEX = 4
-        const val GUIDED_TILE_STEP_INDEX = 5
-        const val PRACTICE_STEP_INDEX = 6
+        const val WORKED_EXAMPLE_STEP_INDEX = 4
+        const val PRACTICE_STEP_INDEX = 5
+        const val WORKED_EXAMPLE_FRAME_WAIT_MS = 1_000L
         const val TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS = 1_000L
         const val TUTORIAL_STEP_WAIT_TIMEOUT_MS = 5_000L
     }

--- a/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingState.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/onboarding/OnboardingState.kt
@@ -22,8 +22,7 @@ enum class FirstRunTutorialOutcome(internal val persistedValue: Int) {
 
 enum class OnboardingStageCheckpoint(internal val persistedValue: Int) {
     NONE(0),
-    STAGE_ONE(1),
-    STAGE_TWO(2);
+    EXPLANATION_COMPLETED(3);
 
     internal companion object {
         fun fromPersistedValue(value: Int): OnboardingStageCheckpoint = entries

--- a/app/src/main/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRoute.kt
@@ -155,13 +155,11 @@ internal fun OnboardingState.nextRequiredTutorialStepIndex(
 
 private fun OnboardingStageCheckpoint.toTutorialProgressCheckpointOrNull(): TutorialProgressCheckpoint? = when (this) {
     OnboardingStageCheckpoint.NONE -> null
-    OnboardingStageCheckpoint.STAGE_ONE -> TutorialProgressCheckpoint.STRIP_INTRODUCTION_COMPLETED
-    OnboardingStageCheckpoint.STAGE_TWO -> TutorialProgressCheckpoint.TILES_INTRODUCTION_COMPLETED
+    OnboardingStageCheckpoint.EXPLANATION_COMPLETED -> TutorialProgressCheckpoint.WORKED_EXAMPLE_COMPLETED
 }
 
 private fun TutorialProgressCheckpoint.toOnboardingStageCheckpoint(): OnboardingStageCheckpoint = when (this) {
-    TutorialProgressCheckpoint.STRIP_INTRODUCTION_COMPLETED -> OnboardingStageCheckpoint.STAGE_ONE
-    TutorialProgressCheckpoint.TILES_INTRODUCTION_COMPLETED -> OnboardingStageCheckpoint.STAGE_TWO
+    TutorialProgressCheckpoint.WORKED_EXAMPLE_COMPLETED -> OnboardingStageCheckpoint.EXPLANATION_COMPLETED
 }
 
 object RequiredOnboardingTestTags {

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
@@ -2,19 +2,13 @@ package org.cescfe.numpairs.feature.tutorial
 
 import org.cescfe.numpairs.R
 import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.domain.puzzle.model.StripItem
 
 internal object LearnBasicsTutorialContent {
     private val stripAndTilesIntroductionScenario = stripAndTilesIntroductionScenario()
     private val repeatedValuePracticeScenario = repeatedValuePracticeScenario()
-    private val guidedIntroductionPuzzle = stripAndTilesIntroductionScenario.initialPuzzle.copy(
-        board = stripAndTilesIntroductionScenario.initialPuzzle.board.copy(
-            tiles = listOf(hiddenTile(result = 5)) + stripAndTilesIntroductionScenario.solvedPuzzle.board.tiles.drop(1)
-        )
-    )
-    private val completedIntroductionStripPuzzle = guidedIntroductionPuzzle.copy(
-        strip = stripAndTilesIntroductionScenario.initialPuzzle.strip.withUpdatedEntry(index = 1, value = 3)
-    )
+    private val workedExampleFrames = workedExampleFrames()
 
     val scenarios: List<TutorialScenario> = listOf(
         stripAndTilesIntroductionScenario,
@@ -22,42 +16,7 @@ internal object LearnBasicsTutorialContent {
     )
 
     val steps: List<TutorialStep> = explanationSteps() + listOf(
-        TutorialStep(
-            scenarioId = TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
-            playerFacingCopyResId = R.string.tutorial_strip_introduction_copy,
-            highlightedTargets = listOf(
-                TutorialHighlightTarget.StripEntries(indexes = listOf(1))
-            ),
-            requiredAction = TutorialRequiredAction.EnterStripValue(
-                stripEntryIndex = 1,
-                value = 3
-            ),
-            completionPredicate = TutorialStepCompletionPredicate.StripValueEntered(
-                stripEntryIndex = 1,
-                value = 3
-            ),
-            progressCheckpoint = TutorialProgressCheckpoint.STRIP_INTRODUCTION_COMPLETED,
-            isBoardVisible = false,
-            stripEntryGuidanceResId = R.string.tutorial_strip_entry_guidance,
-            entryPuzzle = guidedIntroductionPuzzle
-        ),
-        TutorialStep(
-            scenarioId = TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
-            playerFacingCopyResId = R.string.tutorial_tiles_introduction_copy,
-            highlightedTargets = listOf(
-                TutorialHighlightTarget.TileExpressionSlots(tileIndex = 0),
-                TutorialHighlightTarget.WholeTile(tileIndex = 1)
-            ),
-            requiredAction = TutorialRequiredAction.CompleteTileWithNormalInteractions(tileIndex = 0),
-            completionPredicate = TutorialStepCompletionPredicate.TileExpressionCompleted(
-                tileIndex = 0,
-                leftValue = 2,
-                operator = Operator.ADDITION,
-                rightValue = 3
-            ),
-            progressCheckpoint = TutorialProgressCheckpoint.TILES_INTRODUCTION_COMPLETED,
-            entryPuzzle = completedIntroductionStripPuzzle
-        ),
+        workedExampleStep(),
         TutorialStep(
             scenarioId = TutorialScenarioId.REPEATED_VALUE_PRACTICE,
             playerFacingCopyResId = R.string.tutorial_repeated_value_practice_copy,
@@ -67,6 +26,99 @@ internal object LearnBasicsTutorialContent {
             ),
             requiredAction = TutorialRequiredAction.CompleteScenario,
             completionPredicate = TutorialStepCompletionPredicate.ScenarioSolved
+        )
+    )
+
+    private fun workedExampleStep(): TutorialStep {
+        val initialFrame = workedExampleFrames.first()
+
+        return TutorialStep(
+            scenarioId = TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
+            playerFacingCopyResId = initialFrame.playerFacingCopyResId,
+            highlightedTargets = initialFrame.highlightedTargets,
+            requiredAction = TutorialRequiredAction.PlayWorkedExample(frames = workedExampleFrames),
+            completionPredicate = TutorialStepCompletionPredicate.ManualAdvance,
+            progressCheckpoint = TutorialProgressCheckpoint.WORKED_EXAMPLE_COMPLETED,
+            entryPuzzle = initialFrame.puzzle
+        )
+    }
+
+    private fun workedExampleFrames(): List<TutorialWorkedExampleFrame> {
+        val scenario = stripAndTilesIntroductionScenario
+        val initialPuzzle = scenario.initialPuzzle
+        val productFourAndFive = initialPuzzle.withSolvedTiles(scenario = scenario, tileIndexes = intArrayOf(3))
+        val pairFourAndFive = productFourAndFive.withSolvedTiles(scenario = scenario, tileIndexes = intArrayOf(2))
+        val completedStrip = pairFourAndFive.copy(
+            strip = pairFourAndFive.strip.withUpdatedEntry(index = 1, value = 3)
+        )
+        val productTwoAndThree = completedStrip.withSolvedTiles(scenario = scenario, tileIndexes = intArrayOf(1))
+        val solvedExample = productTwoAndThree.withSolvedTiles(scenario = scenario, tileIndexes = intArrayOf(0))
+
+        return listOf(
+            TutorialWorkedExampleFrame(
+                playerFacingCopyResId = R.string.tutorial_worked_example_introduction_copy,
+                puzzle = initialPuzzle,
+                highlightedTargets = listOf(
+                    TutorialHighlightTarget.StripEntries(indexes = listOf(0, 1, 2, 3)),
+                    TutorialHighlightTarget.WholeTile(tileIndex = 0),
+                    TutorialHighlightTarget.WholeTile(tileIndex = 1),
+                    TutorialHighlightTarget.WholeTile(tileIndex = 2),
+                    TutorialHighlightTarget.WholeTile(tileIndex = 3)
+                )
+            ),
+            workedExampleFrame(
+                copyResId = R.string.tutorial_worked_example_product_four_five_copy,
+                puzzle = productFourAndFive,
+                stripEntryIndexes = listOf(2, 3),
+                tileIndexes = listOf(3)
+            ),
+            workedExampleFrame(
+                copyResId = R.string.tutorial_worked_example_sum_four_five_copy,
+                puzzle = pairFourAndFive,
+                stripEntryIndexes = listOf(2, 3),
+                tileIndexes = listOf(2)
+            ),
+            workedExampleFrame(
+                copyResId = R.string.tutorial_worked_example_reveal_three_copy,
+                puzzle = completedStrip,
+                stripEntryIndexes = listOf(0, 1),
+                tileIndexes = listOf(0, 1)
+            ),
+            workedExampleFrame(
+                copyResId = R.string.tutorial_worked_example_product_two_three_copy,
+                puzzle = productTwoAndThree,
+                stripEntryIndexes = listOf(0, 1),
+                tileIndexes = listOf(1)
+            ),
+            workedExampleFrame(
+                copyResId = R.string.tutorial_worked_example_sum_two_three_copy,
+                puzzle = solvedExample,
+                stripEntryIndexes = listOf(0, 1),
+                tileIndexes = listOf(0)
+            )
+        )
+    }
+
+    private fun workedExampleFrame(
+        copyResId: Int,
+        puzzle: Puzzle,
+        stripEntryIndexes: List<Int>,
+        tileIndexes: List<Int>
+    ): TutorialWorkedExampleFrame = TutorialWorkedExampleFrame(
+        playerFacingCopyResId = copyResId,
+        puzzle = puzzle,
+        highlightedTargets = listOf(
+            TutorialHighlightTarget.StripEntries(indexes = stripEntryIndexes)
+        ) + tileIndexes.map(TutorialHighlightTarget::WholeTile)
+    )
+
+    private fun Puzzle.withSolvedTiles(scenario: TutorialScenario, tileIndexes: IntArray): Puzzle = copy(
+        board = board.copy(
+            tiles = board.tiles.toMutableList().apply {
+                tileIndexes.forEach { tileIndex ->
+                    set(tileIndex, scenario.solvedPuzzle.board.tiles[tileIndex])
+                }
+            }
         )
     )
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
@@ -8,7 +8,6 @@ import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.cescfe.numpairs.domain.puzzle.model.Tile
 import org.cescfe.numpairs.feature.game.presentation.GameUiState
 import org.cescfe.numpairs.feature.game.presentation.PuzzleOutcomeUiState
-import org.cescfe.numpairs.feature.game.presentation.StripItemVisualStyle
 
 enum class TutorialMode {
     LEARN_BASICS,
@@ -16,8 +15,7 @@ enum class TutorialMode {
 }
 
 enum class TutorialProgressCheckpoint {
-    STRIP_INTRODUCTION_COMPLETED,
-    TILES_INTRODUCTION_COMPLETED
+    WORKED_EXAMPLE_COMPLETED
 }
 
 data class TutorialScenario(
@@ -59,15 +57,11 @@ data class TutorialStep(
     val completionPredicate: TutorialStepCompletionPredicate,
     val progressCheckpoint: TutorialProgressCheckpoint? = null,
     val isBoardVisible: Boolean = true,
-    @param:StringRes val stripEntryGuidanceResId: Int? = null,
     val entryPuzzle: Puzzle? = null
 ) {
     init {
         require(playerFacingCopyResId != 0) {
             "Tutorial step copy string resource must be defined."
-        }
-        require(stripEntryGuidanceResId == null || stripEntryGuidanceResId != 0) {
-            "Tutorial strip entry guidance must reference a defined string resource."
         }
     }
 
@@ -110,21 +104,10 @@ sealed interface TutorialHighlightTarget {
 sealed interface TutorialRequiredAction {
     data object NoInteraction : TutorialRequiredAction
 
-    data class EnterStripValue(val stripEntryIndex: Int, val value: Int) : TutorialRequiredAction {
+    data class PlayWorkedExample(val frames: List<TutorialWorkedExampleFrame>) : TutorialRequiredAction {
         init {
-            require(stripEntryIndex >= 0) {
-                "Tutorial strip entry action index must be non-negative."
-            }
-            require(value > 0) {
-                "Tutorial strip entry action value must be positive."
-            }
-        }
-    }
-
-    data class CompleteTileWithNormalInteractions(val tileIndex: Int) : TutorialRequiredAction {
-        init {
-            require(tileIndex >= 0) {
-                "Tutorial tile action index must be non-negative."
+            require(frames.size >= 2) {
+                "Tutorial worked example must contain an initial frame and at least one resolved frame."
             }
         }
     }
@@ -176,29 +159,23 @@ sealed interface TutorialRequiredAction {
     data object CompleteScenario : TutorialRequiredAction
 }
 
+data class TutorialWorkedExampleFrame(
+    @param:StringRes val playerFacingCopyResId: Int,
+    val puzzle: Puzzle,
+    val highlightedTargets: List<TutorialHighlightTarget>
+) {
+    init {
+        require(playerFacingCopyResId != 0) {
+            "Tutorial worked-example frame copy string resource must be defined."
+        }
+    }
+}
+
 sealed interface TutorialStepCompletionPredicate {
     fun isSatisfiedBy(uiState: GameUiState): Boolean
 
     data object ManualAdvance : TutorialStepCompletionPredicate {
         override fun isSatisfiedBy(uiState: GameUiState): Boolean = false
-    }
-
-    data class StripValueEntered(val stripEntryIndex: Int, val value: Int) : TutorialStepCompletionPredicate {
-        init {
-            require(stripEntryIndex >= 0) {
-                "Tutorial strip completion index must be non-negative."
-            }
-            require(value > 0) {
-                "Tutorial strip completion value must be positive."
-            }
-        }
-
-        override fun isSatisfiedBy(uiState: GameUiState): Boolean {
-            val stripItem = uiState.stripItems.getOrNull(stripEntryIndex) ?: return false
-
-            return stripItem.label == value.toString() &&
-                stripItem.visualStyle == StripItemVisualStyle.PLAYER_ENTERED
-        }
     }
 
     data class TileExpressionCompleted(

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -19,17 +19,20 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.cescfe.numpairs.R
 import org.cescfe.numpairs.domain.puzzle.model.OperandSlot
 import org.cescfe.numpairs.domain.puzzle.model.StripItem
@@ -49,6 +52,7 @@ fun TutorialRoute(
     mode: TutorialMode = TutorialMode.LEARN_BASICS,
     startStepIndex: Int = 0,
     saveProgressAcrossRecreation: Boolean = true,
+    sequentialWorkedExamplePlaybackOverride: Boolean? = null,
     onProgressCheckpointReached: suspend (TutorialProgressCheckpoint) -> Unit = {},
     onTutorialCompleted: (() -> Unit)? = null,
     onSkipTutorialRequested: (() -> Unit)? = null,
@@ -75,17 +79,30 @@ fun TutorialRoute(
         mutableIntStateOf(startStepIndex - 1)
     }
     var latestGameUiSnapshot by remember(playbackKey) { mutableStateOf<TutorialGameUiSnapshot?>(null) }
+    val coroutineScope = rememberCoroutineScope()
     val currentOnProgressCheckpointReached by rememberUpdatedState(onProgressCheckpointReached)
     val currentOnTutorialCompleted by rememberUpdatedState(onTutorialCompleted)
     val currentStep = steps[currentStepIndex]
     val currentScenario = TutorialContent.scenario(currentStep.scenarioId)
-    val currentEntryPuzzle = currentStep.entryPuzzle ?: currentScenario.initialPuzzle
+    val workedExample = currentStep.requiredAction as? TutorialRequiredAction.PlayWorkedExample
+    var workedExampleFrameIndex by remember(playbackKey, currentStepIndex) { mutableIntStateOf(0) }
+    var isCheckpointNavigationInProgress by remember(playbackKey, currentStepIndex) {
+        mutableStateOf(false)
+    }
+    val workedExampleFrame = workedExample?.frames?.get(workedExampleFrameIndex)
+    val presentedStep = workedExampleFrame?.let { frame ->
+        currentStep.copy(
+            playerFacingCopyResId = frame.playerFacingCopyResId,
+            highlightedTargets = frame.highlightedTargets,
+            entryPuzzle = frame.puzzle
+        )
+    } ?: currentStep
+    val currentEntryPuzzle = presentedStep.entryPuzzle ?: currentScenario.initialPuzzle
+    val isWorkedExamplePlaybackActive = workedExample != null &&
+        workedExampleFrameIndex < workedExample.frames.lastIndex
     val latestGameUiState = latestGameUiSnapshot
         ?.takeIf { snapshot -> snapshot.scenarioId == currentScenario.id }
         ?.uiState
-    val stripItemEntryGuidance = currentStep.stripEntryGuidanceResId?.let { guidanceResId ->
-        stringResource(guidanceResId)
-    }
 
     LaunchedEffect(currentStepIndex, latestGameUiState) {
         val uiState = latestGameUiState ?: return@LaunchedEffect
@@ -110,6 +127,23 @@ fun TutorialRoute(
         }
     }
 
+    LaunchedEffect(currentStepIndex, workedExample, sequentialWorkedExamplePlaybackOverride) {
+        val frames = workedExample?.frames ?: return@LaunchedEffect
+        workedExampleFrameIndex = 0
+        val systemAllowsSequentialPlayback = coroutineContext[MotionDurationScale]?.scaleFactor != 0f
+        val shouldPlaySequentially = sequentialWorkedExamplePlaybackOverride ?: systemAllowsSequentialPlayback
+
+        if (!shouldPlaySequentially) {
+            workedExampleFrameIndex = frames.lastIndex
+            return@LaunchedEffect
+        }
+
+        for (frameIndex in 1..frames.lastIndex) {
+            delay(TUTORIAL_WORKED_EXAMPLE_FRAME_DELAY)
+            workedExampleFrameIndex = frameIndex
+        }
+    }
+
     GameRoute(
         title = stringResource(R.string.tutorial_screen_title),
         initialPuzzle = currentEntryPuzzle,
@@ -123,13 +157,12 @@ fun TutorialRoute(
             observedScenarioId = latestGameUiSnapshot?.scenarioId,
             isRequiredPlayback = onTutorialCompleted != null
         ),
-        isBoardVisible = currentStep.isBoardVisible,
-        stripItemEntryGuidance = stripItemEntryGuidance,
-        interactionPolicy = currentStep.toInteractionPolicy(
+        isBoardVisible = presentedStep.isBoardVisible,
+        interactionPolicy = presentedStep.toInteractionPolicy(
             scenario = currentScenario,
             uiState = latestGameUiState
         ),
-        highlightState = currentStep.toHighlightState(
+        highlightState = presentedStep.toHighlightState(
             scenario = currentScenario,
             uiState = latestGameUiState
         ),
@@ -140,16 +173,27 @@ fun TutorialRoute(
         },
         contentBeforePuzzle = {
             TutorialInstructionSurface(
-                currentStep = currentStep,
+                currentStep = presentedStep,
                 currentStepNumber = currentStepIndex + 1,
                 totalSteps = steps.size,
-                canNavigateBack = currentStepIndex > 0,
+                isWorkedExamplePlaybackActive = isWorkedExamplePlaybackActive,
+                canNavigateBack = currentStepIndex > 0 && !isCheckpointNavigationInProgress,
+                canNavigateNext = !isCheckpointNavigationInProgress,
                 onNavigateBack = {
                     currentStepIndex -= 1
                 },
                 onNavigateNext = {
-                    if (currentStepIndex < steps.lastIndex) {
+                    val progressCheckpoint = currentStep.progressCheckpoint
+
+                    if (progressCheckpoint == null && currentStepIndex < steps.lastIndex) {
                         currentStepIndex += 1
+                    } else if (!isCheckpointNavigationInProgress && currentStepIndex < steps.lastIndex) {
+                        isCheckpointNavigationInProgress = true
+                        coroutineScope.launch {
+                            currentOnProgressCheckpointReached(requireNotNull(progressCheckpoint))
+                            currentStepIndex += 1
+                            isCheckpointNavigationInProgress = false
+                        }
                     }
                 },
                 modifier = Modifier.fillMaxWidth()
@@ -183,7 +227,9 @@ private fun TutorialInstructionSurface(
     currentStep: TutorialStep,
     currentStepNumber: Int,
     totalSteps: Int,
+    isWorkedExamplePlaybackActive: Boolean,
     canNavigateBack: Boolean,
+    canNavigateNext: Boolean,
     onNavigateBack: () -> Unit,
     onNavigateNext: () -> Unit,
     modifier: Modifier = Modifier
@@ -216,11 +262,16 @@ private fun TutorialInstructionSurface(
                 color = MaterialTheme.colorScheme.onSurface
             )
             if (currentStep.completionPredicate == TutorialStepCompletionPredicate.ManualAdvance) {
-                TutorialStepNavigation(
-                    canNavigateBack = canNavigateBack,
-                    onNavigateBack = onNavigateBack,
-                    onNavigateNext = onNavigateNext
-                )
+                if (isWorkedExamplePlaybackActive) {
+                    TutorialWorkedExampleProgress()
+                } else {
+                    TutorialStepNavigation(
+                        canNavigateBack = canNavigateBack,
+                        canNavigateNext = canNavigateNext,
+                        onNavigateBack = onNavigateBack,
+                        onNavigateNext = onNavigateNext
+                    )
+                }
             }
         }
     }
@@ -229,6 +280,7 @@ private fun TutorialInstructionSurface(
 @Composable
 private fun TutorialStepNavigation(
     canNavigateBack: Boolean,
+    canNavigateNext: Boolean,
     onNavigateBack: () -> Unit,
     onNavigateNext: () -> Unit,
     modifier: Modifier = Modifier
@@ -252,6 +304,7 @@ private fun TutorialStepNavigation(
         }
         TextButton(
             onClick = onNavigateNext,
+            enabled = canNavigateNext,
             modifier = Modifier
                 .heightIn(min = 48.dp)
                 .testTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
@@ -261,6 +314,23 @@ private fun TutorialStepNavigation(
                 style = MaterialTheme.typography.labelLarge
             )
         }
+    }
+}
+
+@Composable
+private fun TutorialWorkedExampleProgress(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = 48.dp)
+            .testTag(TutorialScreenTestTags.WORKED_EXAMPLE_PROGRESS),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = stringResource(R.string.tutorial_worked_example_progress),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }
 
@@ -302,33 +372,12 @@ private fun TutorialRequiredAction.toInteractionPolicy(
     uiState: GameUiState?,
     highlightedStripEntryIds: Set<Int>
 ): GameInteractionPolicy = when (this) {
-    TutorialRequiredAction.NoInteraction -> GameInteractionPolicy(
-        canTapStripItem = { false },
-        canConfirmStripItemEntry = { _, _ -> false },
-        canTapTileLeftOperand = { false },
-        canTapTileRightOperand = { false },
-        canTapTileOperator = { false },
-        canTapTileReset = { false },
-        canConfirmTileOperand = { _, _, _ -> false },
-        canConfirmTileOperator = { _, _ -> false }
-    )
-    is TutorialRequiredAction.EnterStripValue -> GameInteractionPolicy(
-        canTapStripItem = { index -> index == stripEntryIndex },
-        canConfirmStripItemEntry = { index, value ->
-            index == stripEntryIndex && value == this.value
-        },
-        canTapTileLeftOperand = { false },
-        canTapTileRightOperand = { false },
-        canTapTileOperator = { false },
-        canTapTileReset = { false },
-        canConfirmTileOperand = { _, _, _ -> false },
-        canConfirmTileOperator = { _, _ -> false }
-    )
+    TutorialRequiredAction.NoInteraction,
+    is TutorialRequiredAction.PlayWorkedExample -> noInteractionPolicy()
     is TutorialRequiredAction.CompleteTileExpression -> toInteractionPolicy(
         scenario = scenario,
         highlightedStripEntryIds = highlightedStripEntryIds
     )
-    is TutorialRequiredAction.CompleteTileWithNormalInteractions -> toInteractionPolicy()
     is TutorialRequiredAction.CompleteTileExpressions -> toInteractionPolicy(
         scenario = scenario,
         highlightedStripEntryIds = highlightedStripEntryIds
@@ -340,17 +389,16 @@ private fun TutorialRequiredAction.toInteractionPolicy(
     TutorialRequiredAction.CompleteScenario -> GameInteractionPolicy.AllowAll
 }
 
-private fun TutorialRequiredAction.CompleteTileWithNormalInteractions.toInteractionPolicy(): GameInteractionPolicy =
-    GameInteractionPolicy(
-        canTapStripItem = { false },
-        canConfirmStripItemEntry = { _, _ -> false },
-        canTapTileLeftOperand = { index -> index == tileIndex },
-        canTapTileRightOperand = { index -> index == tileIndex },
-        canTapTileOperator = { index -> index == tileIndex },
-        canTapTileReset = { index -> index == tileIndex },
-        canConfirmTileOperand = { index, _, _ -> index == tileIndex },
-        canConfirmTileOperator = { index, _ -> index == tileIndex }
-    )
+private fun noInteractionPolicy(): GameInteractionPolicy = GameInteractionPolicy(
+    canTapStripItem = { false },
+    canConfirmStripItemEntry = { _, _ -> false },
+    canTapTileLeftOperand = { false },
+    canTapTileRightOperand = { false },
+    canTapTileOperator = { false },
+    canTapTileReset = { false },
+    canConfirmTileOperand = { _, _, _ -> false },
+    canConfirmTileOperator = { _, _ -> false }
+)
 
 private fun TutorialRequiredAction.CompleteTileExpression.toInteractionPolicy(
     scenario: TutorialScenario,
@@ -563,3 +611,4 @@ private fun expressionSlotHighlights(tileIndex: Int): Set<GameTileExpressionSlot
 
 private const val TUTORIAL_GAME_SESSION_KEY = "tutorial-walkthrough"
 private val TUTORIAL_STEP_ADVANCE_DELAY = 350.milliseconds
+private val TUTORIAL_WORKED_EXAMPLE_FRAME_DELAY = 900.milliseconds

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/ui/TutorialScreenTestTags.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/ui/TutorialScreenTestTags.kt
@@ -7,5 +7,6 @@ object TutorialScreenTestTags {
     const val STEP_COPY = "tutorial_step_copy"
     const val PREVIOUS_STEP_ACTION = "tutorial_previous_step_action"
     const val NEXT_STEP_ACTION = "tutorial_next_step_action"
+    const val WORKED_EXAMPLE_PROGRESS = "tutorial_worked_example_progress"
     const val SKIP_ACTION = "tutorial_skip_action"
 }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -67,9 +67,13 @@
     <string name="tutorial_pair_explanation_copy">Agrupa els nombres de la sèrie per parelles. Cada parella completa dues caselles: una suma i una multiplicació.</string>
     <string name="tutorial_previous_step_action">Enrere</string>
     <string name="tutorial_next_step_action">Següent</string>
-    <string name="tutorial_strip_introduction_copy">La llista de números va de menor a major. Un mateix número pot aparéixer més d’una vegada.</string>
-    <string name="tutorial_strip_entry_guidance">Introdueix 3 per completar la sèrie del tutorial.</string>
-    <string name="tutorial_tiles_introduction_copy">Cada casella mostra un resultat. Tria els números i el símbol que donen eixe resultat. Usa els mateixos dos números una vegada amb + i una altra amb ×.</string>
+    <string name="tutorial_worked_example_introduction_copy">Para atenció: resoldrem este puzle per tu una sola vegada.</string>
+    <string name="tutorial_worked_example_product_four_five_copy">4 × 5 = 20, així que 20 és la casella de multiplicació d’esta parella.</string>
+    <string name="tutorial_worked_example_sum_four_five_copy">La mateixa parella també dona 4 + 5 = 9.</string>
+    <string name="tutorial_worked_example_reveal_three_copy">Queden els resultats 5 i 6. Junt amb el 2, el nombre ocult ha de ser 3.</string>
+    <string name="tutorial_worked_example_product_two_three_copy">2 × 3 = 6 completa la multiplicació que falta.</string>
+    <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completa el puzle.</string>
+    <string name="tutorial_worked_example_progress">Resolent l’exemple…</string>
     <string name="tutorial_repeated_value_practice_copy">Resol el puzle. Recorda: la llista de números pot incloure el mateix número més d’una vegada.</string>
     <string name="onboarding_skip_tutorial_action">Omet el tutorial</string>
     <string name="onboarding_skip_tutorial_title">Vols ometre el tutorial?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -67,9 +67,13 @@
     <string name="tutorial_pair_explanation_copy">Agrupa los números de la serie por parejas. Cada pareja completa dos casillas: una suma y una multiplicación.</string>
     <string name="tutorial_previous_step_action">Atrás</string>
     <string name="tutorial_next_step_action">Siguiente</string>
-    <string name="tutorial_strip_introduction_copy">La lista de números va de menor a mayor. Un mismo número puede aparecer más de una vez.</string>
-    <string name="tutorial_strip_entry_guidance">Introduce 3 para completar la serie del tutorial.</string>
-    <string name="tutorial_tiles_introduction_copy">Cada casilla muestra un resultado. Elige los números y el símbolo que dan ese resultado. Usa los mismos dos números una vez con + y otra con ×.</string>
+    <string name="tutorial_worked_example_introduction_copy">Presta atención: vamos a resolver este puzle por ti una sola vez.</string>
+    <string name="tutorial_worked_example_product_four_five_copy">4 × 5 = 20, así que 20 es la casilla de multiplicación de esta pareja.</string>
+    <string name="tutorial_worked_example_sum_four_five_copy">La misma pareja también da 4 + 5 = 9.</string>
+    <string name="tutorial_worked_example_reveal_three_copy">Quedan los resultados 5 y 6. Junto al 2, el número oculto tiene que ser 3.</string>
+    <string name="tutorial_worked_example_product_two_three_copy">2 × 3 = 6 completa la multiplicación que falta.</string>
+    <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completa el puzle.</string>
+    <string name="tutorial_worked_example_progress">Resolviendo ejemplo…</string>
     <string name="tutorial_repeated_value_practice_copy">Resuelve el puzle. Recuerda: la lista de números puede incluir el mismo número más de una vez.</string>
     <string name="onboarding_skip_tutorial_action">Saltar tutorial</string>
     <string name="onboarding_skip_tutorial_title">¿Saltar el tutorial?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,9 +67,13 @@
     <string name="tutorial_pair_explanation_copy">Group the strip numbers into pairs. Each pair completes two tiles: one addition and one multiplication.</string>
     <string name="tutorial_previous_step_action">Back</string>
     <string name="tutorial_next_step_action">Next</string>
-    <string name="tutorial_strip_introduction_copy">The number list goes from smallest to largest. The same number can appear more than once.</string>
-    <string name="tutorial_strip_entry_guidance">Enter 3 to complete the Tutorial strip.</string>
-    <string name="tutorial_tiles_introduction_copy">Each tile shows a result. Choose the numbers and symbol that make it. Use the same two numbers once with + and once with ×.</string>
+    <string name="tutorial_worked_example_introduction_copy">Watch closely: we’ll solve this puzzle for you once.</string>
+    <string name="tutorial_worked_example_product_four_five_copy">4 × 5 = 20, so 20 is this pair’s multiplication tile.</string>
+    <string name="tutorial_worked_example_sum_four_five_copy">The same pair also gives 4 + 5 = 9.</string>
+    <string name="tutorial_worked_example_reveal_three_copy">The remaining results are 5 and 6. Paired with 2, the hidden number must be 3.</string>
+    <string name="tutorial_worked_example_product_two_three_copy">2 × 3 = 6 completes the remaining multiplication.</string>
+    <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completes the puzzle.</string>
+    <string name="tutorial_worked_example_progress">Resolving example…</string>
     <string name="tutorial_repeated_value_practice_copy">Solve the puzzle. Remember: the number list can include the same number more than once.</string>
     <string name="onboarding_skip_tutorial_action">Skip tutorial</string>
     <string name="onboarding_skip_tutorial_title">Skip the tutorial?</string>

--- a/app/src/test/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepositoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/onboarding/DataStoreOnboardingRepositoryTest.kt
@@ -66,14 +66,13 @@ class DataStoreOnboardingRepositoryTest {
     }
 
     @Test
-    fun `stage checkpoints only move forward`() = runBlocking {
+    fun `worked example checkpoint is persisted`() = runBlocking {
         val repository = createRepository().repository
 
-        repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_TWO)
-        repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_ONE)
+        repository.recordStageCompleted(OnboardingStageCheckpoint.EXPLANATION_COMPLETED)
 
         assertEquals(
-            OnboardingStageCheckpoint.STAGE_TWO,
+            OnboardingStageCheckpoint.EXPLANATION_COMPLETED,
             repository.onboardingState.first().lastCompletedStage
         )
     }
@@ -86,13 +85,13 @@ class DataStoreOnboardingRepositoryTest {
     @Test
     fun `tutorial completion is independent from stage checkpoint`() = runBlocking {
         val repository = createRepository().repository
-        repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_TWO)
+        repository.recordStageCompleted(OnboardingStageCheckpoint.EXPLANATION_COMPLETED)
 
         repository.markTutorialCompleted()
 
         val state = repository.onboardingState.first()
         assertTrue(state.firstRunTutorialOutcome.isResolved)
-        assertEquals(OnboardingStageCheckpoint.STAGE_TWO, state.lastCompletedStage)
+        assertEquals(OnboardingStageCheckpoint.EXPLANATION_COMPLETED, state.lastCompletedStage)
         assertEquals(FirstRunTutorialOutcome.COMPLETED, state.firstRunTutorialOutcome)
     }
 
@@ -135,7 +134,7 @@ class DataStoreOnboardingRepositoryTest {
     @Test
     fun `clearing all application data starts a new first run`() = runBlocking {
         val fixture = createRepository()
-        fixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_TWO)
+        fixture.repository.recordStageCompleted(OnboardingStageCheckpoint.EXPLANATION_COMPLETED)
         fixture.repository.markTutorialCompleted()
 
         fixture.dataStore.edit { preferences -> preferences.clear() }
@@ -147,13 +146,13 @@ class DataStoreOnboardingRepositoryTest {
     fun `resolved state persists across repository instances`() = runBlocking {
         val dataStoreFile = createDataStoreFile()
         val firstFixture = createRepository(dataStoreFile)
-        firstFixture.repository.recordStageCompleted(OnboardingStageCheckpoint.STAGE_TWO)
+        firstFixture.repository.recordStageCompleted(OnboardingStageCheckpoint.EXPLANATION_COMPLETED)
         firstFixture.repository.markTutorialCompleted()
         firstFixture.close()
 
         val restoredState = createRepository(dataStoreFile).repository.onboardingState.first()
 
-        assertEquals(OnboardingStageCheckpoint.STAGE_TWO, restoredState.lastCompletedStage)
+        assertEquals(OnboardingStageCheckpoint.EXPLANATION_COMPLETED, restoredState.lastCompletedStage)
         assertEquals(FirstRunTutorialOutcome.COMPLETED, restoredState.firstRunTutorialOutcome)
     }
 

--- a/app/src/test/java/org/cescfe/numpairs/feature/onboarding/OnboardingStartupCoordinatorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/onboarding/OnboardingStartupCoordinatorTest.kt
@@ -105,7 +105,7 @@ class OnboardingStartupCoordinatorTest {
     )
 
     private fun completedState(outcome: FirstRunTutorialOutcome): OnboardingState = OnboardingState(
-        lastCompletedStage = OnboardingStageCheckpoint.STAGE_TWO,
+        lastCompletedStage = OnboardingStageCheckpoint.EXPLANATION_COMPLETED,
         firstRunTutorialOutcome = outcome
     )
 

--- a/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
@@ -10,8 +10,10 @@ class RequiredOnboardingRouteTest {
     @Test
     fun `checkpoints resume after the last completed Tutorial step`() {
         assertEquals(0, state(OnboardingStageCheckpoint.NONE).nextRequiredTutorialStepIndex())
-        assertEquals(5, state(OnboardingStageCheckpoint.STAGE_ONE).nextRequiredTutorialStepIndex())
-        assertEquals(6, state(OnboardingStageCheckpoint.STAGE_TWO).nextRequiredTutorialStepIndex())
+        assertEquals(
+            5,
+            state(OnboardingStageCheckpoint.EXPLANATION_COMPLETED).nextRequiredTutorialStepIndex()
+        )
     }
 
     @Test
@@ -25,13 +27,7 @@ class RequiredOnboardingRouteTest {
 
         assertEquals(
             6,
-            state(OnboardingStageCheckpoint.STAGE_ONE).nextRequiredTutorialStepIndex(
-                steps = stepsWithInsertedOrientation
-            )
-        )
-        assertEquals(
-            7,
-            state(OnboardingStageCheckpoint.STAGE_TWO).nextRequiredTutorialStepIndex(
+            state(OnboardingStageCheckpoint.EXPLANATION_COMPLETED).nextRequiredTutorialStepIndex(
                 steps = stepsWithInsertedOrientation
             )
         )

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -9,10 +9,7 @@ import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.domain.puzzle.model.PuzzleCompletionState
 import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.cescfe.numpairs.domain.puzzle.model.Tile
-import org.cescfe.numpairs.feature.game.GameTileExpressionSlot
-import org.cescfe.numpairs.feature.game.GameTileExpressionSlotHighlight
 import org.cescfe.numpairs.feature.game.presentation.GameUiState
-import org.cescfe.numpairs.feature.game.presentation.TileUiState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -79,16 +76,13 @@ class TutorialContentTest {
     }
 
     @Test
-    fun learn_basics_adds_manual_explanation_before_the_existing_guided_curriculum() {
+    fun learn_basics_contains_explanation_worked_example_and_independent_practice() {
         val introductionScenario = TutorialContent.scenario(TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION)
         val repeatedValueScenario = TutorialContent.scenario(TutorialScenarioId.REPEATED_VALUE_PRACTICE)
         val steps = TutorialContent.stepsFor(TutorialMode.LEARN_BASICS)
-        val guidedIntroductionPuzzle = requireNotNull(steps[4].entryPuzzle)
-        val introductionWithCompletedStrip = guidedIntroductionPuzzle.withStripValue(index = 1, value = 3)
 
         assertEquals(
             listOf(
-                TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
                 TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
                 TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
                 TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
@@ -104,8 +98,7 @@ class TutorialContentTest {
                 null,
                 null,
                 null,
-                TutorialProgressCheckpoint.STRIP_INTRODUCTION_COMPLETED,
-                TutorialProgressCheckpoint.TILES_INTRODUCTION_COMPLETED,
+                TutorialProgressCheckpoint.WORKED_EXAMPLE_COMPLETED,
                 null
             ),
             steps.map(TutorialStep::progressCheckpoint)
@@ -150,31 +143,13 @@ class TutorialContentTest {
             assertEquals(introductionScenario.initialPuzzle, step.entryPuzzle ?: introductionScenario.initialPuzzle)
         }
 
-        steps[4].assertGuidedAction(
-            expectedHighlights = listOf(
-                TutorialHighlightTarget.StripEntries(indexes = listOf(1))
-            ),
-            expectedAction = TutorialRequiredAction.EnterStripValue(stripEntryIndex = 1, value = 3),
-            incompletePuzzle = guidedIntroductionPuzzle,
-            completePuzzle = introductionWithCompletedStrip
-        )
-        assertFalse(steps[4].isBoardVisible)
-        assertEquals(R.string.tutorial_strip_entry_guidance, steps[4].stripEntryGuidanceResId)
+        val workedExampleStep = steps[4]
+        val workedExample = workedExampleStep.requiredAction as TutorialRequiredAction.PlayWorkedExample
+        assertEquals(TutorialStepCompletionPredicate.ManualAdvance, workedExampleStep.completionPredicate)
+        assertEquals(introductionScenario.initialPuzzle, workedExampleStep.entryPuzzle)
+        assertEquals(introductionScenario.initialPuzzle, workedExample.frames.first().puzzle)
 
         steps[5].assertGuidedAction(
-            expectedHighlights = listOf(
-                TutorialHighlightTarget.TileExpressionSlots(tileIndex = 0),
-                TutorialHighlightTarget.WholeTile(tileIndex = 1)
-            ),
-            expectedAction = TutorialRequiredAction.CompleteTileWithNormalInteractions(tileIndex = 0),
-            incompletePuzzle = introductionWithCompletedStrip,
-            completePuzzle = introductionWithCompletedStrip.withSolvedScenarioTiles(introductionScenario, 0)
-        )
-        assertTrue(steps[5].isBoardVisible)
-        assertEquals(null, steps[5].stripEntryGuidanceResId)
-        assertEquals(introductionWithCompletedStrip, steps[5].entryPuzzle)
-
-        steps[6].assertGuidedAction(
             expectedHighlights = listOf(
                 TutorialHighlightTarget.HiddenStripEntries,
                 TutorialHighlightTarget.HiddenTileExpressions
@@ -186,10 +161,77 @@ class TutorialContentTest {
     }
 
     @Test
+    fun worked_example_frames_follow_the_exact_reasoned_solution_order() {
+        val step = TutorialContent.learnBasicsSteps[4]
+        val frames = (step.requiredAction as TutorialRequiredAction.PlayWorkedExample).frames
+
+        assertEquals(
+            listOf(
+                R.string.tutorial_worked_example_introduction_copy,
+                R.string.tutorial_worked_example_product_four_five_copy,
+                R.string.tutorial_worked_example_sum_four_five_copy,
+                R.string.tutorial_worked_example_reveal_three_copy,
+                R.string.tutorial_worked_example_product_two_three_copy,
+                R.string.tutorial_worked_example_sum_two_three_copy
+            ),
+            frames.map(TutorialWorkedExampleFrame::playerFacingCopyResId)
+        )
+        assertEquals(
+            listOf(
+                emptySet(),
+                setOf(3),
+                setOf(2, 3),
+                setOf(2, 3),
+                setOf(1, 2, 3),
+                setOf(0, 1, 2, 3)
+            ),
+            frames.map { frame ->
+                frame.puzzle.board.tiles.mapIndexedNotNullTo(mutableSetOf()) { index, tile ->
+                    index.takeIf { tile.expression.isFullyKnown }
+                }
+            }
+        )
+        assertEquals(StripItem.Hidden, frames[2].puzzle.strip.items[1])
+        assertEquals(StripItem.PlayerEntered(3), frames[3].puzzle.strip.items[1])
+        assertEquals(PuzzleCompletionState.SOLVED, frames.last().puzzle.completionState)
+        assertEquals(
+            listOf(
+                listOf(0, 1, 2, 3),
+                listOf(2, 3),
+                listOf(2, 3),
+                listOf(0, 1),
+                listOf(0, 1),
+                listOf(0, 1)
+            ),
+            frames.map { frame ->
+                frame.highlightedTargets
+                    .filterIsInstance<TutorialHighlightTarget.StripEntries>()
+                    .single()
+                    .indexes
+            }
+        )
+        assertEquals(
+            listOf(
+                listOf(0, 1, 2, 3),
+                listOf(3),
+                listOf(2),
+                listOf(0, 1),
+                listOf(1),
+                listOf(0)
+            ),
+            frames.map { frame ->
+                frame.highlightedTargets
+                    .filterIsInstance<TutorialHighlightTarget.WholeTile>()
+                    .map(TutorialHighlightTarget.WholeTile::tileIndex)
+            }
+        )
+    }
+
+    @Test
     fun manual_explanation_freezes_every_puzzle_interaction() {
         val scenario = TutorialContent.scenario(TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION)
 
-        TutorialContent.learnBasicsSteps.take(4).forEach { step ->
+        TutorialContent.learnBasicsSteps.take(5).forEach { step ->
             val policy = step.toInteractionPolicy(scenario = scenario, uiState = null)
 
             scenario.stripValues.indices.forEach { index ->
@@ -205,59 +247,6 @@ class TutorialContentTest {
     }
 
     @Test
-    fun learn_basics_step_two_highlights_the_editable_slots_and_complementary_product_tile() {
-        val scenario = TutorialContent.scenario(TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION)
-        val step = TutorialContent.learnBasicsSteps[5]
-
-        val highlightState = step.toHighlightState(scenario = scenario, uiState = null)
-
-        assertEquals(setOf(1), highlightState.tileIndexes)
-        assertEquals(
-            GameTileExpressionSlot.entries.mapTo(mutableSetOf()) { slot ->
-                GameTileExpressionSlotHighlight(tileIndex = 0, slot = slot)
-            },
-            highlightState.tileExpressionSlots
-        )
-        assertFalse(highlightState.isTileHighlighted(index = 0))
-        assertFalse(highlightState.isTileHighlighted(index = 2))
-        assertFalse(highlightState.isTileHighlighted(index = 3))
-    }
-
-    @Test
-    fun learn_basics_step_two_keeps_normal_choices_for_the_target_tile() {
-        val scenario = TutorialContent.scenario(TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION)
-        val policy = TutorialContent.learnBasicsSteps[5].toInteractionPolicy(scenario = scenario, uiState = null)
-
-        OperandSlot.entries.forEach { slot ->
-            assertTrue(policy.canConfirmTileOperand(0, slot, 0))
-            assertTrue(policy.canConfirmTileOperand(0, slot, 1))
-            assertFalse(policy.canConfirmTileOperand(1, slot, 0))
-        }
-        assertTrue(policy.canTapTileLeftOperand(0))
-        assertTrue(policy.canTapTileRightOperand(0))
-        assertTrue(policy.canTapTileOperator(0))
-        assertTrue(policy.canTapTileReset(0))
-        assertTrue(policy.canConfirmTileOperator(0, Operator.ADDITION))
-        assertTrue(policy.canConfirmTileOperator(0, Operator.MULTIPLICATION))
-        assertFalse(policy.canTapStripItem(0))
-        assertFalse(policy.canTapTileLeftOperand(1))
-        assertFalse(policy.canTapTileRightOperand(1))
-        assertFalse(policy.canTapTileOperator(1))
-        assertFalse(policy.canTapTileReset(1))
-        assertFalse(policy.canConfirmTileOperator(1, Operator.ADDITION))
-    }
-
-    @Test
-    fun learn_basics_step_two_accepts_the_pair_in_either_operand_order() {
-        val step = TutorialContent.learnBasicsSteps[5]
-
-        assertTrue(step.isComplete(stepTwoUiState(leftValue = 2, operator = Operator.ADDITION, rightValue = 3)))
-        assertTrue(step.isComplete(stepTwoUiState(leftValue = 3, operator = Operator.ADDITION, rightValue = 2)))
-        assertFalse(step.isComplete(stepTwoUiState(leftValue = 3, operator = Operator.MULTIPLICATION, rightValue = 2)))
-        assertFalse(step.isComplete(stepTwoUiState(leftValue = 2, operator = Operator.ADDITION, rightValue = 4)))
-    }
-
-    @Test
     fun strip_and_tiles_introduction_has_the_exact_authored_state() {
         val scenario = TutorialContent.scenario(TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION)
         val tiles = scenario.initialPuzzle.board.tiles
@@ -269,21 +258,6 @@ class TutorialContentTest {
         )
         assertAllTilesHaveHiddenExpressions(scenario.initialPuzzle)
         assertEquals(listOf(5, 6, 9, 20), tiles.map(Tile::result))
-
-        val guidedEntryPuzzle = requireNotNull(TutorialContent.learnBasicsSteps[4].entryPuzzle)
-        assertTrue(guidedEntryPuzzle.board.tiles[0].hasHiddenExpression())
-        assertEquals(
-            Expression(2, Operator.MULTIPLICATION, 3),
-            guidedEntryPuzzle.board.tiles[1].expression.withoutEntryIds()
-        )
-        assertEquals(
-            Expression(4, Operator.ADDITION, 5),
-            guidedEntryPuzzle.board.tiles[2].expression.withoutEntryIds()
-        )
-        assertEquals(
-            Expression(4, Operator.MULTIPLICATION, 5),
-            guidedEntryPuzzle.board.tiles[3].expression.withoutEntryIds()
-        )
     }
 
     @Test
@@ -391,18 +365,6 @@ class TutorialContentTest {
     }
 }
 
-private fun stepTwoUiState(leftValue: Int, operator: Operator, rightValue: Int): GameUiState = GameUiState(
-    stripItems = emptyList(),
-    tiles = listOf(
-        TileUiState(
-            leftOperandLabel = leftValue.toString(),
-            operatorLabel = operator.symbol,
-            rightOperandLabel = rightValue.toString(),
-            resultLabel = "5"
-        )
-    )
-)
-
 private fun assertAllTilesHaveHiddenExpressions(puzzle: Puzzle) {
     assertTrue(
         puzzle.board.tiles.all { tile ->
@@ -414,15 +376,6 @@ private fun assertAllTilesHaveHiddenExpressions(puzzle: Puzzle) {
 private fun Tile.hasHiddenExpression(): Boolean = expression.leftOperand == Expression.Operand.Hidden &&
     expression.operator == Operator.Hidden &&
     expression.rightOperand == Expression.Operand.Hidden
-
-private fun Expression.withoutEntryIds(): Expression = copy(
-    leftOperand = (leftOperand as Expression.Operand.Known).copy(stripEntryId = null),
-    rightOperand = (rightOperand as Expression.Operand.Known).copy(stripEntryId = null)
-)
-
-private fun Puzzle.withStripValue(index: Int, value: Int): Puzzle = copy(
-    strip = strip.withUpdatedEntry(index = index, value = value)
-)
 
 private fun Puzzle.withSolvedScenarioTiles(scenario: TutorialScenario, vararg tileIndexes: Int): Puzzle = copy(
     board = Board(


### PR DESCRIPTION
## Related Issue

Resolves #553

## Summary

- Replace the former guided strip and tile actions with a deterministic, fully explained worked example.
- Resolve the authored puzzle in five focused frames while locking puzzle and step navigation.
- Restore manual navigation after playback, restart the sequence on re-entry, and skip staged delays for reduced motion.
- Persist required-onboarding progress only after the example has completed.
- Cover authored frame order, final state, playback locking, replay, reduced motion, localization, and resume behavior.

## UI Consistency

- Shared components or tokens reused: existing Tutorial instruction surface, game highlights, Material 3 text buttons, spacing, typography, colors, border, and 48 dp footer touch-target height.
- Intentional deviations from established visual roles: during playback, the Back/Next row is temporarily replaced by a same-height progress message so unavailable navigation is clear without shifting the puzzle layout.

## Validation

- ./gradlew spotlessApply
- ./gradlew testDebugUnitTest
- ./gradlew spotlessCheck
- ./gradlew compileDebugAndroidTestKotlin
- ./gradlew lintDebug