### PR TITLE
[271] Refine Tutorial focus and review navigation

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenHighlightTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenHighlightTest.kt
@@ -12,6 +12,7 @@ class GameScreenHighlightTest : GameScreenTestHost() {
     @Test
     fun puzzleElementsAreNotHighlightedByDefault() {
         screen
+            .assertStripNotHighlighted()
             .assertStripItemNotHighlighted(index = 1)
             .scrollToBoard()
             .assertTileNotHighlighted(index = 0)
@@ -21,9 +22,10 @@ class GameScreenHighlightTest : GameScreenTestHost() {
     }
 
     @Test
-    fun rendersStaticHighlightsForStripEntriesTilesAndExpressionSlots() {
+    fun rendersStaticHighlightsForStripSurfaceEntriesTilesAndExpressionSlots() {
         showHighlightState(
             GameHighlightState(
+                isStripHighlighted = true,
                 stripEntryIndexes = setOf(1),
                 tileIndexes = setOf(0),
                 tileExpressionSlots = setOf(
@@ -44,6 +46,7 @@ class GameScreenHighlightTest : GameScreenTestHost() {
         )
 
         screen
+            .assertStripHighlighted()
             .assertStripItemHighlighted(index = 1)
             .assertStripItemNotHighlighted(index = 2)
             .scrollToBoard()

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenRobot.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenRobot.kt
@@ -61,6 +61,14 @@ class GameScreenRobot(
             .assertIsDisplayed()
     }
 
+    fun assertStripHighlighted(): GameScreenRobot = apply {
+        assertHighlighted(testTag = GameScreenTestTags.STRIP)
+    }
+
+    fun assertStripNotHighlighted(): GameScreenRobot = apply {
+        assertNotHighlighted(testTag = GameScreenTestTags.STRIP)
+    }
+
     fun tapStripItem(index: Int): GameScreenRobot = apply {
         interactions
             .onNodeWithTag(GameScreenTestTags.stripItem(index))

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/tutorial/TutorialRouteTest.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
@@ -51,26 +50,32 @@ class TutorialRouteTest {
             .assertIsDisplayed()
         assertNoRequiredSkipAction()
         repeat(4) { index ->
-            assertHighlighted(testTag = GameScreenTestTags.stripItem(index))
-            assertHighlighted(testTag = GameScreenTestTags.tile(index), useUnmergedTree = true)
+            assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(index))
+            assertUnmergedNodeNotHighlighted(testTag = GameScreenTestTags.tile(index))
+            assertTileExpressionSlotsNotHighlighted(tileIndex = index)
             assertTileExpressionHidden(tileIndex = index)
         }
+        assertNodeNotHighlighted(testTag = GameScreenTestTags.STRIP)
         composeTestRule
             .onNodeWithTag(TutorialScreenTestTags.PREVIOUS_STEP_ACTION)
-            .assertIsDisplayed()
-            .assertIsNotEnabled()
+            .assertDoesNotExist()
         composeTestRule
             .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
             .assertIsDisplayed()
             .assertIsEnabled()
         val minimumTouchTargetHeight = with(composeTestRule.density) { 48.dp.toPx() }
+        val instructionBounds = composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.INSTRUCTION_SURFACE)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val nextBounds = composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .fetchSemanticsNode()
+            .boundsInRoot
         assertTrue(
-            composeTestRule
-                .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
-                .fetchSemanticsNode()
-                .boundsInRoot
-                .height >= minimumTouchTargetHeight
+            nextBounds.height >= minimumTouchTargetHeight
         )
+        assertTrue(nextBounds.center.x > instructionBounds.center.x)
         composeTestRule
             .onNodeWithTag(GameScreenTestTags.RULES_HELPER_ACTION)
             .assertDoesNotExist()
@@ -106,8 +111,38 @@ class TutorialRouteTest {
             .assertHasNoClickAction()
         assertTileExpressionSlotsHaveNoClickAction(tileIndex = 0)
 
-        navigateToExplanationStep(PAIR_EXPLANATION_STEP_INDEX)
+        navigateToExplanationStep(STRIP_EXPLANATION_STEP_INDEX)
 
+        assertHighlighted(testTag = GameScreenTestTags.STRIP)
+        repeat(4) { index ->
+            assertHighlighted(testTag = GameScreenTestTags.stripItem(index))
+            assertUnmergedNodeNotHighlighted(testTag = GameScreenTestTags.tile(index))
+            assertTileExpressionSlotsNotHighlighted(tileIndex = index)
+        }
+
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .performClick()
+        assertStepDisplayed(stepIndex = TILE_EXPLANATION_STEP_INDEX)
+
+        assertNodeNotHighlighted(testTag = GameScreenTestTags.STRIP)
+        repeat(4) { index ->
+            assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(index))
+        }
+        assertHighlighted(testTag = GameScreenTestTags.tile(0), useUnmergedTree = true)
+        assertTileExpressionSlotsHighlighted(tileIndex = 0)
+        repeat(3) { offset ->
+            val tileIndex = offset + 1
+            assertUnmergedNodeNotHighlighted(testTag = GameScreenTestTags.tile(tileIndex))
+            assertTileExpressionSlotsNotHighlighted(tileIndex = tileIndex)
+        }
+
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .performClick()
+        assertStepDisplayed(stepIndex = PAIR_EXPLANATION_STEP_INDEX)
+
+        assertNodeNotHighlighted(testTag = GameScreenTestTags.STRIP)
         assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(0))
         assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(1))
         assertHighlighted(testTag = GameScreenTestTags.stripItem(2))
@@ -137,6 +172,12 @@ class TutorialRouteTest {
             .assertHasNoClickAction()
         assertTileExpressionSlotsHaveNoClickAction(tileIndex = 3)
         repeat(4, ::assertTileExpressionHidden)
+        assertNodeNotHighlighted(testTag = GameScreenTestTags.STRIP)
+        repeat(4) { index ->
+            assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(index))
+            assertUnmergedNodeNotHighlighted(testTag = GameScreenTestTags.tile(index))
+            assertTileExpressionSlotsNotHighlighted(tileIndex = index)
+        }
 
         advanceWorkedExampleStep(PRODUCT_FOUR_FIVE_STEP_INDEX)
         assertTileExpression(tileIndex = 3, operator = Operator.MULTIPLICATION, leftValue = "4", rightValue = "5")
@@ -144,6 +185,15 @@ class TutorialRouteTest {
         assertTileExpression(tileIndex = 2, operator = Operator.ADDITION, leftValue = "4", rightValue = "5")
         advanceWorkedExampleStep(REVEAL_THREE_STEP_INDEX)
         assertFocusedIntroductionStripDisplayed(expectedSecondValue = "3", isSecondValuePlayerEntered = true)
+        assertNodeNotHighlighted(testTag = GameScreenTestTags.STRIP)
+        assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(0))
+        assertHighlighted(testTag = GameScreenTestTags.stripItem(1))
+        assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(2))
+        assertNodeNotHighlighted(testTag = GameScreenTestTags.stripItem(3))
+        repeat(4) { index ->
+            assertUnmergedNodeNotHighlighted(testTag = GameScreenTestTags.tile(index))
+            assertTileExpressionSlotsNotHighlighted(tileIndex = index)
+        }
         advanceWorkedExampleStep(PRODUCT_TWO_THREE_STEP_INDEX)
         assertTileExpression(tileIndex = 1, operator = Operator.MULTIPLICATION)
         advanceWorkedExampleStep(SUM_TWO_THREE_STEP_INDEX)
@@ -198,6 +248,63 @@ class TutorialRouteTest {
             .onNodeWithTag(GameScreenTestTags.tileReset(0), useUnmergedTree = true)
             .assertIsDisplayed()
             .performClick()
+        assertPracticeCueDismissed()
+    }
+
+    @Test
+    fun independentPracticeCanReviewPreviousStepsWithoutLosingProgressOrRepeatingCheckpoint() {
+        val checkpointCount = AtomicInteger(0)
+        setContent(
+            onProgressCheckpointReached = { progressCheckpoint ->
+                if (progressCheckpoint == TutorialProgressCheckpoint.WORKED_EXAMPLE_COMPLETED) {
+                    checkpointCount.incrementAndGet()
+                }
+            }
+        )
+        advanceThroughExplanation()
+        advanceThroughWorkedExample()
+
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.PREVIOUS_STEP_ACTION)
+            .assertIsDisplayed()
+            .assertIsEnabled()
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .assertDoesNotExist()
+        val minimumTouchTargetHeight = with(composeTestRule.density) { 48.dp.toPx() }
+        val instructionBounds = composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.INSTRUCTION_SURFACE)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val previousBounds = composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.PREVIOUS_STEP_ACTION)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        assertTrue(previousBounds.height >= minimumTouchTargetHeight)
+        assertTrue(previousBounds.center.x < instructionBounds.center.x)
+
+        enterStripValue(index = 0, value = "1")
+        assertPracticeCueDismissed()
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.PREVIOUS_STEP_ACTION)
+            .performScrollTo()
+            .performClick()
+        assertStepDisplayed(stepIndex = SUM_TWO_THREE_STEP_INDEX)
+        assertTileExpression(tileIndex = 0, operator = Operator.ADDITION)
+
+        composeTestRule
+            .onNodeWithTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            .performScrollTo()
+            .performClick()
+        waitForStep(stepIndex = PRACTICE_STEP_INDEX)
+
+        assertEquals(1, checkpointCount.get())
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.stripItem(0))
+            .performScrollTo()
+            .assertContentDescriptionEquals(
+                string(R.string.strip_item_player_entered_content_description, "1")
+            )
         assertPracticeCueDismissed()
     }
 
@@ -727,6 +834,7 @@ class TutorialRouteTest {
     private companion object {
         const val OBJECTIVE_EXPLANATION_STEP_INDEX = 0
         const val STRIP_EXPLANATION_STEP_INDEX = 1
+        const val TILE_EXPLANATION_STEP_INDEX = 2
         const val PAIR_EXPLANATION_STEP_INDEX = 3
         const val WORKED_EXAMPLE_INTRODUCTION_STEP_INDEX = 4
         const val PRODUCT_FOUR_FIVE_STEP_INDEX = 5

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/GameHighlightState.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/GameHighlightState.kt
@@ -1,6 +1,7 @@
 package org.cescfe.numpairs.feature.game
 
 data class GameHighlightState(
+    val isStripHighlighted: Boolean = false,
     val stripEntryIndexes: Set<Int> = emptySet(),
     val tileIndexes: Set<Int> = emptySet(),
     val tileExpressionSlots: Set<GameTileExpressionSlotHighlight> = emptySet()

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenSections.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenSections.kt
@@ -3,6 +3,7 @@ package org.cescfe.numpairs.feature.game.ui.screen
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -49,6 +50,7 @@ import org.cescfe.numpairs.feature.game.ui.components.strip.AvailableNumberInput
 import org.cescfe.numpairs.feature.game.ui.components.strip.CHIP_HORIZONTAL_CONTENT_INSET
 import org.cescfe.numpairs.feature.game.ui.components.tile.PuzzleTile
 import org.cescfe.numpairs.feature.game.ui.semantics.completionFeedbackSemantics
+import org.cescfe.numpairs.feature.game.ui.semantics.gameHighlightSemantics
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 import org.cescfe.numpairs.ui.theme.NumPairsTextStyles
 import org.cescfe.numpairs.ui.theme.numPairsSemanticColors
@@ -214,10 +216,19 @@ internal fun StripSection(
         stripItems = stripItems,
         stripItemEntryInput = stripItemEntryInput
     )
+    val stripBorder = if (highlightState.isStripHighlighted) {
+        BorderStroke(
+            width = STRIP_HIGHLIGHTED_BORDER_WIDTH,
+            color = MaterialTheme.numPairsSemanticColors.tutorialHighlight
+        )
+    } else {
+        NumPairsComponents.subtleBorder()
+    }
 
     Surface(
         modifier = modifier
             .testTag(GameScreenTestTags.STRIP)
+            .gameHighlightSemantics(highlightState.isStripHighlighted)
             .semantics {
                 contentDescription = stripContentDescription
                 stripEntryFeedbackText?.let { feedbackText ->
@@ -226,7 +237,7 @@ internal fun StripSection(
             },
         color = NumPairsComponents.subtleSurfaceColor(),
         shape = NumPairsComponents.LargeShape,
-        border = NumPairsComponents.subtleBorder()
+        border = stripBorder
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenTokens.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenTokens.kt
@@ -16,6 +16,7 @@ internal val STRIP_CHIP_MAX_WIDTH = 56.dp
 internal val STRIP_CHIP_SPACING = 4.dp
 internal val STRIP_ROW_SPACING = 8.dp
 internal val STRIP_ENTRY_FEEDBACK_TOP_SPACING = 8.dp
+internal val STRIP_HIGHLIGHTED_BORDER_WIDTH = 3.dp
 internal val STRIP_HORIZONTAL_PADDING = 8.dp
 internal val STRIP_VERTICAL_PADDING = 14.dp
 internal val TILE_OPERATOR_MENU_CORNER_RADIUS = 16.dp

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/LearnBasicsTutorialContent.kt
@@ -43,13 +43,7 @@ internal object LearnBasicsTutorialContent {
             manualWorkedExampleStep(
                 copyResId = R.string.tutorial_worked_example_introduction_copy,
                 entryPuzzle = initialPuzzle,
-                highlightedTargets = listOf(
-                    TutorialHighlightTarget.StripEntries(indexes = listOf(0, 1, 2, 3)),
-                    TutorialHighlightTarget.WholeTile(tileIndex = 0),
-                    TutorialHighlightTarget.WholeTile(tileIndex = 1),
-                    TutorialHighlightTarget.WholeTile(tileIndex = 2),
-                    TutorialHighlightTarget.WholeTile(tileIndex = 3)
-                )
+                highlightedTargets = emptyList()
             ),
             manualWorkedExampleStep(
                 copyResId = R.string.tutorial_worked_example_product_four_five_copy,
@@ -66,8 +60,9 @@ internal object LearnBasicsTutorialContent {
             manualWorkedExampleStep(
                 copyResId = R.string.tutorial_worked_example_reveal_three_copy,
                 entryPuzzle = completedStrip,
-                stripEntryIndexes = listOf(0, 1),
-                tileIndexes = listOf(0, 1)
+                highlightedTargets = listOf(
+                    TutorialHighlightTarget.StripEntries(indexes = listOf(1))
+                )
             ),
             manualWorkedExampleStep(
                 copyResId = R.string.tutorial_worked_example_product_two_three_copy,
@@ -128,24 +123,20 @@ internal object LearnBasicsTutorialContent {
     private fun explanationSteps(): List<TutorialStep> = listOf(
         manualExplanationStep(
             copyResId = R.string.tutorial_objective_explanation_copy,
-            highlightedTargets = listOf(
-                TutorialHighlightTarget.StripEntries(indexes = listOf(0, 1, 2, 3)),
-                TutorialHighlightTarget.WholeTile(tileIndex = 0),
-                TutorialHighlightTarget.WholeTile(tileIndex = 1),
-                TutorialHighlightTarget.WholeTile(tileIndex = 2),
-                TutorialHighlightTarget.WholeTile(tileIndex = 3)
-            )
+            highlightedTargets = emptyList()
         ),
         manualExplanationStep(
             copyResId = R.string.tutorial_strip_explanation_copy,
             highlightedTargets = listOf(
+                TutorialHighlightTarget.WholeStrip,
                 TutorialHighlightTarget.StripEntries(indexes = listOf(0, 1, 2, 3))
             )
         ),
         manualExplanationStep(
             copyResId = R.string.tutorial_tile_explanation_copy,
             highlightedTargets = listOf(
-                TutorialHighlightTarget.WholeTile(tileIndex = 0)
+                TutorialHighlightTarget.WholeTile(tileIndex = 0),
+                TutorialHighlightTarget.TileExpressionSlots(tileIndex = 0)
             )
         ),
         manualExplanationStep(

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialContentModels.kt
@@ -70,6 +70,8 @@ data class TutorialStep(
 }
 
 sealed interface TutorialHighlightTarget {
+    data object WholeStrip : TutorialHighlightTarget
+
     data object HiddenStripEntries : TutorialHighlightTarget
 
     data object HiddenTileExpressions : TutorialHighlightTarget

--- a/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/tutorial/TutorialRoute.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.cescfe.numpairs.R
 import org.cescfe.numpairs.domain.puzzle.model.OperandSlot
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.cescfe.numpairs.feature.game.GameHighlightState
 import org.cescfe.numpairs.feature.game.GameInteractionPolicy
@@ -77,6 +78,9 @@ fun TutorialRoute(
         mutableIntStateOf(startStepIndex - 1)
     }
     var latestGameUiSnapshot by remember(playbackKey) { mutableStateOf<TutorialGameUiSnapshot?>(null) }
+    var latestPuzzleSnapshot by remember(playbackKey) { mutableStateOf<TutorialPuzzleSnapshot?>(null) }
+    var retainedPracticePuzzle by remember(playbackKey) { mutableStateOf<Puzzle?>(null) }
+    var wasPracticeCueDismissed by remember(playbackKey) { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
     val currentOnProgressCheckpointReached by rememberUpdatedState(onProgressCheckpointReached)
     val currentOnTutorialCompleted by rememberUpdatedState(onTutorialCompleted)
@@ -86,12 +90,25 @@ fun TutorialRoute(
         mutableStateOf(false)
     }
     var hasCurrentStepPuzzleChanged by remember(playbackKey, currentStepIndex) {
-        mutableStateOf(false)
+        mutableStateOf(
+            currentStep.scenarioId == TutorialScenarioId.REPEATED_VALUE_PRACTICE &&
+                wasPracticeCueDismissed
+        )
     }
-    val currentEntryPuzzle = currentStep.entryPuzzle ?: currentScenario.initialPuzzle
+    val currentEntryPuzzle = currentStep.entryPuzzle
+        ?: retainedPracticePuzzle.takeIf {
+            currentStep.scenarioId == TutorialScenarioId.REPEATED_VALUE_PRACTICE
+        }
+        ?: currentScenario.initialPuzzle
     val latestGameUiState = latestGameUiSnapshot
         ?.takeIf { snapshot -> snapshot.scenarioId == currentScenario.id }
         ?.uiState
+    val isManualAdvanceStep = currentStep.completionPredicate == TutorialStepCompletionPredicate.ManualAdvance
+    val showPreviousStepAction = currentStepIndex > 0 &&
+        (
+            isManualAdvanceStep ||
+                currentStep.scenarioId == TutorialScenarioId.REPEATED_VALUE_PRACTICE
+            )
 
     LaunchedEffect(currentStepIndex, latestGameUiState) {
         val uiState = latestGameUiState ?: return@LaunchedEffect
@@ -149,9 +166,18 @@ fun TutorialRoute(
                 currentStep = currentStep,
                 currentStepNumber = currentStepIndex + 1,
                 totalSteps = steps.size,
-                canNavigateBack = currentStepIndex > 0 && !isCheckpointNavigationInProgress,
+                showNavigateBack = showPreviousStepAction,
+                showNavigateNext = isManualAdvanceStep,
+                canNavigateBack = showPreviousStepAction && !isCheckpointNavigationInProgress,
                 canNavigateNext = !isCheckpointNavigationInProgress,
                 onNavigateBack = {
+                    if (currentStep.scenarioId == TutorialScenarioId.REPEATED_VALUE_PRACTICE) {
+                        retainedPracticePuzzle = latestPuzzleSnapshot
+                            ?.takeIf { snapshot -> snapshot.scenarioId == currentScenario.id }
+                            ?.puzzle
+                            ?: currentEntryPuzzle
+                        wasPracticeCueDismissed = hasCurrentStepPuzzleChanged
+                    }
                     currentStepIndex -= 1
                 },
                 onNavigateNext = {
@@ -159,10 +185,13 @@ fun TutorialRoute(
 
                     if (progressCheckpoint == null && currentStepIndex < steps.lastIndex) {
                         currentStepIndex += 1
+                    } else if (lastReportedStepIndex >= currentStepIndex && currentStepIndex < steps.lastIndex) {
+                        currentStepIndex += 1
                     } else if (!isCheckpointNavigationInProgress && currentStepIndex < steps.lastIndex) {
                         isCheckpointNavigationInProgress = true
                         coroutineScope.launch {
                             currentOnProgressCheckpointReached(requireNotNull(progressCheckpoint))
+                            lastReportedStepIndex = currentStepIndex
                             currentStepIndex += 1
                             isCheckpointNavigationInProgress = false
                         }
@@ -178,6 +207,10 @@ fun TutorialRoute(
             )
         },
         onPuzzleChanged = { puzzle ->
+            latestPuzzleSnapshot = TutorialPuzzleSnapshot(
+                scenarioId = currentScenario.id,
+                puzzle = puzzle
+            )
             if (puzzle != currentEntryPuzzle) {
                 hasCurrentStepPuzzleChanged = true
             }
@@ -187,6 +220,8 @@ fun TutorialRoute(
 }
 
 private data class TutorialGameUiSnapshot(val scenarioId: TutorialScenarioId, val uiState: GameUiState)
+
+private data class TutorialPuzzleSnapshot(val scenarioId: TutorialScenarioId, val puzzle: Puzzle)
 
 internal fun isTutorialSuccessOverlayEnabled(
     mode: TutorialMode,
@@ -204,6 +239,8 @@ private fun TutorialInstructionSurface(
     currentStep: TutorialStep,
     currentStepNumber: Int,
     totalSteps: Int,
+    showNavigateBack: Boolean,
+    showNavigateNext: Boolean,
     canNavigateBack: Boolean,
     canNavigateNext: Boolean,
     onNavigateBack: () -> Unit,
@@ -237,8 +274,10 @@ private fun TutorialInstructionSurface(
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurface
             )
-            if (currentStep.completionPredicate == TutorialStepCompletionPredicate.ManualAdvance) {
+            if (showNavigateBack || showNavigateNext) {
                 TutorialStepNavigation(
+                    showNavigateBack = showNavigateBack,
+                    showNavigateNext = showNavigateNext,
                     canNavigateBack = canNavigateBack,
                     canNavigateNext = canNavigateNext,
                     onNavigateBack = onNavigateBack,
@@ -251,6 +290,8 @@ private fun TutorialInstructionSurface(
 
 @Composable
 private fun TutorialStepNavigation(
+    showNavigateBack: Boolean,
+    showNavigateNext: Boolean,
     canNavigateBack: Boolean,
     canNavigateNext: Boolean,
     onNavigateBack: () -> Unit,
@@ -259,32 +300,40 @@ private fun TutorialStepNavigation(
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
+        horizontalArrangement = when {
+            showNavigateBack && showNavigateNext -> Arrangement.SpaceBetween
+            showNavigateBack -> Arrangement.Start
+            else -> Arrangement.End
+        },
         verticalAlignment = Alignment.CenterVertically
     ) {
-        TextButton(
-            onClick = onNavigateBack,
-            enabled = canNavigateBack,
-            modifier = Modifier
-                .heightIn(min = 48.dp)
-                .testTag(TutorialScreenTestTags.PREVIOUS_STEP_ACTION)
-        ) {
-            Text(
-                text = stringResource(R.string.tutorial_previous_step_action),
-                style = MaterialTheme.typography.labelLarge
-            )
+        if (showNavigateBack) {
+            TextButton(
+                onClick = onNavigateBack,
+                enabled = canNavigateBack,
+                modifier = Modifier
+                    .heightIn(min = 48.dp)
+                    .testTag(TutorialScreenTestTags.PREVIOUS_STEP_ACTION)
+            ) {
+                Text(
+                    text = stringResource(R.string.tutorial_previous_step_action),
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
         }
-        TextButton(
-            onClick = onNavigateNext,
-            enabled = canNavigateNext,
-            modifier = Modifier
-                .heightIn(min = 48.dp)
-                .testTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
-        ) {
-            Text(
-                text = stringResource(R.string.tutorial_next_step_action),
-                style = MaterialTheme.typography.labelLarge
-            )
+        if (showNavigateNext) {
+            TextButton(
+                onClick = onNavigateNext,
+                enabled = canNavigateNext,
+                modifier = Modifier
+                    .heightIn(min = 48.dp)
+                    .testTag(TutorialScreenTestTags.NEXT_STEP_ACTION)
+            ) {
+                Text(
+                    text = stringResource(R.string.tutorial_next_step_action),
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
         }
     }
 }
@@ -479,6 +528,7 @@ private fun TutorialRequiredAction.CompleteTileExpression.hiddenRequiredStripEnt
 private fun TutorialStep.highlightedStripEntryIds(scenario: TutorialScenario): Set<Int> = buildSet {
     highlightedTargets.forEach { target ->
         when (target) {
+            TutorialHighlightTarget.WholeStrip -> Unit
             TutorialHighlightTarget.HiddenStripEntries -> {
                 scenario.initialPuzzle.strip.items.forEachIndexed { index, item ->
                     if (item == StripItem.Hidden) {
@@ -520,9 +570,13 @@ internal fun TutorialStep.toHighlightState(
     val stripEntryIndexes = mutableSetOf<Int>()
     val tileIndexes = mutableSetOf<Int>()
     val tileExpressionSlots = mutableSetOf<GameTileExpressionSlotHighlight>()
+    var isStripHighlighted = false
 
     highlightedTargets.forEach { target ->
         when (target) {
+            TutorialHighlightTarget.WholeStrip -> {
+                isStripHighlighted = true
+            }
             TutorialHighlightTarget.HiddenStripEntries -> {
                 scenario.initialPuzzle.strip.items.forEachIndexed { index, item ->
                     if (item == StripItem.Hidden) {
@@ -550,6 +604,7 @@ internal fun TutorialStep.toHighlightState(
     }
 
     return GameHighlightState(
+        isStripHighlighted = isStripHighlighted,
         stripEntryIndexes = stripEntryIndexes,
         tileIndexes = tileIndexes,
         tileExpressionSlots = tileExpressionSlots

--- a/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/tutorial/TutorialContentTest.kt
@@ -10,6 +10,7 @@ import org.cescfe.numpairs.domain.puzzle.model.PuzzleCompletionState
 import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.cescfe.numpairs.domain.puzzle.model.Tile
 import org.cescfe.numpairs.feature.game.GameHighlightState
+import org.cescfe.numpairs.feature.game.GameTileExpressionSlot
 import org.cescfe.numpairs.feature.game.presentation.GameUiState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -103,18 +104,14 @@ class TutorialContentTest {
         )
         assertEquals(
             listOf(
+                emptyList(),
                 listOf(
-                    TutorialHighlightTarget.StripEntries(indexes = listOf(0, 1, 2, 3)),
-                    TutorialHighlightTarget.WholeTile(tileIndex = 0),
-                    TutorialHighlightTarget.WholeTile(tileIndex = 1),
-                    TutorialHighlightTarget.WholeTile(tileIndex = 2),
-                    TutorialHighlightTarget.WholeTile(tileIndex = 3)
-                ),
-                listOf(
+                    TutorialHighlightTarget.WholeStrip,
                     TutorialHighlightTarget.StripEntries(indexes = listOf(0, 1, 2, 3))
                 ),
                 listOf(
-                    TutorialHighlightTarget.WholeTile(tileIndex = 0)
+                    TutorialHighlightTarget.WholeTile(tileIndex = 0),
+                    TutorialHighlightTarget.TileExpressionSlots(tileIndex = 0)
                 ),
                 listOf(
                     TutorialHighlightTarget.StripEntries(indexes = listOf(2, 3)),
@@ -155,6 +152,36 @@ class TutorialContentTest {
     }
 
     @Test
+    fun learn_basics_maps_each_refined_focus_to_the_exact_game_highlight() {
+        val scenario = TutorialContent.scenario(TutorialScenarioId.STRIP_AND_TILES_INTRODUCTION)
+        val steps = TutorialContent.learnBasicsSteps
+
+        assertEquals(GameHighlightState.None, steps[0].toHighlightState(scenario = scenario, uiState = null))
+
+        val stripExplanation = steps[1].toHighlightState(scenario = scenario, uiState = null)
+        assertTrue(stripExplanation.isStripHighlighted)
+        assertEquals(setOf(0, 1, 2, 3), stripExplanation.stripEntryIndexes)
+        assertTrue(stripExplanation.tileIndexes.isEmpty())
+        assertTrue(stripExplanation.tileExpressionSlots.isEmpty())
+
+        val tileExplanation = steps[2].toHighlightState(scenario = scenario, uiState = null)
+        assertFalse(tileExplanation.isStripHighlighted)
+        assertTrue(tileExplanation.stripEntryIndexes.isEmpty())
+        assertEquals(setOf(0), tileExplanation.tileIndexes)
+        GameTileExpressionSlot.entries.forEach { slot ->
+            assertTrue(tileExplanation.isTileExpressionSlotHighlighted(tileIndex = 0, slot = slot))
+        }
+
+        assertEquals(GameHighlightState.None, steps[4].toHighlightState(scenario = scenario, uiState = null))
+
+        val revealedThree = steps[7].toHighlightState(scenario = scenario, uiState = null)
+        assertFalse(revealedThree.isStripHighlighted)
+        assertEquals(setOf(1), revealedThree.stripEntryIndexes)
+        assertTrue(revealedThree.tileIndexes.isEmpty())
+        assertTrue(revealedThree.tileExpressionSlots.isEmpty())
+    }
+
+    @Test
     fun worked_example_steps_follow_the_exact_reasoned_solution_order() {
         val steps = TutorialContent.learnBasicsSteps.subList(fromIndex = 4, toIndex = 10)
 
@@ -189,26 +216,27 @@ class TutorialContentTest {
         assertEquals(PuzzleCompletionState.SOLVED, requireNotNull(steps.last().entryPuzzle).completionState)
         assertEquals(
             listOf(
-                listOf(0, 1, 2, 3),
+                emptyList(),
                 listOf(2, 3),
                 listOf(2, 3),
-                listOf(0, 1),
+                listOf(1),
                 listOf(0, 1),
                 listOf(0, 1)
             ),
             steps.map { step ->
                 step.highlightedTargets
                     .filterIsInstance<TutorialHighlightTarget.StripEntries>()
-                    .single()
-                    .indexes
+                    .singleOrNull()
+                    ?.indexes
+                    .orEmpty()
             }
         )
         assertEquals(
             listOf(
-                listOf(0, 1, 2, 3),
+                emptyList(),
                 listOf(3),
                 listOf(2),
-                listOf(0, 1),
+                emptyList(),
                 listOf(1),
                 listOf(0)
             ),

--- a/docs/product/prd/prd-v6.md
+++ b/docs/product/prd/prd-v6.md
@@ -117,20 +117,20 @@ tiles: ? ? ? = 5
        ? ? ? = 20
 ```
 
-Every explanatory step disables strip, operand, operator, and reset interaction. The player advances or returns manually with accessible `Back` and `Next` actions below the current copy. The controls keep stable layout and touch targets; `Back` is unavailable on the first explanation without moving `Next`.
+Every explanatory step disables strip, operand, operator, and reset interaction. The player advances or returns manually with accessible `Back` and `Next` actions below the current copy. The controls keep stable layout and touch targets. The first explanation omits `Back` entirely while keeping `Next` in its established right-hand position.
 
 Use one short message and one matching focus per step:
 
-1. Show the whole puzzle and explain that the objective is to discover every hidden number and symbol.
-2. Highlight the strip and explain that its positive integers are ordered from lowest to highest, may repeat, and may be hidden.
-3. Highlight one tile and explain that its visible result is produced by two operands and one operator in the hidden expression.
+1. Show the whole puzzle without highlighting any element and explain that the objective is to discover every hidden number and symbol.
+2. Highlight the complete strip surface and all its entries; explain that its positive integers are ordered from lowest to highest, may repeat, and may be hidden.
+3. Highlight one whole tile and its three hidden expression slots; explain that its visible result is produced by two operands and one operator in the hidden expression.
 4. Highlight strip entries `4` and `5` with result tiles `9` and `20`; explain that each pair completes two tiles, one sum and one product.
 
-Continue with a deterministic, manually paced worked example. Its first step keeps the same unresolved state visible, then five more steps apply these transitions in order:
+Continue with a deterministic, manually paced worked example. Its first step keeps the same unresolved state visible without highlighting any element, then five more steps apply these transitions in order:
 
 1. `4 × 5 = 20`: the larger product is resolved first.
 2. `4 + 5 = 9`: the same pair also completes its sum.
-3. Reveal strip value `3`: with `2`, it produces the remaining results `5` and `6`.
+3. Reveal and exclusively highlight strip value `3`: with `2`, it produces the remaining results `5` and `6`.
 4. `2 × 3 = 6`: resolve the remaining product.
 5. `2 + 3 = 5`: resolve the remaining sum.
 
@@ -161,6 +161,8 @@ These results correspond to one addition and one multiplication for the `1`/`2` 
 Tell the player that it is their turn, that tapping any unknown starts an interaction, and that strip values may repeat. Present multiplication as a useful starting heuristic rather than a universal rule. Initially focus the known `2` and `3` entries with result tile `6` without restricting the player's first action; remove that cue after the player commits the first puzzle change.
 
 Allow normal strip, operand, operator, correction, reset, and validation behavior from the beginning.
+
+Show an accessible `Back` action and no `Next` action during independent practice. `Back` returns to the final worked-example step so the player can review any previous explanation. Returning to practice restores committed in-session puzzle progress and keeps its initial cue dismissed if the player had already changed the puzzle. Revisiting the final worked-example boundary does not record its checkpoint again.
 
 The two strip entries that display `2` remain distinct stable entries. Because exchanging those equal-valued entries produces an equivalent player-visible solution, Tutorial completion must accept either valid stable-entry assignment as long as all shared puzzle rules are satisfied.
 


### PR DESCRIPTION
## Related Issue

Resolves #564

## Summary

- Refine Learn Basics highlights so Steps 1 and 5 stay neutral, Step 2 focuses the complete strip and its entries, Step 3 focuses one tile and its hidden expression slots, and Step 8 focuses only the revealed `3`.
- Hide the unavailable `Back` action on Step 1 and add a `Back`-only review path from independent practice that retains committed in-session progress and avoids duplicate checkpoint reporting.
- Update the active v6 product contract and add unit and Compose coverage for exact focus, button visibility, retained practice state, and strip-surface rendering.

## UI Consistency

- Shared components or tokens reused: Existing Material `TextButton` navigation, `NumPairsComponents.LargeShape`, subtle strip surface and border, and the semantic `tutorialHighlight` color. The strip highlight uses the same 3 dp border emphasis as existing highlighted tiles and strip entries.
- Intentional deviations from established visual roles: None.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew lintDebug`
- `git diff --check`
