### PR TITLE
[270] Refine Tutorial copy across supported languages

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
@@ -78,7 +78,7 @@ class LocalizationResourceTest {
         assertEquals("Pas 1 de 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
         assertTutorialExplanationCopy(
             resources = resources,
-            objective = "Benvingut a NumPairs. L’objectiu és descobrir tots els nombres i símbols ocults.",
+            objective = "Benvingut a NumPairs. L’objectiu és descobrir tots els nombres, sumes i multiplicacions ocultes.",
             strip = "Aquesta és la sèrie. Els nombres estan ordenats de menor a major, " +
                 "es poden repetir i alguns estan ocults.",
             tile = "Cada casella mostra un resultat. Completa la part superior amb els dos nombres " +
@@ -126,7 +126,7 @@ class LocalizationResourceTest {
         assertEquals("Step 1 of 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
         assertTutorialExplanationCopy(
             resources = resources,
-            objective = "Welcome to NumPairs. Your goal is to discover every hidden number and symbol.",
+            objective = "Welcome to NumPairs. Your goal is to discover every hidden number, addition and multiplication.",
             strip = "This is the number strip. Its numbers are ordered from lowest to highest, " +
                 "may repeat, and some are hidden.",
             tile = "Each tile shows a result. Complete its top row with the two numbers and symbol " +

--- a/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
@@ -29,31 +29,37 @@ class LocalizationResourceTest {
         assertEquals("Paso 1 de 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
         assertTutorialExplanationCopy(
             resources = resources,
-            objective = "Bienvenido a NumPairs. Tu objetivo es descubrir todos los números y símbolos ocultos.",
-            strip = "Esta es la serie. Sus números están ordenados de menor a mayor, " +
-                "pueden repetirse y algunos están ocultos.",
-            tile = "Cada casilla muestra un resultado. Completa la parte superior con los dos números " +
-                "y el signo que producen ese resultado.",
-            pair = "Agrupa los números de la serie por parejas. Cada pareja completa dos casillas: " +
-                "una suma y una multiplicación.",
+            objective = "Bienvenido a NumPairs. Tu objetivo es descubrir todos los números y " +
+                "completar todas las sumas y multiplicaciones ocultas.",
+            strip = "La secuencia de la parte superior del puzle es una lista de números ordenados " +
+                "de menor a mayor. Pueden repetirse y, al principio, algunos están ocultos.",
+            tile = "Las casillas están debajo. Cada una tiene dos partes: abajo aparece un resultado " +
+                "conocido y arriba hay una suma o multiplicación cuyos números y signo debes deducir.",
+            pair = "¿Cómo se deducen? Forma parejas con los números de la secuencia superior. " +
+                "Cada pareja completa dos casillas: una suma y una multiplicación.",
             previous = "Atrás",
             next = "Siguiente"
         )
         assertTutorialCopy(
             resources = resources,
             expectedCopy = listOf(
-                "Presta atención: vamos a resolver este puzle por ti una sola vez.",
+                "Presta atención: esta será la primera y última vez que resolveremos un puzle por ti.",
                 "4 × 5 = 20, así que 20 es la casilla de multiplicación de esta pareja.",
-                "La misma pareja también da 4 + 5 = 9.",
-                "Quedan los resultados 5 y 6. Junto al 2, el número oculto tiene que ser 3.",
+                "La misma pareja también resuelve la suma: 4 + 5 = 9.",
+                "Quedan por completar las casillas con resultados 5 y 6. Junto al 2, " +
+                    "el número oculto solo puede ser 3.",
                 "2 × 3 = 6 completa la multiplicación que falta.",
-                "2 + 3 = 5 completa el puzle.",
+                "2 + 3 = 5 completa la suma y resuelve el puzle.",
                 "Ahora tú: resuelve el puzle. Toca cualquier ? para empezar. " +
                     "Los números pueden repetirse. Consejo: las multiplicaciones suelen ser " +
                     "un buen punto de partida."
             )
         )
         assertEquals("Saltar tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
+        assertEquals(
+            "Si es la primera vez que juegas a NumPairs, te recomendamos continuar.",
+            resources.getString(R.string.onboarding_skip_tutorial_message)
+        )
         assertEquals("Continuar tutorial", resources.getString(R.string.onboarding_continue_tutorial_button))
         assertEquals("Saltar igualmente", resources.getString(R.string.onboarding_skip_anyway_button))
         assertEquals("No se puede abrir NumPairs", resources.getString(R.string.onboarding_startup_failure_title))
@@ -78,30 +84,37 @@ class LocalizationResourceTest {
         assertEquals("Pas 1 de 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
         assertTutorialExplanationCopy(
             resources = resources,
-            objective = "Benvingut a NumPairs. L’objectiu és descobrir tots els nombres, sumes i multiplicacions ocultes.",
-            strip = "Aquesta és la sèrie. Els nombres estan ordenats de menor a major, " +
-                "es poden repetir i alguns estan ocults.",
-            tile = "Cada casella mostra un resultat. Completa la part superior amb els dos nombres " +
-                "i el signe que produeixen aquest resultat.",
-            pair = "Agrupa els nombres de la sèrie per parelles. Cada parella completa dues caselles: " +
-                "una suma i una multiplicació.",
+            objective = "Benvingut a NumPairs. L’objectiu és descobrir tots els nombres i completar " +
+                "totes les sumes i multiplicacions ocultes.",
+            strip = "La seqüència de la part superior del puzle és una llista de nombres ordenats " +
+                "de menor a major. Es poden repetir i, al principi, alguns estan ocults.",
+            tile = "Davall hi ha les caselles. Cada una té dues parts: baix apareix un resultat " +
+                "conegut i dalt hi ha una suma o multiplicació amb els nombres i el signe que has " +
+                "de deduir.",
+            pair = "Com els pots deduir? Forma parelles amb els nombres de la seqüència superior. " +
+                "Cada parella completa dues caselles: una suma i una multiplicació.",
             previous = "Enrere",
             next = "Següent"
         )
         assertTutorialCopy(
             resources = resources,
             expectedCopy = listOf(
-                "Para atenció: resoldrem este puzle per tu una sola vegada.",
+                "Para atenció: esta serà la primera i última vegada que resoldrem un puzle per tu.",
                 "4 × 5 = 20, així que 20 és la casella de multiplicació d’esta parella.",
-                "La mateixa parella també dona 4 + 5 = 9.",
-                "Queden els resultats 5 i 6. Junt amb el 2, el nombre ocult ha de ser 3.",
+                "La mateixa parella també resol la suma: 4 + 5 = 9.",
+                "Queden per completar les caselles amb els resultats 5 i 6. Junt amb el 2, " +
+                    "el nombre ocult només pot ser 3.",
                 "2 × 3 = 6 completa la multiplicació que falta.",
-                "2 + 3 = 5 completa el puzle.",
+                "2 + 3 = 5 completa la suma i resol el puzle.",
                 "Ara tu: resol el puzle. Toca qualsevol ? per començar. Els nombres es poden repetir. " +
                     "Consell: les multiplicacions solen ser un bon punt de partida."
             )
         )
         assertEquals("Omet el tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
+        assertEquals(
+            "Si és la primera vegada que jugues a NumPairs, et recomanem continuar.",
+            resources.getString(R.string.onboarding_skip_tutorial_message)
+        )
         assertEquals("Continua el tutorial", resources.getString(R.string.onboarding_continue_tutorial_button))
         assertEquals("Omet-lo igualment", resources.getString(R.string.onboarding_skip_anyway_button))
         assertEquals("No es pot obrir NumPairs", resources.getString(R.string.onboarding_startup_failure_title))
@@ -126,30 +139,36 @@ class LocalizationResourceTest {
         assertEquals("Step 1 of 2", resources.getString(R.string.tutorial_step_indicator, 1, 2))
         assertTutorialExplanationCopy(
             resources = resources,
-            objective = "Welcome to NumPairs. Your goal is to discover every hidden number, addition and multiplication.",
-            strip = "This is the number strip. Its numbers are ordered from lowest to highest, " +
-                "may repeat, and some are hidden.",
-            tile = "Each tile shows a result. Complete its top row with the two numbers and symbol " +
-                "that produce that result.",
-            pair = "Group the strip numbers into pairs. Each pair completes two tiles: " +
-                "one addition and one multiplication.",
+            objective = "Welcome to NumPairs. Your goal is to find every number and complete all " +
+                "the hidden additions and multiplications.",
+            strip = "The sequence at the top of the puzzle is a list of numbers ordered from lowest " +
+                "to highest. Numbers may repeat, and some are hidden at first.",
+            tile = "The tiles are below. Each has two parts: a known result at the bottom and an " +
+                "addition or multiplication at the top whose numbers and symbol you must work out.",
+            pair = "How do you work them out? Pair up the numbers in the sequence above. Each pair " +
+                "completes two tiles: one addition and one multiplication.",
             previous = "Back",
             next = "Next"
         )
         assertTutorialCopy(
             resources = resources,
             expectedCopy = listOf(
-                "Watch closely: we’ll solve this puzzle for you once.",
+                "Watch closely: this is the first and last time we’ll solve a puzzle for you.",
                 "4 × 5 = 20, so 20 is this pair’s multiplication tile.",
-                "The same pair also gives 4 + 5 = 9.",
-                "The remaining results are 5 and 6. Paired with 2, the hidden number must be 3.",
+                "The same pair also completes the addition: 4 + 5 = 9.",
+                "The tiles showing 5 and 6 are still incomplete. Paired with 2, " +
+                    "the hidden number can only be 3.",
                 "2 × 3 = 6 completes the remaining multiplication.",
-                "2 + 3 = 5 completes the puzzle.",
+                "2 + 3 = 5 completes the addition and solves the puzzle.",
                 "Your turn: solve the puzzle. Tap any ? to begin. Numbers may repeat. " +
                     "Tip: multiplication is often a good place to start."
             )
         )
         assertEquals("Skip tutorial", resources.getString(R.string.onboarding_skip_tutorial_action))
+        assertEquals(
+            "If this is your first time playing NumPairs, we recommend continuing.",
+            resources.getString(R.string.onboarding_skip_tutorial_message)
+        )
         assertEquals("Continue tutorial", resources.getString(R.string.onboarding_continue_tutorial_button))
         assertEquals("Skip anyway", resources.getString(R.string.onboarding_skip_anyway_button))
         assertEquals("Unable to open NumPairs", resources.getString(R.string.onboarding_startup_failure_title))

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -61,22 +61,22 @@
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Pas %1$d de %2$d</string>
-    <string name="tutorial_objective_explanation_copy">Benvingut a NumPairs. L’objectiu és descobrir tots els nombres, sumes i multiplicacions ocultes.</string>
-    <string name="tutorial_strip_explanation_copy">La sequència de la part superior del puzle és una llista de nombres ordenats de menor a major, es poden repetir i, inicialment, alguns estan ocults.</string>
-    <string name="tutorial_tile_explanation_copy">Cada casella mostra un resultat. Completa la part superior amb els dos nombres i el signe que produeixen aquest resultat.</string>
-    <string name="tutorial_pair_explanation_copy">Agrupa els nombres de la sèrie per parelles. Cada parella completa dues caselles: una suma i una multiplicació.</string>
+    <string name="tutorial_objective_explanation_copy">Benvingut a NumPairs. L’objectiu és descobrir tots els nombres i completar totes les sumes i multiplicacions ocultes.</string>
+    <string name="tutorial_strip_explanation_copy">La seqüència de la part superior del puzle és una llista de nombres ordenats de menor a major. Es poden repetir i, al principi, alguns estan ocults.</string>
+    <string name="tutorial_tile_explanation_copy">Davall hi ha les caselles. Cada una té dues parts: baix apareix un resultat conegut i dalt hi ha una suma o multiplicació amb els nombres i el signe que has de deduir.</string>
+    <string name="tutorial_pair_explanation_copy">Com els pots deduir? Forma parelles amb els nombres de la seqüència superior. Cada parella completa dues caselles: una suma i una multiplicació.</string>
     <string name="tutorial_previous_step_action">Enrere</string>
     <string name="tutorial_next_step_action">Següent</string>
-    <string name="tutorial_worked_example_introduction_copy">Para atenció: resoldrem este puzle per tu una sola vegada.</string>
+    <string name="tutorial_worked_example_introduction_copy">Para atenció: esta serà la primera i última vegada que resoldrem un puzle per tu.</string>
     <string name="tutorial_worked_example_product_four_five_copy">4 × 5 = 20, així que 20 és la casella de multiplicació d’esta parella.</string>
-    <string name="tutorial_worked_example_sum_four_five_copy">La mateixa parella també dona 4 + 5 = 9.</string>
-    <string name="tutorial_worked_example_reveal_three_copy">Queden els resultats 5 i 6. Junt amb el 2, el nombre ocult ha de ser 3.</string>
+    <string name="tutorial_worked_example_sum_four_five_copy">La mateixa parella també resol la suma: 4 + 5 = 9.</string>
+    <string name="tutorial_worked_example_reveal_three_copy">Queden per completar les caselles amb els resultats 5 i 6. Junt amb el 2, el nombre ocult només pot ser 3.</string>
     <string name="tutorial_worked_example_product_two_three_copy">2 × 3 = 6 completa la multiplicació que falta.</string>
-    <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completa el puzle.</string>
+    <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completa la suma i resol el puzle.</string>
     <string name="tutorial_repeated_value_practice_copy">Ara tu: resol el puzle. Toca qualsevol ? per començar. Els nombres es poden repetir. Consell: les multiplicacions solen ser un bon punt de partida.</string>
     <string name="onboarding_skip_tutorial_action">Omet el tutorial</string>
     <string name="onboarding_skip_tutorial_title">Vols ometre el tutorial?</string>
-    <string name="onboarding_skip_tutorial_message">Si és la primera vegada que jugues a NumPairs o a jocs similars, et recomanem continuar. Podràs tornar a obrir el tutorial més tard des de Com jugar.</string>
+    <string name="onboarding_skip_tutorial_message">Si és la primera vegada que jugues a NumPairs, et recomanem continuar.</string>
     <string name="onboarding_continue_tutorial_button">Continua el tutorial</string>
     <string name="onboarding_skip_anyway_button">Omet-lo igualment</string>
     <string name="tutorial_solving_tips_step_one_copy">En dificultat baixa, cap número apareix dos vegades i la sèrie no inclou mai l’1, així que els resultats primers sempre són sumes. Completa el resultat primer com una casella de suma.</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -61,8 +61,8 @@
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Pas %1$d de %2$d</string>
-    <string name="tutorial_objective_explanation_copy">Benvingut a NumPairs. L’objectiu és descobrir tots els nombres i símbols ocults.</string>
-    <string name="tutorial_strip_explanation_copy">Aquesta és la sèrie. Els nombres estan ordenats de menor a major, es poden repetir i alguns estan ocults.</string>
+    <string name="tutorial_objective_explanation_copy">Benvingut a NumPairs. L’objectiu és descobrir tots els nombres, sumes i multiplicacions ocultes.</string>
+    <string name="tutorial_strip_explanation_copy">La sequència de la part superior del puzle és una llista de nombres ordenats de menor a major, es poden repetir i, inicialment, alguns estan ocults.</string>
     <string name="tutorial_tile_explanation_copy">Cada casella mostra un resultat. Completa la part superior amb els dos nombres i el signe que produeixen aquest resultat.</string>
     <string name="tutorial_pair_explanation_copy">Agrupa els nombres de la sèrie per parelles. Cada parella completa dues caselles: una suma i una multiplicació.</string>
     <string name="tutorial_previous_step_action">Enrere</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -61,16 +61,16 @@
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Paso %1$d de %2$d</string>
-    <string name="tutorial_objective_explanation_copy">Bienvenido a NumPairs. Tu objetivo es descubrir todos los números, sumas y multiplicaciones ocultas.</string>
-    <string name="tutorial_strip_explanation_copy">La secuencia de la parte superior del puzle es una lista de números ordenados de menor a mayor, pueden repetirse e, inicialmente, algunos están ocultos.</string>
-    <string name="tutorial_tile_explanation_copy">Debajo tenemos las casillas. Cada una se compone de 2 partes: en su parte inferior, muestra un resultado conocido; en su parte superior contiene una suma o multiplicación cuyos elementos debes deducir.</string>
-    <string name="tutorial_pair_explanation_copy">¿Cómo deducirlos? Debes formar parejas con los números de la secuencia superior. Cada pareja debe resolver dos casillas: una suma y una multiplicación.</string>
+    <string name="tutorial_objective_explanation_copy">Bienvenido a NumPairs. Tu objetivo es descubrir todos los números y completar todas las sumas y multiplicaciones ocultas.</string>
+    <string name="tutorial_strip_explanation_copy">La secuencia de la parte superior del puzle es una lista de números ordenados de menor a mayor. Pueden repetirse y, al principio, algunos están ocultos.</string>
+    <string name="tutorial_tile_explanation_copy">Las casillas están debajo. Cada una tiene dos partes: abajo aparece un resultado conocido y arriba hay una suma o multiplicación cuyos números y signo debes deducir.</string>
+    <string name="tutorial_pair_explanation_copy">¿Cómo se deducen? Forma parejas con los números de la secuencia superior. Cada pareja completa dos casillas: una suma y una multiplicación.</string>
     <string name="tutorial_previous_step_action">Atrás</string>
     <string name="tutorial_next_step_action">Siguiente</string>
-    <string name="tutorial_worked_example_introduction_copy">Presta atención: por primera y última vez vamos a resolver este puzle por ti.</string>
+    <string name="tutorial_worked_example_introduction_copy">Presta atención: esta será la primera y última vez que resolveremos un puzle por ti.</string>
     <string name="tutorial_worked_example_product_four_five_copy">4 × 5 = 20, así que 20 es la casilla de multiplicación de esta pareja.</string>
-    <string name="tutorial_worked_example_sum_four_five_copy">La misma pareja también debe resolver la suma 4 + 5 = 9.</string>
-    <string name="tutorial_worked_example_reveal_three_copy">Quedan por resolver los resultados 5 y 6. Junto al 2, el número oculto sólo puede ser 3.</string>
+    <string name="tutorial_worked_example_sum_four_five_copy">La misma pareja también resuelve la suma: 4 + 5 = 9.</string>
+    <string name="tutorial_worked_example_reveal_three_copy">Quedan por completar las casillas con resultados 5 y 6. Junto al 2, el número oculto solo puede ser 3.</string>
     <string name="tutorial_worked_example_product_two_three_copy">2 × 3 = 6 completa la multiplicación que falta.</string>
     <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completa la suma y resuelve el puzle.</string>
     <string name="tutorial_repeated_value_practice_copy">Ahora tú: resuelve el puzle. Toca cualquier ? para empezar. Los números pueden repetirse. Consejo: las multiplicaciones suelen ser un buen punto de partida.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -61,22 +61,22 @@
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Paso %1$d de %2$d</string>
-    <string name="tutorial_objective_explanation_copy">Bienvenido a NumPairs. Tu objetivo es descubrir todos los números y símbolos ocultos.</string>
-    <string name="tutorial_strip_explanation_copy">Esta es la serie. Sus números están ordenados de menor a mayor, pueden repetirse y algunos están ocultos.</string>
-    <string name="tutorial_tile_explanation_copy">Cada casilla muestra un resultado. Completa la parte superior con los dos números y el signo que producen ese resultado.</string>
-    <string name="tutorial_pair_explanation_copy">Agrupa los números de la serie por parejas. Cada pareja completa dos casillas: una suma y una multiplicación.</string>
+    <string name="tutorial_objective_explanation_copy">Bienvenido a NumPairs. Tu objetivo es descubrir todos los números, sumas y multiplicaciones ocultas.</string>
+    <string name="tutorial_strip_explanation_copy">La secuencia de la parte superior del puzle es una lista de números ordenados de menor a mayor, pueden repetirse e, inicialmente, algunos están ocultos.</string>
+    <string name="tutorial_tile_explanation_copy">Debajo tenemos las casillas. Cada una se compone de 2 partes: en su parte inferior, muestra un resultado conocido; en su parte superior contiene una suma o multiplicación cuyos elementos debes deducir.</string>
+    <string name="tutorial_pair_explanation_copy">¿Cómo deducirlos? Debes formar parejas con los números de la secuencia superior. Cada pareja debe resolver dos casillas: una suma y una multiplicación.</string>
     <string name="tutorial_previous_step_action">Atrás</string>
     <string name="tutorial_next_step_action">Siguiente</string>
-    <string name="tutorial_worked_example_introduction_copy">Presta atención: vamos a resolver este puzle por ti una sola vez.</string>
+    <string name="tutorial_worked_example_introduction_copy">Presta atención: por primera y última vez vamos a resolver este puzle por ti.</string>
     <string name="tutorial_worked_example_product_four_five_copy">4 × 5 = 20, así que 20 es la casilla de multiplicación de esta pareja.</string>
-    <string name="tutorial_worked_example_sum_four_five_copy">La misma pareja también da 4 + 5 = 9.</string>
-    <string name="tutorial_worked_example_reveal_three_copy">Quedan los resultados 5 y 6. Junto al 2, el número oculto tiene que ser 3.</string>
+    <string name="tutorial_worked_example_sum_four_five_copy">La misma pareja también debe resolver la suma 4 + 5 = 9.</string>
+    <string name="tutorial_worked_example_reveal_three_copy">Quedan por resolver los resultados 5 y 6. Junto al 2, el número oculto sólo puede ser 3.</string>
     <string name="tutorial_worked_example_product_two_three_copy">2 × 3 = 6 completa la multiplicación que falta.</string>
-    <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completa el puzle.</string>
+    <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completa la suma y resuelve el puzle.</string>
     <string name="tutorial_repeated_value_practice_copy">Ahora tú: resuelve el puzle. Toca cualquier ? para empezar. Los números pueden repetirse. Consejo: las multiplicaciones suelen ser un buen punto de partida.</string>
     <string name="onboarding_skip_tutorial_action">Saltar tutorial</string>
     <string name="onboarding_skip_tutorial_title">¿Saltar el tutorial?</string>
-    <string name="onboarding_skip_tutorial_message">Si es la primera vez que juegas a NumPairs o a juegos similares, te recomendamos continuar. Podrás volver a abrir el tutorial más tarde desde Cómo jugar.</string>
+    <string name="onboarding_skip_tutorial_message">Si es la primera vez que juegas a NumPairs, te recomendamos continuar.</string>
     <string name="onboarding_continue_tutorial_button">Continuar tutorial</string>
     <string name="onboarding_skip_anyway_button">Saltar igualmente</string>
     <string name="tutorial_solving_tips_step_one_copy">En dificultad baja, ningún número aparece dos veces y la serie nunca incluye el 1, así que los resultados primos siempre son sumas. Completa el resultado primo como una casilla de suma.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,22 +61,22 @@
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Step %1$d of %2$d</string>
-    <string name="tutorial_objective_explanation_copy">Welcome to NumPairs. Your goal is to discover every hidden number, addition and multiplication.</string>
-    <string name="tutorial_strip_explanation_copy">The sequence at the top of the puzzle is a list of numbers ordered from lowest to highest, may repeat, and initially, some are hidden.</string>
-    <string name="tutorial_tile_explanation_copy">Each tile shows a result. Complete its top row with the two numbers and symbol that produce that result.</string>
-    <string name="tutorial_pair_explanation_copy">Group the strip numbers into pairs. Each pair completes two tiles: one addition and one multiplication.</string>
+    <string name="tutorial_objective_explanation_copy">Welcome to NumPairs. Your goal is to find every number and complete all the hidden additions and multiplications.</string>
+    <string name="tutorial_strip_explanation_copy">The sequence at the top of the puzzle is a list of numbers ordered from lowest to highest. Numbers may repeat, and some are hidden at first.</string>
+    <string name="tutorial_tile_explanation_copy">The tiles are below. Each has two parts: a known result at the bottom and an addition or multiplication at the top whose numbers and symbol you must work out.</string>
+    <string name="tutorial_pair_explanation_copy">How do you work them out? Pair up the numbers in the sequence above. Each pair completes two tiles: one addition and one multiplication.</string>
     <string name="tutorial_previous_step_action">Back</string>
     <string name="tutorial_next_step_action">Next</string>
-    <string name="tutorial_worked_example_introduction_copy">Watch closely: we’ll solve this puzzle for you once.</string>
+    <string name="tutorial_worked_example_introduction_copy">Watch closely: this is the first and last time we’ll solve a puzzle for you.</string>
     <string name="tutorial_worked_example_product_four_five_copy">4 × 5 = 20, so 20 is this pair’s multiplication tile.</string>
-    <string name="tutorial_worked_example_sum_four_five_copy">The same pair also gives 4 + 5 = 9.</string>
-    <string name="tutorial_worked_example_reveal_three_copy">The remaining results are 5 and 6. Paired with 2, the hidden number must be 3.</string>
+    <string name="tutorial_worked_example_sum_four_five_copy">The same pair also completes the addition: 4 + 5 = 9.</string>
+    <string name="tutorial_worked_example_reveal_three_copy">The tiles showing 5 and 6 are still incomplete. Paired with 2, the hidden number can only be 3.</string>
     <string name="tutorial_worked_example_product_two_three_copy">2 × 3 = 6 completes the remaining multiplication.</string>
-    <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completes the puzzle.</string>
+    <string name="tutorial_worked_example_sum_two_three_copy">2 + 3 = 5 completes the addition and solves the puzzle.</string>
     <string name="tutorial_repeated_value_practice_copy">Your turn: solve the puzzle. Tap any ? to begin. Numbers may repeat. Tip: multiplication is often a good place to start.</string>
     <string name="onboarding_skip_tutorial_action">Skip tutorial</string>
     <string name="onboarding_skip_tutorial_title">Skip the tutorial?</string>
-    <string name="onboarding_skip_tutorial_message">If you’re new to NumPairs or similar games, we recommend continuing. You can open the Tutorial again later from How to play.</string>
+    <string name="onboarding_skip_tutorial_message">If this is your first time playing NumPairs, we recommend continuing.</string>
     <string name="onboarding_continue_tutorial_button">Continue tutorial</string>
     <string name="onboarding_skip_anyway_button">Skip anyway</string>
     <string name="tutorial_solving_tips_step_one_copy">In low difficulty, no number appears twice and the strip never includes 1, so prime results are always sums. Complete the prime result as an addition tile.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,8 +61,8 @@
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Step %1$d of %2$d</string>
-    <string name="tutorial_objective_explanation_copy">Welcome to NumPairs. Your goal is to discover every hidden number and symbol.</string>
-    <string name="tutorial_strip_explanation_copy">This is the number strip. Its numbers are ordered from lowest to highest, may repeat, and some are hidden.</string>
+    <string name="tutorial_objective_explanation_copy">Welcome to NumPairs. Your goal is to discover every hidden number, addition and multiplication.</string>
+    <string name="tutorial_strip_explanation_copy">The sequence at the top of the puzzle is a list of numbers ordered from lowest to highest, may repeat, and initially, some are hidden.</string>
     <string name="tutorial_tile_explanation_copy">Each tile shows a result. Complete its top row with the two numbers and symbol that produce that result.</string>
     <string name="tutorial_pair_explanation_copy">Group the strip numbers into pairs. Each pair completes two tiles: one addition and one multiplication.</string>
     <string name="tutorial_previous_step_action">Back</string>


### PR DESCRIPTION
## Related Issue

Resolves #562

## Summary

- Refine the Spanish Tutorial wording for clearer grammar, references, and first-time-player comprehension.
- Propagate the same learning intent through natural English and Valencian copy.
- Align localization expectations for every revised Tutorial message, including the onboarding skip recommendation.

## UI Consistency

- Shared components or tokens reused: Existing Tutorial surfaces and Android string resources remain unchanged.
- Intentional deviations from established visual roles: None; this Pull Request changes copy only.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew lintDebug`
- `git diff --check`
