### PR TITLE
[269] Let players pace the Tutorial worked example

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
@@ -48,7 +48,6 @@ class LocalizationResourceTest {
                 "Quedan los resultados 5 y 6. Junto al 2, el número oculto tiene que ser 3.",
                 "2 × 3 = 6 completa la multiplicación que falta.",
                 "2 + 3 = 5 completa el puzle.",
-                "Resolviendo ejemplo…",
                 "Ahora tú: resuelve el puzle. Toca cualquier ? para empezar. " +
                     "Los números pueden repetirse. Consejo: las multiplicaciones suelen ser " +
                     "un buen punto de partida."
@@ -98,7 +97,6 @@ class LocalizationResourceTest {
                 "Queden els resultats 5 i 6. Junt amb el 2, el nombre ocult ha de ser 3.",
                 "2 × 3 = 6 completa la multiplicació que falta.",
                 "2 + 3 = 5 completa el puzle.",
-                "Resolent l’exemple…",
                 "Ara tu: resol el puzle. Toca qualsevol ? per començar. Els nombres es poden repetir. " +
                     "Consell: les multiplicacions solen ser un bon punt de partida."
             )
@@ -147,7 +145,6 @@ class LocalizationResourceTest {
                 "The remaining results are 5 and 6. Paired with 2, the hidden number must be 3.",
                 "2 × 3 = 6 completes the remaining multiplication.",
                 "2 + 3 = 5 completes the puzzle.",
-                "Resolving example…",
                 "Your turn: solve the puzzle. Tap any ? to begin. Numbers may repeat. " +
                     "Tip: multiplication is often a good place to start."
             )
@@ -167,7 +164,6 @@ class LocalizationResourceTest {
             R.string.tutorial_worked_example_reveal_three_copy,
             R.string.tutorial_worked_example_product_two_three_copy,
             R.string.tutorial_worked_example_sum_two_three_copy,
-            R.string.tutorial_worked_example_progress,
             R.string.tutorial_repeated_value_practice_copy
         )
 

--- a/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
@@ -101,7 +101,8 @@ class RequiredOnboardingNavigationTest {
         setContent(repository)
 
         advanceThroughExplanation()
-        waitForTutorialCopy(R.string.tutorial_worked_example_sum_two_three_copy)
+        advanceThroughWorkedExample()
+        assertEquals(OnboardingStageCheckpoint.NONE, repository.onboardingState.value.lastCompletedStage)
         composeTestRule
             .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
             .performScrollTo()
@@ -252,6 +253,16 @@ class RequiredOnboardingNavigationTest {
                 .performScrollTo()
                 .performClick()
         }
+    }
+
+    private fun advanceThroughWorkedExample() {
+        repeat(5) {
+            composeTestRule
+                .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+                .performScrollTo()
+                .performClick()
+        }
+        waitForTutorialCopy(R.string.tutorial_worked_example_sum_two_three_copy)
     }
 
     private fun completeTile(tileIndex: Int, leftStripEntryId: Int, operator: Operator, rightStripEntryId: Int) {

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -119,79 +119,49 @@ class TutorialRouteTest {
     }
 
     @Test
-    fun workedExamplePlaysInOrderWhileNavigationAndPuzzleInteractionsAreLocked() {
-        composeTestRule.mainClock.autoAdvance = false
-        setContent(sequentialWorkedExamplePlayback = true)
+    fun workedExampleAdvancesManuallyInOrderWhilePuzzleInteractionsStayLocked() {
+        setContent()
         advanceThroughExplanation()
 
-        assertWorkedExampleFrame(R.string.tutorial_worked_example_introduction_copy)
-        composeTestRule
-            .onNodeWithTag(TutorialScreenTestTags.WORKED_EXAMPLE_PROGRESS)
-            .assertIsDisplayed()
+        assertStepDisplayed(stepIndex = WORKED_EXAMPLE_INTRODUCTION_STEP_INDEX)
         composeTestRule
             .onNodeWithTag(TutorialScreenTestTags.PREVIOUS_STEP_ACTION)
-            .assertDoesNotExist()
+            .assertIsDisplayed()
+            .assertIsEnabled()
         composeTestRule
             .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
-            .assertDoesNotExist()
+            .assertIsDisplayed()
+            .assertIsEnabled()
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.stripItem(1))
             .assertHasNoClickAction()
         assertTileExpressionSlotsHaveNoClickAction(tileIndex = 3)
+        repeat(4, ::assertTileExpressionHidden)
 
-        advanceWorkedExampleFrame(R.string.tutorial_worked_example_product_four_five_copy)
+        advanceWorkedExampleStep(PRODUCT_FOUR_FIVE_STEP_INDEX)
         assertTileExpression(tileIndex = 3, operator = Operator.MULTIPLICATION, leftValue = "4", rightValue = "5")
-        advanceWorkedExampleFrame(R.string.tutorial_worked_example_sum_four_five_copy)
+        advanceWorkedExampleStep(SUM_FOUR_FIVE_STEP_INDEX)
         assertTileExpression(tileIndex = 2, operator = Operator.ADDITION, leftValue = "4", rightValue = "5")
-        advanceWorkedExampleFrame(R.string.tutorial_worked_example_reveal_three_copy)
+        advanceWorkedExampleStep(REVEAL_THREE_STEP_INDEX)
         assertFocusedIntroductionStripDisplayed(expectedSecondValue = "3", isSecondValuePlayerEntered = true)
-        advanceWorkedExampleFrame(R.string.tutorial_worked_example_product_two_three_copy)
+        advanceWorkedExampleStep(PRODUCT_TWO_THREE_STEP_INDEX)
         assertTileExpression(tileIndex = 1, operator = Operator.MULTIPLICATION)
-        advanceWorkedExampleFrame(R.string.tutorial_worked_example_sum_two_three_copy)
+        advanceWorkedExampleStep(SUM_TWO_THREE_STEP_INDEX)
         assertTileExpression(tileIndex = 0, operator = Operator.ADDITION)
 
-        composeTestRule
-            .onNodeWithTag(TutorialScreenTestTags.WORKED_EXAMPLE_PROGRESS)
-            .assertDoesNotExist()
         composeTestRule
             .onNodeWithTag(TutorialScreenTestTags.PREVIOUS_STEP_ACTION)
             .assertIsDisplayed()
             .assertIsEnabled()
             .performClick()
-        assertStepDisplayed(stepIndex = PAIR_EXPLANATION_STEP_INDEX)
-        composeTestRule
-            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
-            .performClick()
-        assertWorkedExampleFrame(R.string.tutorial_worked_example_introduction_copy)
-        composeTestRule
-            .onNodeWithTag(TutorialScreenTestTags.WORKED_EXAMPLE_PROGRESS)
-            .assertIsDisplayed()
-    }
-
-    @Test
-    fun reducedMotionShowsTheSolvedExampleImmediatelyAndRestoresNavigation() {
-        setContent(
-            startStepIndex = WORKED_EXAMPLE_STEP_INDEX,
-            sequentialWorkedExamplePlayback = false
-        )
-        waitForTutorialCopy(R.string.tutorial_worked_example_sum_two_three_copy)
-
-        assertFocusedIntroductionStripDisplayed(expectedSecondValue = "3", isSecondValuePlayerEntered = true)
-        assertTileExpression(tileIndex = 0, operator = Operator.ADDITION)
+        assertStepDisplayed(stepIndex = PRODUCT_TWO_THREE_STEP_INDEX)
+        assertTileExpressionHidden(tileIndex = 0)
         assertTileExpression(tileIndex = 1, operator = Operator.MULTIPLICATION)
-        assertTileExpression(tileIndex = 2, operator = Operator.ADDITION, leftValue = "4", rightValue = "5")
-        assertTileExpression(tileIndex = 3, operator = Operator.MULTIPLICATION, leftValue = "4", rightValue = "5")
-        composeTestRule
-            .onNodeWithTag(TutorialScreenTestTags.WORKED_EXAMPLE_PROGRESS)
-            .assertDoesNotExist()
         composeTestRule
             .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
-            .assertIsDisplayed()
-            .assertIsEnabled()
             .performClick()
-
-        waitForStep(stepIndex = PRACTICE_STEP_INDEX)
-        assertRepeatedValuePracticeScenarioDisplayed()
+        assertStepDisplayed(stepIndex = SUM_TWO_THREE_STEP_INDEX)
+        assertTileExpression(tileIndex = 0, operator = Operator.ADDITION)
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY)
             .assertDoesNotExist()
@@ -272,10 +242,7 @@ class TutorialRouteTest {
         )
 
         advanceThroughExplanation()
-        composeTestRule
-            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
-            .performClick()
-        waitForStep(stepIndex = PRACTICE_STEP_INDEX)
+        advanceThroughWorkedExample()
 
         assertEquals(1, checkpointCount.get())
     }
@@ -284,16 +251,13 @@ class TutorialRouteTest {
     fun reopeningAfterTheWorkedExampleStartsTheTutorialFromTheBeginning() {
         val restartTutorial = setRestartableContent()
         advanceThroughExplanation()
-        composeTestRule
-            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
-            .performClick()
-        waitForStep(stepIndex = PRACTICE_STEP_INDEX)
+        advanceThroughWorkedExample()
 
         restartTutorial()
         assertStepDisplayed(stepIndex = OBJECTIVE_EXPLANATION_STEP_INDEX)
         assertFocusedIntroductionStripDisplayed()
         advanceThroughExplanation()
-        assertStepIndicator(stepIndex = WORKED_EXAMPLE_STEP_INDEX)
+        assertStepDisplayed(stepIndex = WORKED_EXAMPLE_INTRODUCTION_STEP_INDEX)
     }
 
     @Test
@@ -341,7 +305,6 @@ class TutorialRouteTest {
 
     private fun setContent(
         startStepIndex: Int = 0,
-        sequentialWorkedExamplePlayback: Boolean = false,
         onProgressCheckpointReached: suspend (TutorialProgressCheckpoint) -> Unit = {},
         onTutorialCompleted: (() -> Unit)? = null
     ) {
@@ -349,7 +312,6 @@ class TutorialRouteTest {
             NumPairsTheme {
                 TutorialRoute(
                     startStepIndex = startStepIndex,
-                    sequentialWorkedExamplePlaybackOverride = sequentialWorkedExamplePlayback,
                     onProgressCheckpointReached = onProgressCheckpointReached,
                     onTutorialCompleted = onTutorialCompleted
                 )
@@ -378,7 +340,7 @@ class TutorialRouteTest {
         composeTestRule.setContent {
             NumPairsTheme {
                 if (isTutorialVisible.value) {
-                    TutorialRoute(sequentialWorkedExamplePlaybackOverride = false)
+                    TutorialRoute()
                 }
             }
         }
@@ -404,10 +366,7 @@ class TutorialRouteTest {
 
     private fun completeFocusedTutorial() {
         advanceThroughExplanation()
-        composeTestRule
-            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
-            .performClick()
-        waitForStep(stepIndex = PRACTICE_STEP_INDEX)
+        advanceThroughWorkedExample()
 
         enterStripValue(index = 0, value = "1")
         enterStripValue(index = 1, value = "2")
@@ -418,25 +377,36 @@ class TutorialRouteTest {
     }
 
     private fun advanceThroughExplanation() {
-        repeat(WORKED_EXAMPLE_STEP_INDEX) {
+        repeat(WORKED_EXAMPLE_INTRODUCTION_STEP_INDEX) {
             composeTestRule
                 .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
                 .performScrollTo()
                 .performClick()
         }
-        assertStepIndicator(stepIndex = WORKED_EXAMPLE_STEP_INDEX)
+        assertStepDisplayed(stepIndex = WORKED_EXAMPLE_INTRODUCTION_STEP_INDEX)
     }
 
-    private fun advanceWorkedExampleFrame(expectedCopyResId: Int) {
-        composeTestRule.mainClock.advanceTimeBy(WORKED_EXAMPLE_FRAME_WAIT_MS)
-        assertWorkedExampleFrame(expectedCopyResId)
-    }
-
-    private fun assertWorkedExampleFrame(copyResId: Int) {
+    private fun advanceWorkedExampleStep(expectedStepIndex: Int) {
         composeTestRule
-            .onNodeWithTag(TutorialScreenTestTags.STEP_COPY)
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
             .performScrollTo()
-            .assert(hasText(string(copyResId)))
+            .performClick()
+        assertStepDisplayed(stepIndex = expectedStepIndex)
+    }
+
+    private fun advanceThroughWorkedExample() {
+        repeat(SUM_TWO_THREE_STEP_INDEX - WORKED_EXAMPLE_INTRODUCTION_STEP_INDEX) {
+            composeTestRule
+                .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+                .performScrollTo()
+                .performClick()
+        }
+        assertStepDisplayed(stepIndex = SUM_TWO_THREE_STEP_INDEX)
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .performScrollTo()
+            .performClick()
+        waitForStep(stepIndex = PRACTICE_STEP_INDEX)
     }
 
     private fun navigateToExplanationStep(stepIndex: Int) {
@@ -742,15 +712,6 @@ class TutorialRouteTest {
         }
     }
 
-    private fun waitForTutorialCopy(copyResId: Int) {
-        composeTestRule.waitUntil(timeoutMillis = TUTORIAL_STEP_WAIT_TIMEOUT_MS) {
-            composeTestRule
-                .onAllNodes(hasText(string(copyResId)))
-                .fetchSemanticsNodes()
-                .isNotEmpty()
-        }
-    }
-
     private fun string(stringResId: Int, vararg formatArgs: Any): String = if (formatArgs.isEmpty()) {
         composeTestRule.activity.getString(stringResId)
     } else {
@@ -767,9 +728,13 @@ class TutorialRouteTest {
         const val OBJECTIVE_EXPLANATION_STEP_INDEX = 0
         const val STRIP_EXPLANATION_STEP_INDEX = 1
         const val PAIR_EXPLANATION_STEP_INDEX = 3
-        const val WORKED_EXAMPLE_STEP_INDEX = 4
-        const val PRACTICE_STEP_INDEX = 5
-        const val WORKED_EXAMPLE_FRAME_WAIT_MS = 1_000L
+        const val WORKED_EXAMPLE_INTRODUCTION_STEP_INDEX = 4
+        const val PRODUCT_FOUR_FIVE_STEP_INDEX = 5
+        const val SUM_FOUR_FIVE_STEP_INDEX = 6
+        const val REVEAL_THREE_STEP_INDEX = 7
+        const val PRODUCT_TWO_THREE_STEP_INDEX = 8
+        const val SUM_TWO_THREE_STEP_INDEX = 9
+        const val PRACTICE_STEP_INDEX = 10
         const val TUTORIAL_AUTO_ADVANCE_TEST_WAIT_MS = 1_000L
         const val TUTORIAL_STEP_WAIT_TIMEOUT_MS = 5_000L
     }

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
@@ -8,15 +8,13 @@ import org.cescfe.numpairs.domain.puzzle.model.StripItem
 internal object LearnBasicsTutorialContent {
     private val stripAndTilesIntroductionScenario = stripAndTilesIntroductionScenario()
     private val repeatedValuePracticeScenario = repeatedValuePracticeScenario()
-    private val workedExampleFrames = workedExampleFrames()
 
     val scenarios: List<TutorialScenario> = listOf(
         stripAndTilesIntroductionScenario,
         repeatedValuePracticeScenario
     )
 
-    val steps: List<TutorialStep> = explanationSteps() + listOf(
-        workedExampleStep(),
+    val steps: List<TutorialStep> = explanationSteps() + workedExampleSteps() + listOf(
         TutorialStep(
             scenarioId = TutorialScenarioId.REPEATED_VALUE_PRACTICE,
             playerFacingCopyResId = R.string.tutorial_repeated_value_practice_copy,
@@ -30,21 +28,7 @@ internal object LearnBasicsTutorialContent {
         )
     )
 
-    private fun workedExampleStep(): TutorialStep {
-        val initialFrame = workedExampleFrames.first()
-
-        return TutorialStep(
-            scenarioId = TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
-            playerFacingCopyResId = initialFrame.playerFacingCopyResId,
-            highlightedTargets = initialFrame.highlightedTargets,
-            requiredAction = TutorialRequiredAction.PlayWorkedExample(frames = workedExampleFrames),
-            completionPredicate = TutorialStepCompletionPredicate.ManualAdvance,
-            progressCheckpoint = TutorialProgressCheckpoint.WORKED_EXAMPLE_COMPLETED,
-            entryPuzzle = initialFrame.puzzle
-        )
-    }
-
-    private fun workedExampleFrames(): List<TutorialWorkedExampleFrame> {
+    private fun workedExampleSteps(): List<TutorialStep> {
         val scenario = stripAndTilesIntroductionScenario
         val initialPuzzle = scenario.initialPuzzle
         val productFourAndFive = initialPuzzle.withSolvedTiles(scenario = scenario, tileIndexes = intArrayOf(3))
@@ -56,9 +40,9 @@ internal object LearnBasicsTutorialContent {
         val solvedExample = productTwoAndThree.withSolvedTiles(scenario = scenario, tileIndexes = intArrayOf(0))
 
         return listOf(
-            TutorialWorkedExampleFrame(
-                playerFacingCopyResId = R.string.tutorial_worked_example_introduction_copy,
-                puzzle = initialPuzzle,
+            manualWorkedExampleStep(
+                copyResId = R.string.tutorial_worked_example_introduction_copy,
+                entryPuzzle = initialPuzzle,
                 highlightedTargets = listOf(
                     TutorialHighlightTarget.StripEntries(indexes = listOf(0, 1, 2, 3)),
                     TutorialHighlightTarget.WholeTile(tileIndex = 0),
@@ -67,50 +51,68 @@ internal object LearnBasicsTutorialContent {
                     TutorialHighlightTarget.WholeTile(tileIndex = 3)
                 )
             ),
-            workedExampleFrame(
+            manualWorkedExampleStep(
                 copyResId = R.string.tutorial_worked_example_product_four_five_copy,
-                puzzle = productFourAndFive,
+                entryPuzzle = productFourAndFive,
                 stripEntryIndexes = listOf(2, 3),
                 tileIndexes = listOf(3)
             ),
-            workedExampleFrame(
+            manualWorkedExampleStep(
                 copyResId = R.string.tutorial_worked_example_sum_four_five_copy,
-                puzzle = pairFourAndFive,
+                entryPuzzle = pairFourAndFive,
                 stripEntryIndexes = listOf(2, 3),
                 tileIndexes = listOf(2)
             ),
-            workedExampleFrame(
+            manualWorkedExampleStep(
                 copyResId = R.string.tutorial_worked_example_reveal_three_copy,
-                puzzle = completedStrip,
+                entryPuzzle = completedStrip,
                 stripEntryIndexes = listOf(0, 1),
                 tileIndexes = listOf(0, 1)
             ),
-            workedExampleFrame(
+            manualWorkedExampleStep(
                 copyResId = R.string.tutorial_worked_example_product_two_three_copy,
-                puzzle = productTwoAndThree,
+                entryPuzzle = productTwoAndThree,
                 stripEntryIndexes = listOf(0, 1),
                 tileIndexes = listOf(1)
             ),
-            workedExampleFrame(
+            manualWorkedExampleStep(
                 copyResId = R.string.tutorial_worked_example_sum_two_three_copy,
-                puzzle = solvedExample,
+                entryPuzzle = solvedExample,
                 stripEntryIndexes = listOf(0, 1),
-                tileIndexes = listOf(0)
+                tileIndexes = listOf(0),
+                progressCheckpoint = TutorialProgressCheckpoint.WORKED_EXAMPLE_COMPLETED
             )
         )
     }
 
-    private fun workedExampleFrame(
+    private fun manualWorkedExampleStep(
         copyResId: Int,
-        puzzle: Puzzle,
-        stripEntryIndexes: List<Int>,
-        tileIndexes: List<Int>
-    ): TutorialWorkedExampleFrame = TutorialWorkedExampleFrame(
+        entryPuzzle: Puzzle,
+        highlightedTargets: List<TutorialHighlightTarget>,
+        progressCheckpoint: TutorialProgressCheckpoint? = null
+    ): TutorialStep = TutorialStep(
+        scenarioId = TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
         playerFacingCopyResId = copyResId,
-        puzzle = puzzle,
+        highlightedTargets = highlightedTargets,
+        requiredAction = TutorialRequiredAction.NoInteraction,
+        completionPredicate = TutorialStepCompletionPredicate.ManualAdvance,
+        progressCheckpoint = progressCheckpoint,
+        entryPuzzle = entryPuzzle
+    )
+
+    private fun manualWorkedExampleStep(
+        copyResId: Int,
+        entryPuzzle: Puzzle,
+        stripEntryIndexes: List<Int>,
+        tileIndexes: List<Int>,
+        progressCheckpoint: TutorialProgressCheckpoint? = null
+    ): TutorialStep = manualWorkedExampleStep(
+        copyResId = copyResId,
+        entryPuzzle = entryPuzzle,
         highlightedTargets = listOf(
             TutorialHighlightTarget.StripEntries(indexes = stripEntryIndexes)
-        ) + tileIndexes.map(TutorialHighlightTarget::WholeTile)
+        ) + tileIndexes.map(TutorialHighlightTarget::WholeTile),
+        progressCheckpoint = progressCheckpoint
     )
 
     private fun Puzzle.withSolvedTiles(scenario: TutorialScenario, tileIndexes: IntArray): Puzzle = copy(

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
@@ -105,14 +105,6 @@ sealed interface TutorialHighlightTarget {
 sealed interface TutorialRequiredAction {
     data object NoInteraction : TutorialRequiredAction
 
-    data class PlayWorkedExample(val frames: List<TutorialWorkedExampleFrame>) : TutorialRequiredAction {
-        init {
-            require(frames.size >= 2) {
-                "Tutorial worked example must contain an initial frame and at least one resolved frame."
-            }
-        }
-    }
-
     data class CompleteTileExpression(
         val tileIndex: Int,
         val leftStripEntryId: Int,
@@ -158,18 +150,6 @@ sealed interface TutorialRequiredAction {
     }
 
     data object CompleteScenario : TutorialRequiredAction
-}
-
-data class TutorialWorkedExampleFrame(
-    @param:StringRes val playerFacingCopyResId: Int,
-    val puzzle: Puzzle,
-    val highlightedTargets: List<TutorialHighlightTarget>
-) {
-    init {
-        require(playerFacingCopyResId != 0) {
-            "Tutorial worked-example frame copy string resource must be defined."
-        }
-    }
 }
 
 sealed interface TutorialStepCompletionPredicate {

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -52,7 +51,6 @@ fun TutorialRoute(
     mode: TutorialMode = TutorialMode.LEARN_BASICS,
     startStepIndex: Int = 0,
     saveProgressAcrossRecreation: Boolean = true,
-    sequentialWorkedExamplePlaybackOverride: Boolean? = null,
     onProgressCheckpointReached: suspend (TutorialProgressCheckpoint) -> Unit = {},
     onTutorialCompleted: (() -> Unit)? = null,
     onSkipTutorialRequested: (() -> Unit)? = null,
@@ -84,25 +82,13 @@ fun TutorialRoute(
     val currentOnTutorialCompleted by rememberUpdatedState(onTutorialCompleted)
     val currentStep = steps[currentStepIndex]
     val currentScenario = TutorialContent.scenario(currentStep.scenarioId)
-    val workedExample = currentStep.requiredAction as? TutorialRequiredAction.PlayWorkedExample
-    var workedExampleFrameIndex by remember(playbackKey, currentStepIndex) { mutableIntStateOf(0) }
     var isCheckpointNavigationInProgress by remember(playbackKey, currentStepIndex) {
         mutableStateOf(false)
     }
     var hasCurrentStepPuzzleChanged by remember(playbackKey, currentStepIndex) {
         mutableStateOf(false)
     }
-    val workedExampleFrame = workedExample?.frames?.get(workedExampleFrameIndex)
-    val presentedStep = workedExampleFrame?.let { frame ->
-        currentStep.copy(
-            playerFacingCopyResId = frame.playerFacingCopyResId,
-            highlightedTargets = frame.highlightedTargets,
-            entryPuzzle = frame.puzzle
-        )
-    } ?: currentStep
-    val currentEntryPuzzle = presentedStep.entryPuzzle ?: currentScenario.initialPuzzle
-    val isWorkedExamplePlaybackActive = workedExample != null &&
-        workedExampleFrameIndex < workedExample.frames.lastIndex
+    val currentEntryPuzzle = currentStep.entryPuzzle ?: currentScenario.initialPuzzle
     val latestGameUiState = latestGameUiSnapshot
         ?.takeIf { snapshot -> snapshot.scenarioId == currentScenario.id }
         ?.uiState
@@ -130,23 +116,6 @@ fun TutorialRoute(
         }
     }
 
-    LaunchedEffect(currentStepIndex, workedExample, sequentialWorkedExamplePlaybackOverride) {
-        val frames = workedExample?.frames ?: return@LaunchedEffect
-        workedExampleFrameIndex = 0
-        val systemAllowsSequentialPlayback = coroutineContext[MotionDurationScale]?.scaleFactor != 0f
-        val shouldPlaySequentially = sequentialWorkedExamplePlaybackOverride ?: systemAllowsSequentialPlayback
-
-        if (!shouldPlaySequentially) {
-            workedExampleFrameIndex = frames.lastIndex
-            return@LaunchedEffect
-        }
-
-        for (frameIndex in 1..frames.lastIndex) {
-            delay(TUTORIAL_WORKED_EXAMPLE_FRAME_DELAY)
-            workedExampleFrameIndex = frameIndex
-        }
-    }
-
     GameRoute(
         title = stringResource(R.string.tutorial_screen_title),
         initialPuzzle = currentEntryPuzzle,
@@ -160,12 +129,12 @@ fun TutorialRoute(
             observedScenarioId = latestGameUiSnapshot?.scenarioId,
             isRequiredPlayback = onTutorialCompleted != null
         ),
-        isBoardVisible = presentedStep.isBoardVisible,
-        interactionPolicy = presentedStep.toInteractionPolicy(
+        isBoardVisible = currentStep.isBoardVisible,
+        interactionPolicy = currentStep.toInteractionPolicy(
             scenario = currentScenario,
             uiState = latestGameUiState
         ),
-        highlightState = presentedStep.toHighlightState(
+        highlightState = currentStep.toHighlightState(
             scenario = currentScenario,
             uiState = latestGameUiState,
             hasPuzzleChanged = hasCurrentStepPuzzleChanged
@@ -177,10 +146,9 @@ fun TutorialRoute(
         },
         contentBeforePuzzle = {
             TutorialInstructionSurface(
-                currentStep = presentedStep,
+                currentStep = currentStep,
                 currentStepNumber = currentStepIndex + 1,
                 totalSteps = steps.size,
-                isWorkedExamplePlaybackActive = isWorkedExamplePlaybackActive,
                 canNavigateBack = currentStepIndex > 0 && !isCheckpointNavigationInProgress,
                 canNavigateNext = !isCheckpointNavigationInProgress,
                 onNavigateBack = {
@@ -236,7 +204,6 @@ private fun TutorialInstructionSurface(
     currentStep: TutorialStep,
     currentStepNumber: Int,
     totalSteps: Int,
-    isWorkedExamplePlaybackActive: Boolean,
     canNavigateBack: Boolean,
     canNavigateNext: Boolean,
     onNavigateBack: () -> Unit,
@@ -271,16 +238,12 @@ private fun TutorialInstructionSurface(
                 color = MaterialTheme.colorScheme.onSurface
             )
             if (currentStep.completionPredicate == TutorialStepCompletionPredicate.ManualAdvance) {
-                if (isWorkedExamplePlaybackActive) {
-                    TutorialWorkedExampleProgress()
-                } else {
-                    TutorialStepNavigation(
-                        canNavigateBack = canNavigateBack,
-                        canNavigateNext = canNavigateNext,
-                        onNavigateBack = onNavigateBack,
-                        onNavigateNext = onNavigateNext
-                    )
-                }
+                TutorialStepNavigation(
+                    canNavigateBack = canNavigateBack,
+                    canNavigateNext = canNavigateNext,
+                    onNavigateBack = onNavigateBack,
+                    onNavigateNext = onNavigateNext
+                )
             }
         }
     }
@@ -327,23 +290,6 @@ private fun TutorialStepNavigation(
 }
 
 @Composable
-private fun TutorialWorkedExampleProgress(modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .heightIn(min = 48.dp)
-            .testTag(TutorialScreenTestTags.WORKED_EXAMPLE_PROGRESS),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = stringResource(R.string.tutorial_worked_example_progress),
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
-}
-
-@Composable
 private fun TutorialSkipBottomBar(onSkipRequested: () -> Unit, modifier: Modifier = Modifier) {
     Box(
         modifier = modifier
@@ -381,8 +327,7 @@ private fun TutorialRequiredAction.toInteractionPolicy(
     uiState: GameUiState?,
     highlightedStripEntryIds: Set<Int>
 ): GameInteractionPolicy = when (this) {
-    TutorialRequiredAction.NoInteraction,
-    is TutorialRequiredAction.PlayWorkedExample -> noInteractionPolicy()
+    TutorialRequiredAction.NoInteraction -> noInteractionPolicy()
     is TutorialRequiredAction.CompleteTileExpression -> toInteractionPolicy(
         scenario = scenario,
         highlightedStripEntryIds = highlightedStripEntryIds
@@ -628,4 +573,3 @@ private fun expressionSlotHighlights(tileIndex: Int): Set<GameTileExpressionSlot
 
 private const val TUTORIAL_GAME_SESSION_KEY = "tutorial-walkthrough"
 private val TUTORIAL_STEP_ADVANCE_DELAY = 350.milliseconds
-private val TUTORIAL_WORKED_EXAMPLE_FRAME_DELAY = 900.milliseconds

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/ui/TutorialScreenTestTags.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/ui/TutorialScreenTestTags.kt
@@ -7,6 +7,5 @@ object TutorialScreenTestTags {
     const val STEP_COPY = "tutorial_step_copy"
     const val PREVIOUS_STEP_ACTION = "tutorial_previous_step_action"
     const val NEXT_STEP_ACTION = "tutorial_next_step_action"
-    const val WORKED_EXAMPLE_PROGRESS = "tutorial_worked_example_progress"
     const val SKIP_ACTION = "tutorial_skip_action"
 }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -73,7 +73,6 @@
     <string name="tutorial_worked_example_reveal_three_copy">Queden els resultats 5 i 6. Junt amb el 2, el nombre ocult ha de ser 3.</string>
     <string name="tutorial_worked_example_product_two_three_copy">2 × 3 = 6 completa la multiplicació que falta.</string>
     <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completa el puzle.</string>
-    <string name="tutorial_worked_example_progress">Resolent l’exemple…</string>
     <string name="tutorial_repeated_value_practice_copy">Ara tu: resol el puzle. Toca qualsevol ? per començar. Els nombres es poden repetir. Consell: les multiplicacions solen ser un bon punt de partida.</string>
     <string name="onboarding_skip_tutorial_action">Omet el tutorial</string>
     <string name="onboarding_skip_tutorial_title">Vols ometre el tutorial?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -73,7 +73,6 @@
     <string name="tutorial_worked_example_reveal_three_copy">Quedan los resultados 5 y 6. Junto al 2, el número oculto tiene que ser 3.</string>
     <string name="tutorial_worked_example_product_two_three_copy">2 × 3 = 6 completa la multiplicación que falta.</string>
     <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completa el puzle.</string>
-    <string name="tutorial_worked_example_progress">Resolviendo ejemplo…</string>
     <string name="tutorial_repeated_value_practice_copy">Ahora tú: resuelve el puzle. Toca cualquier ? para empezar. Los números pueden repetirse. Consejo: las multiplicaciones suelen ser un buen punto de partida.</string>
     <string name="onboarding_skip_tutorial_action">Saltar tutorial</string>
     <string name="onboarding_skip_tutorial_title">¿Saltar el tutorial?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,7 +73,6 @@
     <string name="tutorial_worked_example_reveal_three_copy">The remaining results are 5 and 6. Paired with 2, the hidden number must be 3.</string>
     <string name="tutorial_worked_example_product_two_three_copy">2 × 3 = 6 completes the remaining multiplication.</string>
     <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completes the puzzle.</string>
-    <string name="tutorial_worked_example_progress">Resolving example…</string>
     <string name="tutorial_repeated_value_practice_copy">Your turn: solve the puzzle. Tap any ? to begin. Numbers may repeat. Tip: multiplication is often a good place to start.</string>
     <string name="onboarding_skip_tutorial_action">Skip tutorial</string>
     <string name="onboarding_skip_tutorial_title">Skip the tutorial?</string>

--- a/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/onboarding/RequiredOnboardingRouteTest.kt
@@ -11,7 +11,7 @@ class RequiredOnboardingRouteTest {
     fun `checkpoints resume after the last completed Tutorial step`() {
         assertEquals(0, state(OnboardingStageCheckpoint.NONE).nextRequiredTutorialStepIndex())
         assertEquals(
-            5,
+            10,
             state(OnboardingStageCheckpoint.EXPLANATION_COMPLETED).nextRequiredTutorialStepIndex()
         )
     }
@@ -26,7 +26,7 @@ class RequiredOnboardingRouteTest {
         }
 
         assertEquals(
-            6,
+            11,
             state(OnboardingStageCheckpoint.EXPLANATION_COMPLETED).nextRequiredTutorialStepIndex(
                 steps = stepsWithInsertedOrientation
             )

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -83,25 +83,12 @@ class TutorialContentTest {
         val steps = TutorialContent.stepsFor(TutorialMode.LEARN_BASICS)
 
         assertEquals(
-            listOf(
-                TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
-                TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
-                TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
-                TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
-                TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION,
-                TutorialScenarioId.REPEATED_VALUE_PRACTICE
-            ),
+            List(10) { TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION } +
+                TutorialScenarioId.REPEATED_VALUE_PRACTICE,
             steps.map(TutorialStep::scenarioId)
         )
         assertEquals(
-            listOf(
-                null,
-                null,
-                null,
-                null,
-                TutorialProgressCheckpoint.WORKED_EXAMPLE_COMPLETED,
-                null
-            ),
+            List(9) { null } + TutorialProgressCheckpoint.WORKED_EXAMPLE_COMPLETED + null,
             steps.map(TutorialStep::progressCheckpoint)
         )
 
@@ -144,13 +131,19 @@ class TutorialContentTest {
             assertEquals(introductionScenario.initialPuzzle, step.entryPuzzle ?: introductionScenario.initialPuzzle)
         }
 
-        val workedExampleStep = steps[4]
-        val workedExample = workedExampleStep.requiredAction as TutorialRequiredAction.PlayWorkedExample
-        assertEquals(TutorialStepCompletionPredicate.ManualAdvance, workedExampleStep.completionPredicate)
-        assertEquals(introductionScenario.initialPuzzle, workedExampleStep.entryPuzzle)
-        assertEquals(introductionScenario.initialPuzzle, workedExample.frames.first().puzzle)
+        val workedExampleSteps = steps.subList(fromIndex = 4, toIndex = 10)
+        workedExampleSteps.forEach { step ->
+            assertEquals(TutorialRequiredAction.NoInteraction, step.requiredAction)
+            assertEquals(TutorialStepCompletionPredicate.ManualAdvance, step.completionPredicate)
+            assertTrue(step.isBoardVisible)
+        }
+        assertEquals(introductionScenario.initialPuzzle, workedExampleSteps.first().entryPuzzle)
+        assertEquals(
+            TutorialProgressCheckpoint.WORKED_EXAMPLE_COMPLETED,
+            workedExampleSteps.last().progressCheckpoint
+        )
 
-        steps[5].assertGuidedAction(
+        steps[10].assertGuidedAction(
             expectedHighlights = listOf(
                 TutorialHighlightTarget.StripEntries(indexes = listOf(2, 3)),
                 TutorialHighlightTarget.WholeTile(tileIndex = 3)
@@ -162,9 +155,8 @@ class TutorialContentTest {
     }
 
     @Test
-    fun worked_example_frames_follow_the_exact_reasoned_solution_order() {
-        val step = TutorialContent.learnBasicsSteps[4]
-        val frames = (step.requiredAction as TutorialRequiredAction.PlayWorkedExample).frames
+    fun worked_example_steps_follow_the_exact_reasoned_solution_order() {
+        val steps = TutorialContent.learnBasicsSteps.subList(fromIndex = 4, toIndex = 10)
 
         assertEquals(
             listOf(
@@ -175,7 +167,7 @@ class TutorialContentTest {
                 R.string.tutorial_worked_example_product_two_three_copy,
                 R.string.tutorial_worked_example_sum_two_three_copy
             ),
-            frames.map(TutorialWorkedExampleFrame::playerFacingCopyResId)
+            steps.map(TutorialStep::playerFacingCopyResId)
         )
         assertEquals(
             listOf(
@@ -186,15 +178,15 @@ class TutorialContentTest {
                 setOf(1, 2, 3),
                 setOf(0, 1, 2, 3)
             ),
-            frames.map { frame ->
-                frame.puzzle.board.tiles.mapIndexedNotNullTo(mutableSetOf()) { index, tile ->
+            steps.map { step ->
+                requireNotNull(step.entryPuzzle).board.tiles.mapIndexedNotNullTo(mutableSetOf()) { index, tile ->
                     index.takeIf { tile.expression.isFullyKnown }
                 }
             }
         )
-        assertEquals(StripItem.Hidden, frames[2].puzzle.strip.items[1])
-        assertEquals(StripItem.PlayerEntered(3), frames[3].puzzle.strip.items[1])
-        assertEquals(PuzzleCompletionState.SOLVED, frames.last().puzzle.completionState)
+        assertEquals(StripItem.Hidden, requireNotNull(steps[2].entryPuzzle).strip.items[1])
+        assertEquals(StripItem.PlayerEntered(3), requireNotNull(steps[3].entryPuzzle).strip.items[1])
+        assertEquals(PuzzleCompletionState.SOLVED, requireNotNull(steps.last().entryPuzzle).completionState)
         assertEquals(
             listOf(
                 listOf(0, 1, 2, 3),
@@ -204,8 +196,8 @@ class TutorialContentTest {
                 listOf(0, 1),
                 listOf(0, 1)
             ),
-            frames.map { frame ->
-                frame.highlightedTargets
+            steps.map { step ->
+                step.highlightedTargets
                     .filterIsInstance<TutorialHighlightTarget.StripEntries>()
                     .single()
                     .indexes
@@ -220,8 +212,8 @@ class TutorialContentTest {
                 listOf(1),
                 listOf(0)
             ),
-            frames.map { frame ->
-                frame.highlightedTargets
+            steps.map { step ->
+                step.highlightedTargets
                     .filterIsInstance<TutorialHighlightTarget.WholeTile>()
                     .map(TutorialHighlightTarget.WholeTile::tileIndex)
             }
@@ -232,7 +224,7 @@ class TutorialContentTest {
     fun manual_explanation_freezes_every_puzzle_interaction() {
         val scenario = TutorialContent.scenario(TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION)
 
-        TutorialContent.learnBasicsSteps.take(5).forEach { step ->
+        TutorialContent.learnBasicsSteps.take(10).forEach { step ->
             val policy = step.toInteractionPolicy(scenario = scenario, uiState = null)
 
             scenario.stripValues.indices.forEach { index ->

--- a/docs/product/prd/prd-v6.md
+++ b/docs/product/prd/prd-v6.md
@@ -126,7 +126,7 @@ Use one short message and one matching focus per step:
 3. Highlight one tile and explain that its visible result is produced by two operands and one operator in the hidden expression.
 4. Highlight strip entries `4` and `5` with result tiles `9` and `20`; explain that each pair completes two tiles, one sum and one product.
 
-The final explanation step starts a deterministic worked example from the same unresolved state. Use short reasoning and focused highlights while applying these transitions in order:
+Continue with a deterministic, manually paced worked example. Its first step keeps the same unresolved state visible, then five more steps apply these transitions in order:
 
 1. `4 × 5 = 20`: the larger product is resolved first.
 2. `4 + 5 = 9`: the same pair also completes its sum.
@@ -134,9 +134,7 @@ The final explanation step starts a deterministic worked example from the same u
 4. `2 × 3 = 6`: resolve the remaining product.
 5. `2 + 3 = 5`: resolve the remaining sum.
 
-The puzzle remains non-interactive during playback. While staged playback is active, preserve the navigation footer space but replace or disable `Back` and `Next` with a clear progress state. Restore both actions after completion so the player may return and replay the example or continue. Returning to the worked-example step restarts it from the unresolved state.
-
-When the system requests reduced motion, present the same ordered reasoning and final explained state without staged delays. Reduced motion changes pacing, not content or completion meaning.
+The puzzle remains non-interactive throughout all six worked-example steps. The player controls every transition with the same accessible `Back` and `Next` actions used by the preceding explanation. Moving backward restores the previous authored snapshot, and moving forward applies the next deduction. No worked-example state changes on a timer, so every player has enough time to read the reasoning and inspect the highlighted result before continuing.
 
 ### Part 2 - Solve A Two-Pair Puzzle
 
@@ -221,7 +219,7 @@ Solving the puzzle completes Tutorial. Required first-run playback persists the 
 
 - A fresh installation starts Tutorial instead of Menu
 - A new player sees the complete puzzle while focused steps explain the objective, strip, tile anatomy, and one-sum/one-product pair rule
-- The worked example makes every deduction visible before changing the authored puzzle state
+- Each worked-example step keeps its deduction and resulting puzzle state visible until the player manually continues
 - Independent practice teaches the real interaction model through unrestricted player actions
 - `Skip tutorial` is available from Step 1 and always requires explicit confirmation
 - Confirmed skip opens Menu without final validation


### PR DESCRIPTION
## Related Issue

Resolves #560

## Summary

- Replace timed worked-example playback with six manually paced Tutorial steps.
- Preserve the existing unresolved state, five deductions, reasoning, highlights, and authored puzzle snapshots.
- Keep the puzzle locked while Back and Next navigate deterministically through every state.
- Record the onboarding checkpoint only when the final solved step advances to independent practice.
- Remove the playback timer, progress placeholder, reduced-motion shortcut, obsolete model, resources, and time-based tests.
- Update the active v6 product contract and milestone description for player-controlled pacing.

## UI Consistency

- Shared components or tokens reused: existing Tutorial instruction surface, Material 3 text-button navigation, NumPairs spacing, typography, colors, borders, 48 dp touch targets, and game highlight semantics.
- Intentional deviations from established visual roles: none; the worked example now uses the same manual navigation role already established by the preceding explanation steps.

## Validation

- ./gradlew spotlessApply
- ./gradlew testDebugUnitTest
- ./gradlew spotlessCheck
- ./gradlew compileDebugAndroidTestKotlin
- ./gradlew lintDebug