### PR TITLE
[268] Guide the independent Tutorial practice

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
@@ -49,8 +49,9 @@ class LocalizationResourceTest {
                 "2 × 3 = 6 completa la multiplicación que falta.",
                 "2 + 3 = 5 completa el puzle.",
                 "Resolviendo ejemplo…",
-                "Resuelve el puzle. Recuerda: la lista de números puede incluir " +
-                    "el mismo número más de una vez."
+                "Ahora tú: resuelve el puzle. Toca cualquier ? para empezar. " +
+                    "Los números pueden repetirse. Consejo: las multiplicaciones suelen ser " +
+                    "un buen punto de partida."
             )
         )
         assertEquals("Saltar tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
@@ -98,8 +99,8 @@ class LocalizationResourceTest {
                 "2 × 3 = 6 completa la multiplicació que falta.",
                 "2 + 3 = 5 completa el puzle.",
                 "Resolent l’exemple…",
-                "Resol el puzle. Recorda: la llista de números pot incloure " +
-                    "el mateix número més d’una vegada."
+                "Ara tu: resol el puzle. Toca qualsevol ? per començar. Els nombres es poden repetir. " +
+                    "Consell: les multiplicacions solen ser un bon punt de partida."
             )
         )
         assertEquals("Omet el tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
@@ -147,8 +148,8 @@ class LocalizationResourceTest {
                 "2 × 3 = 6 completes the remaining multiplication.",
                 "2 + 3 = 5 completes the puzzle.",
                 "Resolving example…",
-                "Solve the puzzle. Remember: the number list can include " +
-                    "the same number more than once."
+                "Your turn: solve the puzzle. Tap any ? to begin. Numbers may repeat. " +
+                    "Tip: multiplication is often a good place to start."
             )
         )
         assertEquals("Skip tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -198,6 +198,40 @@ class TutorialRouteTest {
     }
 
     @Test
+    fun independentPracticeCueAllowsAnyFirstActionThenStaysDismissed() {
+        setContent(startStepIndex = PRACTICE_STEP_INDEX)
+
+        assertRepeatedValuePracticeScenarioDisplayed()
+        assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(0))
+        assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(1))
+        assertHighlighted(testTag = GameScreenTestTags.stripItem(2))
+        assertHighlighted(testTag = GameScreenTestTags.stripItem(3))
+        assertUnmergedNodeNotHighlighted(testTag = GameScreenTestTags.tile(0))
+        assertHighlighted(testTag = GameScreenTestTags.tile(3), useUnmergedTree = true)
+
+        openTileOperatorMenu(tileIndex = 0)
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileOperatorOption(Operator.ADDITION), useUnmergedTree = true)
+            .assertIsEnabled()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileOperatorOption(Operator.MULTIPLICATION), useUnmergedTree = true)
+            .assertIsEnabled()
+            .performClick()
+        assertPracticeCueDismissed()
+
+        openTileOperatorMenu(tileIndex = 0)
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileOperatorOption(Operator.ADDITION), useUnmergedTree = true)
+            .assertIsEnabled()
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.tileReset(0), useUnmergedTree = true)
+            .assertIsDisplayed()
+            .performClick()
+        assertPracticeCueDismissed()
+    }
+
+    @Test
     fun independentPracticeUsesNormalInteractionsAndCompletesLearnBasicsWithoutShowingSuccess() {
         setContent()
 
@@ -680,6 +714,13 @@ class TutorialRouteTest {
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.tileRightOperand(tileIndex), useUnmergedTree = true)
             .assertHasNoClickAction()
+    }
+
+    private fun assertPracticeCueDismissed() {
+        repeat(4) { index ->
+            assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(index))
+            assertUnmergedNodeNotHighlighted(testTag = GameScreenTestTags.tile(index))
+        }
     }
 
     private fun assertNodeNotHighlighted(testTag: String, useUnmergedTree: Boolean = false) {

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
@@ -21,11 +21,12 @@ internal object LearnBasicsTutorialContent {
             scenarioId = TutorialScenarioId.REPEATED_VALUE_PRACTICE,
             playerFacingCopyResId = R.string.tutorial_repeated_value_practice_copy,
             highlightedTargets = listOf(
-                TutorialHighlightTarget.HiddenStripEntries,
-                TutorialHighlightTarget.HiddenTileExpressions
+                TutorialHighlightTarget.StripEntries(indexes = listOf(2, 3)),
+                TutorialHighlightTarget.WholeTile(tileIndex = 3)
             ),
             requiredAction = TutorialRequiredAction.CompleteScenario,
-            completionPredicate = TutorialStepCompletionPredicate.ScenarioSolved
+            completionPredicate = TutorialStepCompletionPredicate.ScenarioSolved,
+            dismissHighlightsAfterFirstPuzzleChange = true
         )
     )
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
@@ -57,6 +57,7 @@ data class TutorialStep(
     val completionPredicate: TutorialStepCompletionPredicate,
     val progressCheckpoint: TutorialProgressCheckpoint? = null,
     val isBoardVisible: Boolean = true,
+    val dismissHighlightsAfterFirstPuzzleChange: Boolean = false,
     val entryPuzzle: Puzzle? = null
 ) {
     init {

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -89,6 +89,9 @@ fun TutorialRoute(
     var isCheckpointNavigationInProgress by remember(playbackKey, currentStepIndex) {
         mutableStateOf(false)
     }
+    var hasCurrentStepPuzzleChanged by remember(playbackKey, currentStepIndex) {
+        mutableStateOf(false)
+    }
     val workedExampleFrame = workedExample?.frames?.get(workedExampleFrameIndex)
     val presentedStep = workedExampleFrame?.let { frame ->
         currentStep.copy(
@@ -164,7 +167,8 @@ fun TutorialRoute(
         ),
         highlightState = presentedStep.toHighlightState(
             scenario = currentScenario,
-            uiState = latestGameUiState
+            uiState = latestGameUiState,
+            hasPuzzleChanged = hasCurrentStepPuzzleChanged
         ),
         bottomBar = {
             onSkipTutorialRequested?.let { onSkipRequested ->
@@ -204,6 +208,11 @@ fun TutorialRoute(
                 scenarioId = currentScenario.id,
                 uiState = uiState
             )
+        },
+        onPuzzleChanged = { puzzle ->
+            if (puzzle != currentEntryPuzzle) {
+                hasCurrentStepPuzzleChanged = true
+            }
         },
         onNavigateBack = onNavigateBack
     )
@@ -540,7 +549,15 @@ private fun TutorialStep.highlightedStripEntryIds(scenario: TutorialScenario): S
     }
 }
 
-internal fun TutorialStep.toHighlightState(scenario: TutorialScenario, uiState: GameUiState?): GameHighlightState {
+internal fun TutorialStep.toHighlightState(
+    scenario: TutorialScenario,
+    uiState: GameUiState?,
+    hasPuzzleChanged: Boolean = false
+): GameHighlightState {
+    if (dismissHighlightsAfterFirstPuzzleChange && hasPuzzleChanged) {
+        return GameHighlightState.None
+    }
+
     val orderedAction = requiredAction as? TutorialRequiredAction.CompleteTileExpressionsInOrder
 
     if (orderedAction != null) {

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -74,7 +74,7 @@
     <string name="tutorial_worked_example_product_two_three_copy">2 × 3 = 6 completa la multiplicació que falta.</string>
     <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completa el puzle.</string>
     <string name="tutorial_worked_example_progress">Resolent l’exemple…</string>
-    <string name="tutorial_repeated_value_practice_copy">Resol el puzle. Recorda: la llista de números pot incloure el mateix número més d’una vegada.</string>
+    <string name="tutorial_repeated_value_practice_copy">Ara tu: resol el puzle. Toca qualsevol ? per començar. Els nombres es poden repetir. Consell: les multiplicacions solen ser un bon punt de partida.</string>
     <string name="onboarding_skip_tutorial_action">Omet el tutorial</string>
     <string name="onboarding_skip_tutorial_title">Vols ometre el tutorial?</string>
     <string name="onboarding_skip_tutorial_message">Si és la primera vegada que jugues a NumPairs o a jocs similars, et recomanem continuar. Podràs tornar a obrir el tutorial més tard des de Com jugar.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -74,7 +74,7 @@
     <string name="tutorial_worked_example_product_two_three_copy">2 × 3 = 6 completa la multiplicación que falta.</string>
     <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completa el puzle.</string>
     <string name="tutorial_worked_example_progress">Resolviendo ejemplo…</string>
-    <string name="tutorial_repeated_value_practice_copy">Resuelve el puzle. Recuerda: la lista de números puede incluir el mismo número más de una vez.</string>
+    <string name="tutorial_repeated_value_practice_copy">Ahora tú: resuelve el puzle. Toca cualquier ? para empezar. Los números pueden repetirse. Consejo: las multiplicaciones suelen ser un buen punto de partida.</string>
     <string name="onboarding_skip_tutorial_action">Saltar tutorial</string>
     <string name="onboarding_skip_tutorial_title">¿Saltar el tutorial?</string>
     <string name="onboarding_skip_tutorial_message">Si es la primera vez que juegas a NumPairs o a juegos similares, te recomendamos continuar. Podrás volver a abrir el tutorial más tarde desde Cómo jugar.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,7 +74,7 @@
     <string name="tutorial_worked_example_product_two_three_copy">2 × 3 = 6 completes the remaining multiplication.</string>
     <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completes the puzzle.</string>
     <string name="tutorial_worked_example_progress">Resolving example…</string>
-    <string name="tutorial_repeated_value_practice_copy">Solve the puzzle. Remember: the number list can include the same number more than once.</string>
+    <string name="tutorial_repeated_value_practice_copy">Your turn: solve the puzzle. Tap any ? to begin. Numbers may repeat. Tip: multiplication is often a good place to start.</string>
     <string name="onboarding_skip_tutorial_action">Skip tutorial</string>
     <string name="onboarding_skip_tutorial_title">Skip the tutorial?</string>
     <string name="onboarding_skip_tutorial_message">If you’re new to NumPairs or similar games, we recommend continuing. You can open the Tutorial again later from How to play.</string>

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -9,6 +9,7 @@ import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.domain.puzzle.model.PuzzleCompletionState
 import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.cescfe.numpairs.domain.puzzle.model.Tile
+import org.cescfe.numpairs.feature.game.GameHighlightState
 import org.cescfe.numpairs.feature.game.presentation.GameUiState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -151,8 +152,8 @@ class TutorialContentTest {
 
         steps[5].assertGuidedAction(
             expectedHighlights = listOf(
-                TutorialHighlightTarget.HiddenStripEntries,
-                TutorialHighlightTarget.HiddenTileExpressions
+                TutorialHighlightTarget.StripEntries(indexes = listOf(2, 3)),
+                TutorialHighlightTarget.WholeTile(tileIndex = 3)
             ),
             expectedAction = TutorialRequiredAction.CompleteScenario,
             incompletePuzzle = repeatedValueScenario.initialPuzzle,
@@ -284,6 +285,45 @@ class TutorialContentTest {
         assertEquals(PuzzleCompletionState.SOLVED, alternateSolvedPuzzle.completionState)
         assertTrue(finalStep.isComplete(GameUiState.from(scenario.solvedPuzzle)))
         assertTrue(finalStep.isComplete(GameUiState.from(alternateSolvedPuzzle)))
+    }
+
+    @Test
+    fun repeated_value_practice_starts_with_a_dismissible_cue_and_unrestricted_interactions() {
+        val scenario = TutorialContent.scenario(TutorialScenarioId.REPEATED_VALUE_PRACTICE)
+        val step = TutorialContent.learnBasicsSteps.last()
+        val initialHighlightState = step.toHighlightState(
+            scenario = scenario,
+            uiState = GameUiState.from(scenario.initialPuzzle)
+        )
+        val policy = step.toInteractionPolicy(
+            scenario = scenario,
+            uiState = GameUiState.from(scenario.initialPuzzle)
+        )
+
+        assertTrue(step.dismissHighlightsAfterFirstPuzzleChange)
+        assertEquals(setOf(2, 3), initialHighlightState.stripEntryIndexes)
+        assertEquals(setOf(3), initialHighlightState.tileIndexes)
+        assertEquals(
+            GameHighlightState.None,
+            step.toHighlightState(
+                scenario = scenario,
+                uiState = GameUiState.from(scenario.initialPuzzle),
+                hasPuzzleChanged = true
+            )
+        )
+        scenario.stripValues.indices.forEach { index ->
+            assertTrue(policy.canTapStripItem(index))
+            assertTrue(policy.canConfirmStripItemEntry(index, scenario.stripValues[index]))
+        }
+        scenario.initialPuzzle.board.tiles.indices.forEach { index ->
+            assertTrue(policy.canTapTileLeftOperand(index))
+            assertTrue(policy.canTapTileRightOperand(index))
+            assertTrue(policy.canTapTileOperator(index))
+            assertTrue(policy.canTapTileReset(index))
+            assertTrue(policy.canConfirmTileOperand(index, OperandSlot.LEFT, 0))
+            assertTrue(policy.canConfirmTileOperator(index, Operator.ADDITION))
+            assertTrue(policy.canConfirmTileOperator(index, Operator.MULTIPLICATION))
+        }
     }
 
     @Test


### PR DESCRIPTION
## Related Issue

Resolves #554

## Summary

- Rewrite the final Learn Basics instruction as a clear player-turn prompt with an interaction cue, repeated-value reminder, and multiplication heuristic.
- Focus the initial visual cue on the known 2 and 3 entries and the result-6 tile without restricting normal gameplay.
- Dismiss that cue after the first committed puzzle change and keep it dismissed through corrections and resets in the same attempt.
- Align Spanish, Catalan, and English resources and cover cue behavior, unrestricted interactions, both repeated-value solutions, completion, skip, and replay paths.

## UI Consistency

- Shared components or tokens reused: existing Tutorial instruction surface and existing strip/tile highlight semantics; no new component, color, typography, spacing, or interaction role was introduced.
- Intentional deviations from established visual roles: none.

## Validation

- ./gradlew spotlessApply
- ./gradlew testDebugUnitTest
- ./gradlew spotlessCheck
- ./gradlew compileDebugAndroidTestKotlin
- ./gradlew lintDebug