### PR TITLE
[273] Launch remembered generated difficulty from Menu

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/RequiredOnboardingNavigationTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -315,7 +316,7 @@ class RequiredOnboardingNavigationTest {
     private fun waitForMenu() {
         composeTestRule.waitUntil(timeoutMillis = ONBOARDING_WAIT_TIMEOUT_MILLIS) {
             composeTestRule
-                .onAllNodes(hasText(string(R.string.menu_four_pairs_button)))
+                .onAllNodes(hasTestTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON))
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/eightpairs/EightPairsModeTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/eightpairs/EightPairsModeTest.kt
@@ -54,13 +54,23 @@ class EightPairsModeTest {
             .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
             .assertIsDisplayed()
         composeTestRule
-            .onNodeWithText(string(R.string.menu_four_pairs_button))
+            .onNodeWithText(
+                challengeName(R.string.four_pairs_screen_title, R.string.generated_difficulty_low)
+            )
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON)
             .assertIsDisplayed()
         composeTestRule
             .onNodeWithTag(MenuScreenTestTags.EIGHT_PAIRS_BUTTON)
             .assertIsDisplayed()
         composeTestRule
-            .onNodeWithText(string(R.string.menu_eight_pairs_button))
+            .onNodeWithText(
+                challengeName(R.string.eight_pairs_screen_title, R.string.generated_difficulty_medium)
+            )
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.EIGHT_PAIRS_DIFFICULTY_BUTTON)
             .assertIsDisplayed()
     }
 
@@ -163,6 +173,12 @@ class EightPairsModeTest {
 
     private fun string(stringResId: Int, vararg formatArgs: Any): String =
         composeTestRule.activity.getString(stringResId, *formatArgs)
+
+    private fun challengeName(modeNameResource: Int, difficultyNameResource: Int): String = string(
+        R.string.generated_challenge_title,
+        string(modeNameResource),
+        string(difficultyNameResource)
+    )
 
     private fun eightPairsProviderFactory(
         puzzleProvider: RecordingGeneratedPuzzleProvider

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTest.kt
@@ -1,0 +1,112 @@
+package org.cescfe.numpairs.feature.menu.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MenuScreenTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun generated_mode_rows_identify_the_selected_challenge_and_emit_distinct_actions() {
+        var playCount = 0
+        var difficultyCount = 0
+        setContent(
+            onFourPairsSelected = { playCount += 1 },
+            onFourPairsDifficultySelected = { difficultyCount += 1 }
+        )
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
+            .assertIsDisplayed()
+            .assertTextEquals(fourPairsState.challengeName)
+            .assertContentDescriptionEquals(
+                string(
+                    R.string.menu_play_generated_challenge_content_description,
+                    fourPairsState.challengeName
+                )
+            )
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON)
+            .assertIsDisplayed()
+            .assertContentDescriptionEquals(
+                string(
+                    R.string.menu_choose_generated_difficulty_content_description,
+                    fourPairsState.modeName
+                )
+            )
+            .performClick()
+
+        composeTestRule.runOnIdle {
+            assertEquals(1, playCount)
+            assertEquals(1, difficultyCount)
+        }
+    }
+
+    @Test
+    fun difficulty_actions_are_square_and_match_the_primary_action_height() {
+        setContent()
+
+        listOf(
+            MenuScreenTestTags.FOUR_PAIRS_BUTTON to MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON,
+            MenuScreenTestTags.EIGHT_PAIRS_BUTTON to MenuScreenTestTags.EIGHT_PAIRS_DIFFICULTY_BUTTON
+        ).forEach { (playTag, difficultyTag) ->
+            val playBounds = composeTestRule
+                .onNodeWithTag(playTag)
+                .assertIsDisplayed()
+                .fetchSemanticsNode()
+                .boundsInRoot
+            val difficultyBounds = composeTestRule
+                .onNodeWithTag(difficultyTag)
+                .assertIsDisplayed()
+                .fetchSemanticsNode()
+                .boundsInRoot
+
+            assertEquals(playBounds.height, difficultyBounds.height, 0.5f)
+            assertEquals(difficultyBounds.width, difficultyBounds.height, 0.5f)
+            assertTrue(playBounds.right < difficultyBounds.left)
+        }
+    }
+
+    private fun setContent(onFourPairsSelected: () -> Unit = {}, onFourPairsDifficultySelected: () -> Unit = {}) {
+        composeTestRule.setContent {
+            NumPairsTheme {
+                MenuScreen(
+                    fourPairsMode = fourPairsState,
+                    eightPairsMode = eightPairsState,
+                    onFourPairsSelected = onFourPairsSelected,
+                    onFourPairsDifficultySelected = onFourPairsDifficultySelected
+                )
+            }
+        }
+    }
+
+    private fun string(stringResId: Int, vararg formatArgs: Any): String =
+        composeTestRule.activity.getString(stringResId, *formatArgs)
+
+    private companion object {
+        val fourPairsState = GeneratedModeMenuUiState(
+            modeName = "4 pairs",
+            challengeName = "4 pairs · Low"
+        )
+        val eightPairsState = GeneratedModeMenuUiState(
+            modeName = "8 pairs",
+            challengeName = "8 pairs · Medium"
+        )
+    }
+}

--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedDifficultyNavigationTestActions.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedDifficultyNavigationTestActions.kt
@@ -4,13 +4,9 @@ import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import org.cescfe.numpairs.feature.generated.selector.ui.GeneratedDifficultySelectorTestTags
 
 internal fun SemanticsNodeInteractionsProvider.navigateToSelectedGeneratedChallenge(menuButtonTag: String) {
     onNodeWithTag(menuButtonTag)
-        .assertIsDisplayed()
-        .performClick()
-    onNodeWithTag(GeneratedDifficultySelectorTestTags.PLAY_BUTTON)
         .assertIsDisplayed()
         .performClick()
 }

--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedDifficultySelectionNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedDifficultySelectionNavigationTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -49,15 +50,15 @@ class GeneratedDifficultySelectionNavigationTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun menu_routes_to_independent_read_only_selector_defaults() {
+    fun secondary_actions_route_to_independent_read_only_selector_defaults() {
         val fixture = setContent()
 
-        composeTestRule.onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON).performClick()
+        composeTestRule.onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON).performClick()
         composeTestRule.onNodeWithTag(optionTag(GeneratedModes.FOUR_PAIRS_LOW)).assertIsSelected()
         composeTestRule.onNodeWithTag(optionTag(GeneratedModes.FOUR_PAIRS_MEDIUM)).assertIsNotSelected()
         composeTestRule.onNodeWithTag(GeneratedDifficultySelectorTestTags.BACK_BUTTON).performClick()
 
-        composeTestRule.onNodeWithTag(MenuScreenTestTags.EIGHT_PAIRS_BUTTON).performClick()
+        composeTestRule.onNodeWithTag(MenuScreenTestTags.EIGHT_PAIRS_DIFFICULTY_BUTTON).performClick()
         composeTestRule.onNodeWithTag(optionTag(GeneratedModes.EIGHT_PAIRS_MEDIUM)).assertIsSelected()
         composeTestRule.onNodeWithTag(optionTag(GeneratedModes.EIGHT_PAIRS_HARD)).assertIsNotSelected()
 
@@ -79,7 +80,7 @@ class GeneratedDifficultySelectionNavigationTest {
     fun explicit_four_pairs_medium_selection_persists_and_launches_that_exact_challenge() {
         val fixture = setContent()
 
-        composeTestRule.onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON).performClick()
+        composeTestRule.onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON).performClick()
         composeTestRule
             .onNodeWithTag(optionTag(GeneratedModes.FOUR_PAIRS_MEDIUM))
             .performClick()
@@ -102,7 +103,7 @@ class GeneratedDifficultySelectionNavigationTest {
         }
 
         composeTestRule.onNodeWithTag(GameScreenTestTags.BACK_BUTTON).performClick()
-        composeTestRule.onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON).performClick()
+        composeTestRule.onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON).performClick()
         composeTestRule.onNodeWithTag(optionTag(GeneratedModes.FOUR_PAIRS_MEDIUM)).assertIsSelected()
         composeTestRule.runOnIdle {
             assertEquals(1, fixture.difficultyRepository.explicitSelections.size)
@@ -113,7 +114,7 @@ class GeneratedDifficultySelectionNavigationTest {
     fun eight_pairs_hard_selection_launches_and_stores_the_hard_profile() {
         val fixture = setContent()
 
-        composeTestRule.onNodeWithTag(MenuScreenTestTags.EIGHT_PAIRS_BUTTON).performClick()
+        composeTestRule.onNodeWithTag(MenuScreenTestTags.EIGHT_PAIRS_DIFFICULTY_BUTTON).performClick()
         composeTestRule
             .onNodeWithTag(optionTag(GeneratedModes.EIGHT_PAIRS_HARD))
             .performClick()
@@ -129,6 +130,31 @@ class GeneratedDifficultySelectionNavigationTest {
                 GeneratedModes.EIGHT_PAIRS_HARD.profile.id.value,
                 fixture.sessionRepository.session.value?.profileId
             )
+        }
+    }
+
+    @Test
+    fun menu_restores_independent_selections_and_primary_action_launches_them_directly() {
+        val difficultyRepository = FakeGeneratedDifficultySelectionRepository(
+            initialSelections = mapOf(
+                GeneratedModes.FOUR_PAIRS.id to DifficultyTier.MEDIUM,
+                GeneratedModes.EIGHT_PAIRS.id to DifficultyTier.HARD
+            )
+        )
+        val fixture = setContent(difficultyRepository = difficultyRepository)
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.EIGHT_PAIRS_BUTTON)
+            .assertTextEquals(challengeName(GeneratedModes.EIGHT_PAIRS_HARD))
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
+            .assertTextEquals(challengeName(GeneratedModes.FOUR_PAIRS_MEDIUM))
+            .performClick()
+
+        composeTestRule.onNodeWithTag(GameScreenTestTags.SCREEN).assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(listOf(GeneratedModes.FOUR_PAIRS_MEDIUM), fixture.generatedChallenges)
+            assertTrue(difficultyRepository.explicitSelections.isEmpty())
         }
     }
 
@@ -167,10 +193,14 @@ class GeneratedDifficultySelectionNavigationTest {
         }
     }
 
-    private fun setContent(initialSession: GeneratedSessionSnapshot? = null): NavigationFixture {
+    private fun setContent(
+        initialSession: GeneratedSessionSnapshot? = null,
+        difficultyRepository: FakeGeneratedDifficultySelectionRepository =
+            FakeGeneratedDifficultySelectionRepository()
+    ): NavigationFixture {
         val fixture = NavigationFixture(
             sessionRepository = FakeGeneratedSessionRepository(initialSession = initialSession),
-            difficultyRepository = FakeGeneratedDifficultySelectionRepository()
+            difficultyRepository = difficultyRepository
         )
         composeTestRule.setContent {
             NumPairsTheme {

--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceNavigationTest.kt
@@ -124,7 +124,7 @@ class GeneratedSessionChoiceNavigationTest {
             difficultyRepository = difficultyRepository
         )
 
-        composeTestRule.onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON).performClick()
+        composeTestRule.onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON).performClick()
         composeTestRule
             .onNodeWithTag(
                 GeneratedDifficultySelectorTestTags.option(
@@ -245,7 +245,7 @@ class GeneratedSessionChoiceNavigationTest {
             .onNodeWithTag(MenuScreenTestTags.SESSION_CHOICE_DIALOG)
             .assertDoesNotExist()
         composeTestRule
-            .onNodeWithTag(GeneratedDifficultySelectorTestTags.SCREEN)
+            .onNodeWithTag(MenuScreenTestTags.SCREEN)
             .assertIsDisplayed()
         composeTestRule.runOnIdle {
             assertTrue(recorder.generatedChallenges.isEmpty())

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/MenuRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/MenuRoute.kt
@@ -1,26 +1,76 @@
 package org.cescfe.numpairs.feature.menu
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import org.cescfe.numpairs.data.generated.selection.GeneratedDifficultySelectionRepository
+import org.cescfe.numpairs.feature.generated.GeneratedChallenge
+import org.cescfe.numpairs.feature.generated.GeneratedChallengeCatalog
+import org.cescfe.numpairs.feature.generated.GeneratedModeConfiguration
+import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.generated.localizedTitle
+import org.cescfe.numpairs.feature.menu.ui.GeneratedModeMenuUiState
 import org.cescfe.numpairs.feature.menu.ui.MenuScreen
 
 @Composable
 fun MenuRoute(
+    generatedDifficultySelectionRepository: GeneratedDifficultySelectionRepository,
+    generatedChallengeCatalog: GeneratedChallengeCatalog,
     modifier: Modifier = Modifier,
     resumeChallengeName: String? = null,
     onResumeSelected: () -> Unit = {},
     onTutorialSelected: () -> Unit = {},
     onPersonalizationSelected: () -> Unit = {},
-    onFourPairsSelected: () -> Unit = {},
-    onEightPairsSelected: () -> Unit = {}
+    onGeneratedChallengeSelected: (GeneratedChallenge) -> Unit = {},
+    onFourPairsDifficultySelected: () -> Unit = {},
+    onEightPairsDifficultySelected: () -> Unit = {}
 ) {
+    val fourPairsMode = generatedChallengeCatalog.resolve(GeneratedModes.FOUR_PAIRS.id)
+    val eightPairsMode = generatedChallengeCatalog.resolve(GeneratedModes.EIGHT_PAIRS.id)
+    val fourPairsChallenge = fourPairsMode.selectedChallenge(
+        repository = generatedDifficultySelectionRepository
+    ) ?: return
+    val eightPairsChallenge = eightPairsMode.selectedChallenge(
+        repository = generatedDifficultySelectionRepository
+    ) ?: return
+
     MenuScreen(
         modifier = modifier,
         resumeChallengeName = resumeChallengeName,
+        fourPairsMode = GeneratedModeMenuUiState(
+            modeName = fourPairsMode.localizedTitle(),
+            challengeName = fourPairsChallenge.localizedTitle(generatedChallengeCatalog)
+        ),
+        eightPairsMode = GeneratedModeMenuUiState(
+            modeName = eightPairsMode.localizedTitle(),
+            challengeName = eightPairsChallenge.localizedTitle(generatedChallengeCatalog)
+        ),
         onResumeSelected = onResumeSelected,
         onTutorialSelected = onTutorialSelected,
         onPersonalizationSelected = onPersonalizationSelected,
-        onFourPairsSelected = onFourPairsSelected,
-        onEightPairsSelected = onEightPairsSelected
+        onFourPairsSelected = {
+            onGeneratedChallengeSelected(fourPairsChallenge)
+        },
+        onEightPairsSelected = {
+            onGeneratedChallengeSelected(eightPairsChallenge)
+        },
+        onFourPairsDifficultySelected = onFourPairsDifficultySelected,
+        onEightPairsDifficultySelected = onEightPairsDifficultySelected
     )
+}
+
+@Composable
+private fun GeneratedModeConfiguration.selectedChallenge(
+    repository: GeneratedDifficultySelectionRepository
+): GeneratedChallenge? {
+    val selectedDifficultyFlow = remember(repository, id) {
+        repository.selectedDifficulty(modeId = id)
+    }
+    val selectedDifficulty by selectedDifficultyFlow.collectAsState(initial = null)
+
+    return selectedDifficulty?.let { difficulty ->
+        challenges.singleOrNull { challenge -> challenge.difficulty == difficulty }
+    }
 }

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,6 +17,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -23,10 +25,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -39,13 +43,17 @@ import org.cescfe.numpairs.ui.theme.NumPairsThemePreviewParameterProvider
 
 @Composable
 fun MenuScreen(
+    fourPairsMode: GeneratedModeMenuUiState,
+    eightPairsMode: GeneratedModeMenuUiState,
     modifier: Modifier = Modifier,
     resumeChallengeName: String? = null,
     onResumeSelected: () -> Unit = {},
     onTutorialSelected: () -> Unit = {},
     onPersonalizationSelected: () -> Unit = {},
     onFourPairsSelected: () -> Unit = {},
-    onEightPairsSelected: () -> Unit = {}
+    onEightPairsSelected: () -> Unit = {},
+    onFourPairsDifficultySelected: () -> Unit = {},
+    onEightPairsDifficultySelected: () -> Unit = {}
 ) {
     Scaffold(
         modifier = modifier
@@ -93,24 +101,20 @@ fun MenuScreen(
                             MenuButtonText(text = stringResource(R.string.menu_resume_button))
                         }
                     }
-                    NumPairsComponents.PrimaryCtaButton(
-                        onClick = onFourPairsSelected,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(NumPairsComponents.ButtonHeight)
-                            .testTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
-                    ) {
-                        MenuButtonText(text = stringResource(R.string.menu_four_pairs_button))
-                    }
-                    NumPairsComponents.PrimaryCtaButton(
-                        onClick = onEightPairsSelected,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(NumPairsComponents.ButtonHeight)
-                            .testTag(MenuScreenTestTags.EIGHT_PAIRS_BUTTON)
-                    ) {
-                        MenuButtonText(text = stringResource(R.string.menu_eight_pairs_button))
-                    }
+                    GeneratedModeMenuRow(
+                        state = fourPairsMode,
+                        onPlay = onFourPairsSelected,
+                        onChooseDifficulty = onFourPairsDifficultySelected,
+                        playTestTag = MenuScreenTestTags.FOUR_PAIRS_BUTTON,
+                        difficultyTestTag = MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON
+                    )
+                    GeneratedModeMenuRow(
+                        state = eightPairsMode,
+                        onPlay = onEightPairsSelected,
+                        onChooseDifficulty = onEightPairsDifficultySelected,
+                        playTestTag = MenuScreenTestTags.EIGHT_PAIRS_BUTTON,
+                        difficultyTestTag = MenuScreenTestTags.EIGHT_PAIRS_DIFFICULTY_BUTTON
+                    )
                     Button(
                         onClick = onTutorialSelected,
                         modifier = Modifier
@@ -137,6 +141,74 @@ fun MenuScreen(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun GeneratedModeMenuRow(
+    state: GeneratedModeMenuUiState,
+    onPlay: () -> Unit,
+    onChooseDifficulty: () -> Unit,
+    playTestTag: String,
+    difficultyTestTag: String
+) {
+    val playContentDescription = stringResource(
+        R.string.menu_play_generated_challenge_content_description,
+        state.challengeName
+    )
+    val chooseDifficultyContentDescription = stringResource(
+        R.string.menu_choose_generated_difficulty_content_description,
+        state.modeName
+    )
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(MENU_GENERATED_MODE_ACTION_SPACING)
+    ) {
+        NumPairsComponents.PrimaryCtaButton(
+            onClick = onPlay,
+            modifier = Modifier
+                .weight(1f)
+                .height(NumPairsComponents.ButtonHeight)
+                .semantics {
+                    contentDescription = playContentDescription
+                }
+                .testTag(playTestTag),
+            contentPadding = PaddingValues(
+                horizontal = MENU_GENERATED_MODE_BUTTON_HORIZONTAL_PADDING,
+                vertical = 0.dp
+            )
+        ) {
+            Text(
+                text = state.challengeName,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+                style = MaterialTheme.typography.labelLarge.copy(
+                    fontWeight = FontWeight.Bold,
+                    fontSize = MENU_GENERATED_MODE_BUTTON_TEXT_SIZE,
+                    lineHeight = MENU_GENERATED_MODE_BUTTON_TEXT_LINE_HEIGHT
+                )
+            )
+        }
+        Button(
+            onClick = onChooseDifficulty,
+            modifier = Modifier
+                .size(NumPairsComponents.ButtonHeight)
+                .semantics {
+                    contentDescription = chooseDifficultyContentDescription
+                }
+                .testTag(difficultyTestTag),
+            shape = NumPairsComponents.MediumShape,
+            colors = NumPairsComponents.secondaryButtonColors(),
+            border = NumPairsComponents.secondaryButtonBorder(),
+            contentPadding = PaddingValues(0.dp)
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_menu),
+                contentDescription = null,
+                modifier = Modifier.size(MENU_GENERATED_MODE_ICON_SIZE)
+            )
         }
     }
 }
@@ -172,13 +244,43 @@ private fun MenuButtonText(text: String) {
     )
 }
 
+data class GeneratedModeMenuUiState(val modeName: String, val challengeName: String) {
+    init {
+        require(modeName.isNotBlank()) {
+            "Generated mode Menu name must not be blank."
+        }
+        require(challengeName.isNotBlank()) {
+            "Generated challenge Menu name must not be blank."
+        }
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun MenuScreenPreview(
     @PreviewParameter(NumPairsThemePreviewParameterProvider::class) theme: PersonalizationTheme
 ) {
     NumPairsTheme(theme = theme) {
-        MenuScreen()
+        val fourPairsName = stringResource(R.string.four_pairs_screen_title)
+        val eightPairsName = stringResource(R.string.eight_pairs_screen_title)
+        MenuScreen(
+            fourPairsMode = GeneratedModeMenuUiState(
+                modeName = fourPairsName,
+                challengeName = stringResource(
+                    R.string.generated_challenge_title,
+                    fourPairsName,
+                    stringResource(R.string.generated_difficulty_low)
+                )
+            ),
+            eightPairsMode = GeneratedModeMenuUiState(
+                modeName = eightPairsName,
+                challengeName = stringResource(
+                    R.string.generated_challenge_title,
+                    eightPairsName,
+                    stringResource(R.string.generated_difficulty_medium)
+                )
+            )
+        )
     }
 }
 
@@ -186,3 +288,8 @@ private val MENU_CONTENT_MAX_WIDTH = 360.dp
 private val MENU_BRAND_MARK_SIZE = 32.dp
 private val MENU_BUTTON_TEXT_SIZE = 22.sp
 private val MENU_BUTTON_TEXT_LINE_HEIGHT = 36.sp
+private val MENU_GENERATED_MODE_BUTTON_TEXT_SIZE = 18.sp
+private val MENU_GENERATED_MODE_BUTTON_TEXT_LINE_HEIGHT = 24.sp
+private val MENU_GENERATED_MODE_BUTTON_HORIZONTAL_PADDING = 12.dp
+private val MENU_GENERATED_MODE_ACTION_SPACING = 8.dp
+private val MENU_GENERATED_MODE_ICON_SIZE = 24.dp

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTestTags.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTestTags.kt
@@ -7,6 +7,8 @@ object MenuScreenTestTags {
     const val PERSONALIZATION_BUTTON = "menu_personalization_button"
     const val FOUR_PAIRS_BUTTON = "menu_four_pairs_button"
     const val EIGHT_PAIRS_BUTTON = "menu_eight_pairs_button"
+    const val FOUR_PAIRS_DIFFICULTY_BUTTON = "menu_four_pairs_difficulty_button"
+    const val EIGHT_PAIRS_DIFFICULTY_BUTTON = "menu_eight_pairs_difficulty_button"
     const val SESSION_CHOICE_DIALOG = "generated_session_choice_dialog"
     const val SESSION_CHOICE_RESUME_BUTTON = "generated_session_choice_resume_button"
     const val SESSION_CHOICE_NEW_PUZZLE_BUTTON = "generated_session_choice_new_puzzle_button"

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -156,6 +156,8 @@ private fun UnlockedAppNavigation(
     when (val destination = currentDestination) {
         AppDestination.Menu -> {
             MenuRoute(
+                generatedDifficultySelectionRepository = generatedDifficultySelectionRepository,
+                generatedChallengeCatalog = generatedChallengeCatalog,
                 modifier = modifier,
                 resumeChallengeName = resumableSession?.challenge?.let { challenge ->
                     challenge.localizedTitle(generatedChallengeCatalog)
@@ -176,12 +178,13 @@ private fun UnlockedAppNavigation(
                 onPersonalizationSelected = {
                     currentDestination = AppDestination.Personalization
                 },
-                onFourPairsSelected = {
+                onGeneratedChallengeSelected = onGeneratedChallengeSelected,
+                onFourPairsDifficultySelected = {
                     currentDestination = AppDestination.GeneratedDifficultySelector(
                         modeId = GeneratedModes.FOUR_PAIRS.id
                     )
                 },
-                onEightPairsSelected = {
+                onEightPairsDifficultySelected = {
                     currentDestination = AppDestination.GeneratedDifficultySelector(
                         modeId = GeneratedModes.EIGHT_PAIRS.id
                     )

--- a/app/src/main/res/drawable/ic_menu.xml
+++ b/app/src/main/res/drawable/ic_menu.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M120,720v-80h720v80L120,720zM120,520v-80h720v80L120,520zM120,320v-80h720v80L120,320z" />
+</vector>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -10,6 +10,8 @@
     <string name="menu_personalization_button">Personalització</string>
     <string name="menu_four_pairs_button">Juga a 4 parelles</string>
     <string name="menu_eight_pairs_button">Juga a 8 parelles</string>
+    <string name="menu_play_generated_challenge_content_description">Juga al puzle de %1$s</string>
+    <string name="menu_choose_generated_difficulty_content_description">Tria la dificultat per a %1$s</string>
     <string name="generated_session_choice_title">Puzle sense acabar</string>
     <string name="generated_session_choice_challenge_message">Tens un puzle de %1$s sense acabar.</string>
     <string name="generated_session_choice_new_challenge_button">Puzle nou de %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -10,6 +10,8 @@
     <string name="menu_personalization_button">Personalización</string>
     <string name="menu_four_pairs_button">Jugar 4 pares</string>
     <string name="menu_eight_pairs_button">Jugar 8 pares</string>
+    <string name="menu_play_generated_challenge_content_description">Jugar puzle de %1$s</string>
+    <string name="menu_choose_generated_difficulty_content_description">Elegir dificultad para %1$s</string>
     <string name="generated_session_choice_title">Puzle sin terminar</string>
     <string name="generated_session_choice_challenge_message">Tienes un puzle de %1$s sin terminar.</string>
     <string name="generated_session_choice_new_challenge_button">Nuevo puzle de %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="menu_personalization_button">Personalization</string>
     <string name="menu_four_pairs_button">Play 4 pairs</string>
     <string name="menu_eight_pairs_button">Play 8 pairs</string>
+    <string name="menu_play_generated_challenge_content_description">Play %1$s puzzle</string>
+    <string name="menu_choose_generated_difficulty_content_description">Choose difficulty for %1$s</string>
     <string name="generated_session_choice_title">Unfinished puzzle</string>
     <string name="generated_session_choice_challenge_message">You have an unfinished %1$s puzzle.</string>
     <string name="generated_session_choice_new_challenge_button">New %1$s</string>


### PR DESCRIPTION
## Related Issue

Resolves #568

## Summary

- Show each generated mode with its resolved default or remembered difficulty in Menu.
- Launch the exact selected challenge from the primary CTA while preserving resume-or-replace safety.
- Add a square secondary difficulty action that keeps the existing selector available for the dependent inline-popup delivery.
- Add focused layout, accessibility, navigation, and restored-selection coverage.

## UI Consistency

- Shared components or tokens reused: `NumPairsComponents.PrimaryCtaButton`, `ButtonHeight`, `MediumShape`, secondary button colors, and secondary border.
- Intentional deviations from established visual roles: none; the supplied menu icon is rendered inside the established secondary CTA role.