### PR TITLE
[275] Unify generated mode actions as split primary CTAs

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTest.kt
@@ -10,10 +10,13 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
@@ -21,17 +24,23 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.test.espresso.Espresso.pressBackUnconditionally
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.cescfe.numpairs.R
+import org.cescfe.numpairs.ui.theme.NumPairsComponents
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -65,9 +74,11 @@ class MenuScreenTest {
                     fourPairsState.challengeName
                 )
             )
+            .assertHasClickAction()
             .performClick()
         composeTestRule
             .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON)
+            .assertHasClickAction()
             .performClick()
         composeTestRule
             .onNodeWithTag(MenuScreenTestTags.difficultyOption(fourPairsMediumId))
@@ -112,7 +123,7 @@ class MenuScreenTest {
     }
 
     @Test
-    fun selector_action_switches_between_menu_and_close_states() {
+    fun selector_action_switches_between_collapsed_and_expanded_arrow_states() {
         setContent()
         val action = composeTestRule
             .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON)
@@ -161,6 +172,14 @@ class MenuScreenTest {
     fun compact_width_and_increased_text_scale_keep_selector_inside_the_screen() {
         setContent(width = 320.dp, height = 640.dp, fontScale = 2f)
 
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.EIGHT_PAIRS_BUTTON)
+            .assertContentDescriptionEquals(
+                string(
+                    R.string.menu_play_generated_challenge_content_description,
+                    eightPairsState.challengeName
+                )
+            )
         composeTestRule
             .onNodeWithTag(MenuScreenTestTags.EIGHT_PAIRS_DIFFICULTY_BUTTON)
             .performScrollTo()
@@ -236,27 +255,75 @@ class MenuScreenTest {
     }
 
     @Test
-    fun difficulty_actions_are_square_and_match_the_primary_action_height() {
+    fun generated_mode_split_ctas_match_full_width_buttons_and_keep_distinct_touch_regions() {
         setContent()
 
+        val tutorialBounds = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.TUTORIAL_BUTTON)
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val dividerWidth = with(composeTestRule.density) {
+            NumPairsComponents.ThinBorderWidth.toPx()
+        }
+        val minimumTouchTargetWidth = with(composeTestRule.density) {
+            48.dp.toPx()
+        }
         listOf(
-            MenuScreenTestTags.FOUR_PAIRS_BUTTON to MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON,
-            MenuScreenTestTags.EIGHT_PAIRS_BUTTON to MenuScreenTestTags.EIGHT_PAIRS_DIFFICULTY_BUTTON
-        ).forEach { (playTag, difficultyTag) ->
+            Triple(
+                MenuScreenTestTags.FOUR_PAIRS_SPLIT_CTA,
+                MenuScreenTestTags.FOUR_PAIRS_BUTTON,
+                MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON
+            ),
+            Triple(
+                MenuScreenTestTags.EIGHT_PAIRS_SPLIT_CTA,
+                MenuScreenTestTags.EIGHT_PAIRS_BUTTON,
+                MenuScreenTestTags.EIGHT_PAIRS_DIFFICULTY_BUTTON
+            )
+        ).forEach { (containerTag, playTag, difficultyTag) ->
+            val containerBounds = composeTestRule
+                .onNodeWithTag(containerTag)
+                .assertIsDisplayed()
+                .assertHasNoClickAction()
+                .fetchSemanticsNode()
+                .boundsInRoot
             val playBounds = composeTestRule
                 .onNodeWithTag(playTag)
                 .assertIsDisplayed()
+                .assertHasClickAction()
                 .fetchSemanticsNode()
                 .boundsInRoot
             val difficultyBounds = composeTestRule
                 .onNodeWithTag(difficultyTag)
                 .assertIsDisplayed()
+                .assertHasClickAction()
                 .fetchSemanticsNode()
                 .boundsInRoot
 
-            assertEquals(playBounds.height, difficultyBounds.height, 0.5f)
+            assertEquals(tutorialBounds.left, containerBounds.left, 0.5f)
+            assertEquals(tutorialBounds.right, containerBounds.right, 0.5f)
+            assertEquals(tutorialBounds.height, containerBounds.height, 0.5f)
+            assertEquals(containerBounds.left, playBounds.left, 0.5f)
+            assertEquals(containerBounds.right, difficultyBounds.right, 0.5f)
+            assertEquals(containerBounds.height, playBounds.height, 0.5f)
+            assertEquals(containerBounds.height, difficultyBounds.height, 0.5f)
             assertEquals(difficultyBounds.width, difficultyBounds.height, 0.5f)
-            assertTrue(playBounds.right < difficultyBounds.left)
+            assertEquals(dividerWidth, difficultyBounds.left - playBounds.right, 0.5f)
+            assertTrue(difficultyBounds.width >= minimumTouchTargetWidth)
+        }
+    }
+
+    @Test
+    fun generated_mode_labels_match_the_other_menu_button_typography() {
+        setContent()
+
+        val tutorialStyle = textStyle(string(R.string.menu_tutorial_button))
+        assertEquals(22.sp, tutorialStyle.fontSize)
+        listOf(fourPairsState.challengeName, eightPairsState.challengeName).forEach { challengeName ->
+            val challengeStyle = textStyle(challengeName)
+
+            assertEquals(tutorialStyle.fontSize, challengeStyle.fontSize)
+            assertEquals(tutorialStyle.fontWeight, challengeStyle.fontWeight)
         }
     }
 
@@ -338,6 +405,17 @@ class MenuScreenTest {
 
     private fun string(stringResId: Int, vararg formatArgs: Any): String =
         composeTestRule.activity.getString(stringResId, *formatArgs)
+
+    private fun textStyle(text: String): TextStyle {
+        val layoutResults = mutableListOf<TextLayoutResult>()
+        composeTestRule
+            .onNodeWithText(text = text, useUnmergedTree = true)
+            .performSemanticsAction(SemanticsActions.GetTextLayoutResult) { action ->
+                action(layoutResults)
+            }
+
+        return layoutResults.single().layoutInput.style
+    }
 
     private companion object {
         val fourPairsLowId = GeneratedDifficultyMenuOptionId("four-pairs-low")

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreen.kt
@@ -132,6 +132,7 @@ fun MenuScreen(
                             expandedDifficultyMenu = null
                         },
                         onDifficultySelected = onFourPairsDifficultySelected,
+                        containerTestTag = MenuScreenTestTags.FOUR_PAIRS_SPLIT_CTA,
                         playTestTag = MenuScreenTestTags.FOUR_PAIRS_BUTTON,
                         difficultyTestTag = MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON,
                         difficultyMenuTestTag = MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_MENU
@@ -149,6 +150,7 @@ fun MenuScreen(
                             expandedDifficultyMenu = null
                         },
                         onDifficultySelected = onEightPairsDifficultySelected,
+                        containerTestTag = MenuScreenTestTags.EIGHT_PAIRS_SPLIT_CTA,
                         playTestTag = MenuScreenTestTags.EIGHT_PAIRS_BUTTON,
                         difficultyTestTag = MenuScreenTestTags.EIGHT_PAIRS_DIFFICULTY_BUTTON,
                         difficultyMenuTestTag = MenuScreenTestTags.EIGHT_PAIRS_DIFFICULTY_MENU
@@ -191,6 +193,7 @@ private fun GeneratedModeMenuRow(
     onToggleDifficultyMenu: () -> Unit,
     onDismissDifficultyMenu: () -> Unit,
     onDifficultySelected: (GeneratedDifficultyMenuOptionId) -> Unit,
+    containerTestTag: String,
     playTestTag: String,
     difficultyTestTag: String,
     difficultyMenuTestTag: String
@@ -215,64 +218,47 @@ private fun GeneratedModeMenuRow(
         }
     )
 
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(MENU_GENERATED_MODE_ACTION_SPACING)
-    ) {
-        NumPairsComponents.PrimaryCtaButton(
-            onClick = onPlay,
-            modifier = Modifier
-                .weight(1f)
-                .height(NumPairsComponents.ButtonHeight)
-                .semantics {
-                    contentDescription = playContentDescription
-                }
-                .testTag(playTestTag),
-            contentPadding = PaddingValues(
-                horizontal = MENU_GENERATED_MODE_BUTTON_HORIZONTAL_PADDING,
-                vertical = 0.dp
-            )
-        ) {
-            Text(
+    NumPairsComponents.PrimarySplitCtaButton(
+        onPrimaryClick = onPlay,
+        onSecondaryClick = onToggleDifficultyMenu,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(NumPairsComponents.ButtonHeight)
+            .testTag(containerTestTag),
+        primaryActionModifier = Modifier
+            .semantics {
+                contentDescription = playContentDescription
+            }
+            .testTag(playTestTag),
+        secondaryActionModifier = Modifier
+            .semantics {
+                contentDescription = difficultyActionContentDescription
+                stateDescription = difficultyActionStateDescription
+            }
+            .testTag(difficultyTestTag),
+        primaryContentPadding = PaddingValues(
+            horizontal = MENU_GENERATED_MODE_BUTTON_HORIZONTAL_PADDING,
+            vertical = 0.dp
+        ),
+        primaryContent = {
+            MenuButtonText(
                 text = state.challengeName,
                 overflow = TextOverflow.Ellipsis,
-                maxLines = 1,
-                style = MaterialTheme.typography.labelLarge.copy(
-                    fontWeight = FontWeight.Bold,
-                    fontSize = MENU_GENERATED_MODE_BUTTON_TEXT_SIZE,
-                    lineHeight = MENU_GENERATED_MODE_BUTTON_TEXT_LINE_HEIGHT
-                )
+                maxLines = 1
             )
-        }
-        Box(
-            modifier = Modifier.size(NumPairsComponents.ButtonHeight)
-        ) {
-            Button(
-                onClick = onToggleDifficultyMenu,
-                modifier = Modifier
-                    .size(NumPairsComponents.ButtonHeight)
-                    .semantics {
-                        contentDescription = difficultyActionContentDescription
-                        stateDescription = difficultyActionStateDescription
+        },
+        secondaryContent = {
+            Icon(
+                painter = painterResource(
+                    if (expanded) {
+                        R.drawable.ic_arrow_up
+                    } else {
+                        R.drawable.ic_arrow_down
                     }
-                    .testTag(difficultyTestTag),
-                shape = NumPairsComponents.MediumShape,
-                colors = NumPairsComponents.secondaryButtonColors(),
-                border = NumPairsComponents.secondaryButtonBorder(),
-                contentPadding = PaddingValues(0.dp)
-            ) {
-                Icon(
-                    painter = painterResource(
-                        if (expanded) {
-                            R.drawable.ic_close_big
-                        } else {
-                            R.drawable.ic_menu
-                        }
-                    ),
-                    contentDescription = null,
-                    modifier = Modifier.size(MENU_GENERATED_MODE_ICON_SIZE)
-                )
-            }
+                ),
+                contentDescription = null,
+                modifier = Modifier.size(MENU_GENERATED_MODE_ICON_SIZE)
+            )
             GeneratedDifficultyMenu(
                 state = state,
                 expanded = expanded,
@@ -284,7 +270,7 @@ private fun GeneratedModeMenuRow(
                 testTag = difficultyMenuTestTag
             )
         }
-    }
+    )
 }
 
 @Composable
@@ -374,9 +360,11 @@ private fun MenuScreenTopBar() {
 }
 
 @Composable
-private fun MenuButtonText(text: String) {
+private fun MenuButtonText(text: String, overflow: TextOverflow = TextOverflow.Clip, maxLines: Int = Int.MAX_VALUE) {
     Text(
         text = text,
+        overflow = overflow,
+        maxLines = maxLines,
         style = MaterialTheme.typography.labelLarge.copy(
             fontWeight = FontWeight.Bold,
             fontSize = MENU_BUTTON_TEXT_SIZE,
@@ -448,10 +436,7 @@ private val MENU_CONTENT_MAX_WIDTH = 360.dp
 private val MENU_BRAND_MARK_SIZE = 32.dp
 private val MENU_BUTTON_TEXT_SIZE = 22.sp
 private val MENU_BUTTON_TEXT_LINE_HEIGHT = 36.sp
-private val MENU_GENERATED_MODE_BUTTON_TEXT_SIZE = 18.sp
-private val MENU_GENERATED_MODE_BUTTON_TEXT_LINE_HEIGHT = 24.sp
 private val MENU_GENERATED_MODE_BUTTON_HORIZONTAL_PADDING = 12.dp
-private val MENU_GENERATED_MODE_ACTION_SPACING = 8.dp
 private val MENU_GENERATED_MODE_ICON_SIZE = 24.dp
 private val MENU_GENERATED_DIFFICULTY_MENU_WIDTH = 200.dp
 private val MENU_GENERATED_DIFFICULTY_MENU_END_ALIGNMENT_OFFSET =

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTestTags.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTestTags.kt
@@ -5,6 +5,8 @@ object MenuScreenTestTags {
     const val RESUME_BUTTON = "menu_resume_button"
     const val TUTORIAL_BUTTON = "menu_tutorial_button"
     const val PERSONALIZATION_BUTTON = "menu_personalization_button"
+    const val FOUR_PAIRS_SPLIT_CTA = "menu_four_pairs_split_cta"
+    const val EIGHT_PAIRS_SPLIT_CTA = "menu_eight_pairs_split_cta"
     const val FOUR_PAIRS_BUTTON = "menu_four_pairs_button"
     const val EIGHT_PAIRS_BUTTON = "menu_eight_pairs_button"
     const val FOUR_PAIRS_DIFFICULTY_BUTTON = "menu_four_pairs_difficulty_button"

--- a/app/src/main/java/org/cescfe/numpairs/ui/theme/NumPairsComponents.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/theme/NumPairsComponents.kt
@@ -2,10 +2,16 @@ package org.cescfe.numpairs.ui.theme
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
@@ -65,40 +71,7 @@ object NumPairsComponents {
         content: @Composable () -> Unit
     ) {
         val shape = MediumShape
-        val background = if (enabled) {
-            Brush.verticalGradient(
-                colors = listOf(
-                    lerp(
-                        MaterialTheme.colorScheme.primary,
-                        MaterialTheme.colorScheme.onPrimaryContainer,
-                        PRIMARY_BUTTON_TOP_TINT
-                    ),
-                    MaterialTheme.colorScheme.primary,
-                    lerp(
-                        MaterialTheme.colorScheme.primary,
-                        MaterialTheme.colorScheme.primaryContainer,
-                        PRIMARY_BUTTON_BOTTOM_SHADE
-                    )
-                )
-            )
-        } else {
-            Brush.verticalGradient(
-                colors = listOf(
-                    MaterialTheme.colorScheme.surfaceVariant,
-                    MaterialTheme.colorScheme.surfaceVariant
-                )
-            )
-        }
-        val contentColor = if (enabled) {
-            MaterialTheme.colorScheme.onPrimary
-        } else {
-            MaterialTheme.colorScheme.onSurfaceVariant
-        }
-        val borderColor = if (enabled) {
-            MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = PRIMARY_BUTTON_BORDER_ALPHA)
-        } else {
-            MaterialTheme.colorScheme.outlineVariant
-        }
+        val visuals = primaryCtaVisuals(enabled)
 
         Surface(
             onClick = onClick,
@@ -109,40 +82,97 @@ object NumPairsComponents {
             enabled = enabled,
             shape = shape,
             color = Color.Transparent,
-            contentColor = contentColor,
+            contentColor = visuals.contentColor,
             border = BorderStroke(
                 width = ThinBorderWidth,
-                color = borderColor
+                color = visuals.borderColor
             ),
             shadowElevation = if (enabled) PRIMARY_BUTTON_SHADOW_ELEVATION else 0.dp
         ) {
-            Box(
-                modifier = Modifier.background(background, shape),
-                contentAlignment = Alignment.Center
+            PrimaryCtaBackground(
+                background = visuals.background,
+                shape = shape,
+                enabled = enabled
             ) {
-                if (enabled) {
-                    Box(
-                        modifier = Modifier
-                            .align(Alignment.TopCenter)
-                            .matchParentSize()
-                            .background(
-                                Brush.verticalGradient(
-                                    colors = listOf(
-                                        MaterialTheme.colorScheme.onPrimaryContainer.copy(
-                                            alpha = PRIMARY_BUTTON_INNER_HIGHLIGHT_ALPHA
-                                        ),
-                                        Color.Transparent
-                                    )
-                                ),
-                                shape
-                            )
-                    )
-                }
                 Box(
                     modifier = Modifier.padding(contentPadding),
                     contentAlignment = Alignment.Center
                 ) {
                     content()
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun PrimarySplitCtaButton(
+        onPrimaryClick: () -> Unit,
+        onSecondaryClick: () -> Unit,
+        modifier: Modifier = Modifier,
+        primaryActionModifier: Modifier = Modifier,
+        secondaryActionModifier: Modifier = Modifier,
+        enabled: Boolean = true,
+        primaryContentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+        primaryContent: @Composable BoxScope.() -> Unit,
+        secondaryContent: @Composable BoxScope.() -> Unit
+    ) {
+        val shape = MediumShape
+        val visuals = primaryCtaVisuals(enabled)
+
+        Surface(
+            modifier = modifier.defaultMinSize(
+                minWidth = ButtonDefaults.MinWidth,
+                minHeight = ButtonDefaults.MinHeight
+            ),
+            shape = shape,
+            color = Color.Transparent,
+            contentColor = visuals.contentColor,
+            border = BorderStroke(
+                width = ThinBorderWidth,
+                color = visuals.borderColor
+            ),
+            shadowElevation = if (enabled) PRIMARY_BUTTON_SHADOW_ELEVATION else 0.dp
+        ) {
+            PrimaryCtaBackground(
+                background = visuals.background,
+                shape = shape,
+                enabled = enabled,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                Row(modifier = Modifier.fillMaxSize()) {
+                    Box(
+                        modifier = primaryActionModifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .clickable(
+                                enabled = enabled,
+                                role = Role.Button,
+                                onClick = onPrimaryClick
+                            ).padding(primaryContentPadding),
+                        contentAlignment = Alignment.Center,
+                        content = primaryContent
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .padding(vertical = PRIMARY_SPLIT_DIVIDER_VERTICAL_INSET)
+                            .width(ThinBorderWidth)
+                            .background(
+                                visuals.contentColor.copy(alpha = PRIMARY_SPLIT_DIVIDER_ALPHA)
+                            )
+                    )
+                    Box(
+                        modifier = secondaryActionModifier
+                            .width(ButtonHeight)
+                            .fillMaxHeight()
+                            .clickable(
+                                enabled = enabled,
+                                role = Role.Button,
+                                onClick = onSecondaryClick
+                            ),
+                        contentAlignment = Alignment.Center,
+                        content = secondaryContent
+                    )
                 }
             }
         }
@@ -216,9 +246,91 @@ object NumPairsComponents {
         actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant
     )
 
+    @Composable
+    private fun primaryCtaVisuals(enabled: Boolean): PrimaryCtaVisuals {
+        val background = if (enabled) {
+            Brush.verticalGradient(
+                colors = listOf(
+                    lerp(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.colorScheme.onPrimaryContainer,
+                        PRIMARY_BUTTON_TOP_TINT
+                    ),
+                    MaterialTheme.colorScheme.primary,
+                    lerp(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.colorScheme.primaryContainer,
+                        PRIMARY_BUTTON_BOTTOM_SHADE
+                    )
+                )
+            )
+        } else {
+            Brush.verticalGradient(
+                colors = listOf(
+                    MaterialTheme.colorScheme.surfaceVariant,
+                    MaterialTheme.colorScheme.surfaceVariant
+                )
+            )
+        }
+        val contentColor = if (enabled) {
+            MaterialTheme.colorScheme.onPrimary
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        }
+        val borderColor = if (enabled) {
+            MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = PRIMARY_BUTTON_BORDER_ALPHA)
+        } else {
+            MaterialTheme.colorScheme.outlineVariant
+        }
+
+        return PrimaryCtaVisuals(
+            background = background,
+            contentColor = contentColor,
+            borderColor = borderColor
+        )
+    }
+
+    @Composable
+    private fun PrimaryCtaBackground(
+        background: Brush,
+        shape: Shape,
+        enabled: Boolean,
+        modifier: Modifier = Modifier,
+        content: @Composable BoxScope.() -> Unit
+    ) {
+        Box(
+            modifier = modifier.background(background, shape),
+            contentAlignment = Alignment.Center
+        ) {
+            if (enabled) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .matchParentSize()
+                        .background(
+                            Brush.verticalGradient(
+                                colors = listOf(
+                                    MaterialTheme.colorScheme.onPrimaryContainer.copy(
+                                        alpha = PRIMARY_BUTTON_INNER_HIGHLIGHT_ALPHA
+                                    ),
+                                    Color.Transparent
+                                )
+                            ),
+                            shape
+                        )
+                )
+            }
+            content()
+        }
+    }
+
+    private data class PrimaryCtaVisuals(val background: Brush, val contentColor: Color, val borderColor: Color)
+
     private val PRIMARY_BUTTON_SHADOW_ELEVATION = 2.dp
+    private val PRIMARY_SPLIT_DIVIDER_VERTICAL_INSET = 12.dp
     private const val PRIMARY_BUTTON_TOP_TINT = 0.10f
     private const val PRIMARY_BUTTON_BOTTOM_SHADE = 0.10f
     private const val PRIMARY_BUTTON_BORDER_ALPHA = 0.28f
     private const val PRIMARY_BUTTON_INNER_HIGHLIGHT_ALPHA = 0.18f
+    private const val PRIMARY_SPLIT_DIVIDER_ALPHA = 0.42f
 }

--- a/app/src/main/res/drawable/ic_arrow_down.xml
+++ b/app/src/main/res/drawable/ic_arrow_down.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="960">
     <path
         android:fillColor="@android:color/white"
-        android:pathData="M120,720v-80h720v80L120,720zM120,520v-80h720v80L120,520zM120,320v-80h720v80L120,320z" />
+        android:pathData="M480,616L240,376l56,-56 184,184 184,-184 56,56 -240,240Z" />
 </vector>

--- a/app/src/main/res/drawable/ic_arrow_up.xml
+++ b/app/src/main/res/drawable/ic_arrow_up.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="960">
     <path
         android:fillColor="@android:color/white"
-        android:pathData="M256,760l-56,-56 224,-224 -224,-224 56,-56 224,224 224,-224 56,56 -224,224 224,224 -56,56 -224,-224 -224,224z" />
+        android:pathData="M480,432L296,616l-56,-56 240,-240 240,240 -56,56 -184,-184Z" />
 </vector>

--- a/docs/product/prd/prd-v8.md
+++ b/docs/product/prd/prd-v8.md
@@ -175,22 +175,26 @@ cells are absent from selection rather than displayed as locked or unavailable c
 
 ### Mode And Difficulty Selection
 
-- Present one split action row for `4 Pairs` and one for `8 Pairs` in the normal menu.
-- The primary action identifies the current mode and difficulty and starts that challenge directly.
-- On first use, the primary actions resolve to `4 Pairs Low` and `8 Pairs Medium`.
-- On later use, each primary action resolves to the last supported difficulty selected for that
+- Present one full-width split primary CTA for `4 Pairs` and one for `8 Pairs` in the normal menu.
+- The play region identifies the current mode and difficulty and starts that challenge directly.
+- On first use, the play regions resolve to `4 Pairs Low` and `8 Pairs Medium`.
+- On later use, each play region resolves to the last supported difficulty selected for that
   mode.
-- A square secondary action beside each primary action opens that mode's anchored difficulty menu
-  without leaving the normal menu.
+- A trailing difficulty region within the same primary CTA opens that mode's anchored difficulty
+  menu without leaving the normal menu.
+- The two regions have independent touch and accessibility actions, no visual gap, and a themed
+  vertical divider. The trailing region preserves the established minimum touch target.
+- Generated challenge labels use the same typography and weight as the other normal-menu button
+  labels rather than a smaller adaptive treatment.
 - The `4 Pairs` menu shows exactly `Low` and `Medium`.
 - The `8 Pairs` menu shows exactly `Medium` and `Hard`.
 - Every shown difficulty is enabled; the menu has no locks or progression indicators.
 - The current selection is communicated without relying only on color.
-- The popup's logical end edge aligns with the secondary action's logical end edge so the popup
+- The popup's logical end edge aligns with the difficulty region's logical end edge so the popup
   expands inward and remains inside the menu content bounds.
-- Opening one difficulty menu closes any other. Its trigger changes from the menu icon to the large
-  close icon while expanded.
-- Choosing an option, tapping outside, pressing system back, or using the close action dismisses
+- Opening one difficulty menu closes any other. Its trigger changes from the supplied down arrow
+  to the supplied up arrow while expanded.
+- Choosing an option, tapping outside, pressing system back, or using the expanded trigger dismisses
   the popup without starting a puzzle.
 
 ### Remembered Selection
@@ -309,8 +313,8 @@ characterization; v8 must not invent unevidenced score thresholds before the eva
 
 ### Difficulty Selection Surface
 
-- Add reusable, state-driven Compose content for each generated mode's split menu action and
-  anchored single-choice popup.
+- Add reusable, state-driven Compose content for each generated mode's unified split primary CTA
+  and anchored single-choice popup.
 - Keep domain rules, persistence, generation, and navigation out of the content Composable.
 - Reuse established NumPairs components, tokens, typography, shapes, spacing, and semantic roles.
 - Preserve minimum touch targets, readable text scaling, and non-color selection cues.
@@ -319,9 +323,9 @@ characterization; v8 must not invent unevidenced score thresholds before the eva
 
 ### End-To-End Challenge Integration
 
-- Route each generated-mode primary menu action directly through its effective remembered
+- Route each generated-mode play region directly through its effective remembered
   challenge.
-- Persist changes from the associated secondary difficulty popup without starting generated play.
+- Persist changes from the associated trailing difficulty popup without starting generated play.
 - Generate the actively selected supported challenge.
 - Preserve selected challenge identity through loading, failure, safe replacement, restoration, and
   replay.
@@ -377,8 +381,8 @@ choice independently.
 Work:
 
 1. Add the local mode-specific selection repository and safe fallbacks.
-2. Add reusable generated-mode split actions and anchored difficulty menus.
-3. Route each primary action directly through the selected challenge.
+2. Add reusable generated-mode split primary CTAs and anchored difficulty menus.
+3. Route each play region directly through the selected challenge.
 
 ### Stage 5 - End-To-End Quality And Product Alignment
 

--- a/docs/technical/generated-session-persistence.md
+++ b/docs/technical/generated-session-persistence.md
@@ -40,7 +40,7 @@ unknown, and no-longer-supported stored values resolve to that fallback without 
 The only operation that writes a remembered selection is an explicit supported option choice made
 by the player in that mode's anchored difficulty popup in the normal menu.
 
-Opening or dismissing the popup, showing a fallback, pressing a mode's primary action, resuming or
+Opening or dismissing the popup, showing a fallback, pressing a mode's play region, resuming or
 restoring a session, replacing a session, completing a puzzle, and using `Play another` do not
 write this preference. The two mode values remain independent, and neither completion nor any
 other v8 behavior stores progression, locks, completion counts, rewards, or statistics.

--- a/docs/ui-behavior.md
+++ b/docs/ui-behavior.md
@@ -65,29 +65,34 @@ In this document, strip items are rendered as chips.
 The unlocked normal menu renders actions in this order:
 
 1. `Resume`, only while one valid unfinished generated session is available
-2. the `4 Pairs · <difficulty>` primary action and its square difficulty action
-3. the `8 Pairs · <difficulty>` primary action and its square difficulty action
+2. the unified `4 Pairs · <difficulty>` split primary CTA
+3. the unified `8 Pairs · <difficulty>` split primary CTA
 4. `How to play`
 5. `Personalization`
 
-`Resume` and both generated-mode primary actions use the primary CTA treatment. Each mode's
-square difficulty action, `How to play`, and `Personalization` use the lower-emphasis secondary
-treatment. The localized `Resume` accessibility description identifies the saved mode and
-difficulty, for example `Resume 4 Pairs · Medium puzzle`.
+`Resume` and both generated-mode split actions use the full-width primary CTA treatment. Each
+generated-mode CTA contains an expanding play region and a trailing difficulty region with no
+visual gap. A themed vertical divider distinguishes the two touch actions. `How to play` and
+`Personalization` use the lower-emphasis secondary treatment. The localized `Resume`
+accessibility description identifies the saved mode and difficulty, for example
+`Resume 4 Pairs · Medium puzzle`.
 
 The application derives menu resumability from the one global generated-session slot. Missing, solved, unknown-mode, mode/profile-mismatched, corrupt, and unsupported snapshots do not expose `Resume`.
 
 Selecting `Resume` opens the saved mode and exact current puzzle without generation.
 
-Selecting a generated-mode primary action starts its displayed challenge immediately. The
-displayed challenge uses the mode-specific fallback on first use and the last supported
-difficulty the player selected for that mode thereafter.
+Selecting a generated-mode play region starts its displayed challenge immediately. The displayed
+challenge uses the mode-specific fallback on first use and the last supported difficulty the
+player selected for that mode thereafter. Its visible label uses the same typography and weight
+as the other normal-menu button labels. Compact or increased-font layouts may ellipsize visible
+text while preserving the full localized challenge in accessibility semantics.
 
 ### Difficulty Selector
 
-The square secondary action beside each generated-mode primary action opens an anchored
-single-choice popup without leaving the normal menu. Its icon changes from the supplied menu icon
-to the supplied large close icon while expanded. At most one mode popup is open.
+The trailing difficulty region inside each generated-mode split primary CTA opens an anchored
+single-choice popup without leaving the normal menu. It retains the established minimum touch
+target and changes from the supplied down arrow to the supplied up arrow while expanded. The play
+and difficulty regions remain distinct button semantics, and at most one mode popup is open.
 
 The popup shows only challenges present in the supported generated-challenge catalog:
 
@@ -105,23 +110,23 @@ unsupported stored value is presented using `Low` for `4 Pairs` and `Medium` for
 rewriting storage.
 
 Tapping a supported difficulty makes it the current option and immediately persists that explicit
-choice for the selected mode. It updates the associated primary action and closes the popup without
+choice for the selected mode. It updates the associated play region and closes the popup without
 starting a puzzle. Merely opening or dismissing the popup or displaying a fallback does not write a
-preference. Tapping outside, pressing system back, or activating the square close action dismisses
-the popup without changing the generated-session slot.
+preference. Tapping outside, pressing system back, or activating the expanded difficulty region
+dismisses the popup without changing the generated-session slot.
 
-The popup's logical end edge aligns with the square trigger's logical end edge and expands inward,
-so it remains inside the menu content bounds on compact and wide layouts. The alignment follows
-layout direction rather than assuming a physical right edge.
+The popup's logical end edge aligns with the trailing difficulty region's logical end edge and
+expands inward, so it remains inside the menu content bounds on compact and wide layouts. The
+alignment follows layout direction rather than assuming a physical right edge.
 
-The generated-mode primary action identifies the exact requested challenge, for example
+The generated-mode play region identifies the exact requested challenge, for example
 `4 Pairs · Medium`. Activating it starts the existing resume-or-replace routing for that challenge.
 Difficulty is fixed once play begins; generated gameplay and completion do not expose a
 change-difficulty action.
 
 ### Resume Or Replace
 
-Activating a generated-mode primary action while a resumable session exists opens the same modal
+Activating a generated-mode play region while a resumable session exists opens the same modal
 choice:
 
 - primary: `Resume`


### PR DESCRIPTION
## Related Issue

Resolves #572

## Summary

- Present each generated mode as one full-width split primary CTA with independent play and difficulty actions.
- Match generated challenge labels to the established 22sp Menu typography and preserve full accessibility copy when labels ellipsize.
- Replace the separate menu/close controls with the supplied down/up arrows and a themed vertical divider while preserving popup alignment and behavior.
- Align the v8 PRD, UI behavior, and persistence wording and add focused Compose coverage.

## UI Consistency

- Shared components or tokens reused: extends `NumPairsComponents` with `PrimarySplitCtaButton`, sharing the exact primary CTA gradient, border, elevation, content colors, `MediumShape`, and `ButtonHeight`; the Menu reuses its existing 22sp label style and anchored popup styling.
- Intentional deviations from established visual roles: none. The shared split role adds a 1dp themed divider and a 52dp trailing action; the existing direct Material 3 `DropdownMenu` configuration is unchanged.