### PR TITLE
[279] Record the Daily Challenge identity and persistence architecture

### DIFF
--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -14,6 +14,8 @@
   - `docs/product/prd/prd-v10.md`
   - `docs/technical/generated-session-persistence.md`
   - `docs/technical/adr/adr-005-model-sparse-generated-challenges.md`
+  - `docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md`
+  - `docs/technical/daily-challenge-persistence.md`
   - `docs/game-rules.md`
   - `docs/ubiquitous-language.md`
 
@@ -170,6 +172,38 @@ profile, and seed metadata. Mode/profile identity resolves the exact challenge. 
 restoration reads that snapshot directly; it never regenerates historical content from the seed.
 
 Committed puzzle changes update the current snapshot through the stable session id, solved puzzles clear resumability, and stale callbacks cannot mutate a replacement. Generation, storage failure, or cancellation leaves the previous unfinished slot intact. See `docs/technical/generated-session-persistence.md` for the storage, ordering, validation, and backup contract.
+
+## Daily Recipe Generation Boundary
+
+The v10 Daily Challenge reuses the existing generated-puzzle pipeline without making the generator
+aware of dates, calendars, completion history, Android clocks, or presentation state.
+
+One immutable Daily Recipe version:
+
+- resolves the existing `4 Pairs Low` generated challenge
+- combines its recipe version and one canonical local date into Daily Challenge identity
+- maps that identity plus a zero-based candidate index to one stable signed 32-bit seed
+- supplies one positive fixed candidate limit
+- attempts candidate indexes in ascending order
+
+Each candidate is an ordinary explicit `GeneratedPuzzleGenerationRequest` for the recipe profile.
+The first generated and validated outcome becomes the exact Daily puzzle. Attempts exhausted,
+search budget exhausted, assessment work limit, and cancellation remain typed candidate outcomes.
+Daily coordination never substitutes device randomness, another difficulty, or a different
+challenge.
+
+The recipe payload format, algorithm, challenge, candidate order, and limit are compatibility
+behavior and cannot change under the same recipe version. A deterministic future-date corpus must
+protect both the seed schedule and successful bounded generation before release.
+
+The date is captured by an injected device-local date source outside the platform-independent
+generator. A local-date change never changes an already constructed generation request.
+
+Successful Daily generation persists one exact Daily Session snapshot before readiness. Daily
+restoration reads that snapshot and never regenerates historical progress from recipe seeds. Daily
+uses the separate versioned aggregate documented in
+`docs/technical/daily-challenge-persistence.md`; it does not occupy or mutate the normal generated
+session slot.
 
 ### Quick / `3 Pairs Low`
 
@@ -526,5 +560,9 @@ consistency validation or their selected profile's assessment acceptance policy.
 - `docs/product/prd/prd-v8.md` owns the difficulty-selection and challenge-expansion product contract.
 - `docs/product/prd/prd-v10.md` owns the Quick and Daily Challenge product contract.
 - `docs/technical/generated-session-persistence.md` owns the implemented session storage and coordination boundary.
+- `docs/technical/daily-challenge-persistence.md` owns the planned Daily aggregate storage and
+  coordination boundary.
 - `docs/technical/adr/adr-005-model-sparse-generated-challenges.md` owns the durable sparse challenge-catalog decision.
+- `docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md` owns the durable
+  Daily identity, recipe, and separate aggregate decision.
 - `docs/ubiquitous-language.md` owns shared terminology.

--- a/docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md
+++ b/docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md
@@ -1,0 +1,205 @@
+# ADR-006: Model Daily Challenge As A Versioned Local Cadence
+
+## Context
+
+NumPairs generated play models `3 Pairs`, `4 Pairs`, and `8 Pairs` as replayable puzzle-size
+families. A sparse generated-challenge catalog binds each supported mode and difficulty to one
+validated profile. Normal generated play owns one application-wide resumable session slot, and
+starting another normal challenge safely replaces that slot.
+
+v10 adds one Daily Challenge for each device-local calendar date. The first daily recipe selects
+`4 Pairs Low`, but Daily behavior also requires:
+
+- one stable date-bound content identity
+- deterministic seed selection shared by every installation on the same recipe version
+- exact progress restoration after process death
+- one local completion per date
+- a completion calendar
+- coexistence with an unfinished normal generated session
+- explicit behavior when the local date, recipe, or generator changes
+
+Daily cadence, completion history, and local-date rollover do not belong to a generated puzzle
+profile. Reusing the normal generated-session slot would also let Daily and normal play replace
+one another.
+
+## Options Considered
+
+### Add Daily As A Generated Mode
+
+Create a `daily` generated-mode identity and bind it to `4 Pairs Low`.
+
+This would make cadence look like puzzle size. The new mode would duplicate the existing `4 Pairs`
+shape, make difficulty ownership ambiguous, and force generation and session code to recover a
+date and recipe from a mode that does not own either concept.
+
+### Reuse The Normal Generated-Session Slot
+
+Represent the daily puzzle as an ordinary `4 Pairs Low` generated session with a date-derived seed
+and store completion history separately.
+
+This reuses existing persistence directly, but starting Daily could replace an unfinished Quick,
+4 Pairs, or 8 Pairs puzzle. Starting normal play could likewise erase Daily progress. Completion
+would also require coordinating a session clear and a separate history write without one atomic
+boundary.
+
+### Add A Separate Versioned Daily Aggregate
+
+Model Daily Challenge as a cadence that selects an existing generated challenge through an
+immutable versioned recipe. Persist one independent aggregate containing an optional exact Daily
+Session snapshot and local completion records.
+
+The recipe owns deterministic candidate seed order. The aggregate owns atomic session replacement,
+progress updates, completion recording, and session removal. Normal generated play remains
+unchanged.
+
+## Decision
+
+NumPairs will model Daily Challenge as a versioned local cadence over an explicitly configured
+generated challenge.
+
+### Identity And Recipe
+
+- `DailyChallengeId` combines one device-local calendar date with one stable
+  `DailyRecipeVersion`.
+- The canonical persisted date uses ISO-8601 `YYYY-MM-DD`.
+- `DailyRecipeVersion` identifies one immutable challenge-selection and seed-schedule contract.
+- The v10 recipe version is `daily-4-pairs-low-v1` and resolves to the existing `4 Pairs Low`
+  generated challenge.
+- Display copy, localized date text, profile parameters, and current clock state are not part of
+  Daily Challenge identity.
+
+The v10 recipe constructs one ASCII payload for each candidate:
+
+`daily-4-pairs-low-v1|YYYY-MM-DD|candidate-index`
+
+It hashes the UTF-8 bytes with 32-bit FNV-1a, using offset basis `0x811C9DC5`, prime `0x01000193`,
+and defined 32-bit overflow. The resulting signed 32-bit bit pattern is the generation seed.
+Candidate indexes `0..3` are attempted in ascending order.
+
+The payload format, hash algorithm, constants, selected challenge, and four-candidate limit cannot
+change without a new recipe version.
+
+The generator remains unaware of dates and Daily semantics. It receives ordinary explicit
+generated-puzzle requests. Daily coordination never falls back to device randomness, current
+time-of-day entropy, or a different profile.
+
+### Local-Date Boundary
+
+Application composition supplies the current device-local date through an explicit clock
+boundary. Domain identities and persistence do not read the Android clock directly.
+
+The date is captured when a Daily entry request begins. A local-date change does not mutate an
+already visible Daily Session. Menu resolution compares the current local date with persisted
+Daily identity and does not expose an unfinished prior-date session for backfill.
+
+The clock and time zone are trusted local inputs. Manual changes may make a matching stored
+session or completion visible again; v10 does not add anti-cheat state.
+
+### Daily Aggregate
+
+NumPairs owns one application-private Daily aggregate containing:
+
+- at most one exact versioned Daily Session snapshot
+- zero or more local Daily Completion records
+
+The Daily aggregate is separate from:
+
+- the normal generated-session repository
+- remembered difficulty preferences
+- onboarding
+- personalization and settings
+
+One aggregate and one DataStore edit own the transition from an active solved puzzle to a
+completion record with no resumable Daily Session. A second completion for the same local calendar
+date is rejected even if a different recipe version is later resolved for that date.
+
+### Daily Session Snapshot
+
+The snapshot stores:
+
+- a stable Daily Session id used for stale-callback protection
+- canonical Daily Challenge identity
+- the successful candidate index and derived seed
+- exact initial `Puzzle`
+- exact current `Puzzle`
+
+The recipe version resolves the exact generated challenge. Mode, difficulty, profile parameters,
+and display strings are therefore not persisted redundantly in the Daily snapshot.
+
+Restoration resolves the stored recipe version, verifies its challenge against the puzzle shape
+and snapshot metadata, and reads the exact current puzzle. It never regenerates historical
+progress from the seed.
+
+### Completion History
+
+A Daily Completion record stores:
+
+- canonical Daily Challenge identity
+
+The identity supplies the completed local date and recipe version. Completion does not store a
+score, elapsed time, action count, streak, reward, display label, or full puzzle.
+
+Completion is recorded only by an identity-guarded atomic repository transition that receives a
+solved current puzzle consistent with the active snapshot. Repeating the transition cannot create
+another record.
+
+Calendar presentation may preserve and display the completed date of a record whose recipe version
+is no longer active. An active snapshot whose recipe version cannot be resolved is not resumable.
+
+### Replacement And Rollover
+
+An unfinished prior-date Daily Session remains stored but is not exposed as current after Menu
+observes a later local date.
+
+Starting the later Daily Challenge:
+
+1. captures the new identity
+2. resolves its immutable recipe
+3. attempts deterministic candidate seeds in order
+4. validates the generated puzzle
+5. builds an exact new snapshot
+6. atomically replaces the stale Daily Session only after the successor is stored
+
+Failure or cancellation keeps the prior aggregate intact. The stale session remains hidden and
+cannot be used for past-day play. A successful successor replaces only the Daily slot and does not
+touch normal generated play.
+
+### Local Storage And Transfer
+
+The Daily aggregate uses a dedicated application-private DataStore file and is excluded from
+Android cloud backup, legacy Auto Backup, and device-to-device transfer.
+
+Reinstallation or application-data deletion removes the active Daily Session and completion
+history. Account sync and cross-device transfer remain unsupported.
+
+## Consequences
+
+### Positive
+
+- Daily cadence does not distort generated mode, difficulty, or profile ownership.
+- Normal and Daily progress can be resumable simultaneously.
+- Solved state, completion recording, and removal from Daily Resume are atomic.
+- A recipe version gives date-derived content a stable compatibility boundary.
+- The generator remains reusable and unaware of clocks or presentation.
+- Exact snapshots protect progress from future generator changes.
+- Completion history remains small, local, and independent from puzzle content.
+
+### Negative
+
+- Application composition owns a second resumable-session path.
+- A versioned aggregate and codec must preserve both optional session state and growing completion
+  history.
+- Old recipe resolvers must remain available while their active snapshots may still be restored.
+- Date rollover, clock changes, stale callbacks, recipe mismatches, and partial corruption require
+  explicit test coverage.
+- Local-only history can be reset or manipulated and cannot prove fair participation.
+
+## Future Considerations
+
+A later online product could publish curated daily content or synchronize completion history, but
+that would require a new trust, migration, and account contract. It must not silently reinterpret
+the local v10 identity.
+
+A future recipe may select another existing challenge or use a new deterministic algorithm. It
+must use a new stable recipe version and define how a same-date completion from an older recipe
+suppresses duplicate Daily completion.

--- a/docs/technical/daily-challenge-persistence.md
+++ b/docs/technical/daily-challenge-persistence.md
@@ -1,0 +1,257 @@
+# Daily Challenge Persistence
+
+## Document Status
+
+- Status: planned v10 Daily identity, session, and local completion-history contract
+- Product contract: `docs/product/prd/prd-v10.md`
+- Architecture decision:
+  `docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md`
+- Related generation reference: `docs/product/puzzle-generation.md`
+- Normal generated-session boundary: `docs/technical/generated-session-persistence.md`
+
+This document owns the v10 persistence and coordination boundary for one local Daily Challenge
+aggregate. It does not redefine generated puzzle profiles, normal generated sessions, menu copy,
+calendar layout, or core NumPairs rules.
+
+---
+
+## Scope And Ownership
+
+NumPairs stores one application-private Daily aggregate containing:
+
+- at most one Daily Session snapshot
+- local Daily Completion records
+
+The aggregate is independent from the one normal generated-session slot. An unfinished Daily
+Session and an unfinished normal Quick, 4 Pairs, or 8 Pairs session may coexist. Operations on one
+repository never read, replace, update, clear, or complete the other.
+
+`MainActivity` creates one application-scoped Daily repository and one application-scoped
+device-local date source. Daily feature coordination receives those dependencies alongside the
+existing configured generated-challenge catalog and generation factory.
+
+Tutorial, onboarding, remembered difficulty selection, Personalization, and Settings do not
+receive Daily mutation callbacks.
+
+---
+
+## Daily Identity And Recipe Resolution
+
+`DailyChallengeId` contains:
+
+- canonical local date in ISO-8601 `YYYY-MM-DD`
+- stable Daily Recipe version
+
+The v10 recipe version `daily-4-pairs-low-v1` resolves the existing `4 Pairs Low` challenge. For
+candidate indexes `0..3`, it hashes the UTF-8 payload
+`daily-4-pairs-low-v1|YYYY-MM-DD|candidate-index` with 32-bit FNV-1a and uses the resulting signed
+32-bit bit pattern as the generation seed. The payload, hash constants, overflow semantics,
+challenge, order, and candidate limit belong to that recipe version.
+
+Daily coordination captures the current local date once per entry request and constructs the
+identity before generation begins. A midnight or time-zone transition does not rewrite the
+identity of an in-flight or visible request.
+
+The recipe resolver accepts only configured recipe versions. An unknown recipe makes an active
+snapshot unsupported, but a completion record keeps its canonical completed date for calendar
+history.
+
+---
+
+## Versioned Aggregate
+
+Schema version `1` stores:
+
+- an optional Daily Session snapshot
+- a collection of Daily Completion records
+
+The snapshot stores:
+
+- stable Daily Session id
+- canonical local date
+- Daily Recipe version
+- successful zero-based candidate index
+- derived generation seed
+- exact initial `Puzzle`
+- exact current `Puzzle`
+
+The selected generated mode, difficulty, and profile are derived from the recipe version and are
+not persisted again. The candidate index and seed must agree with the recipe mapping.
+
+The initial and current puzzles preserve:
+
+- board tile order and results
+- expression operands, operators, and strip-entry references
+- strip entry ids, order, and origin state
+
+Snapshot construction rejects changed board results, changed strip-entry identity sets, changed
+known values, invalid initial player-entered values, mismatched recipe seed data, and puzzle shape
+that does not match the recipe challenge.
+
+Each completion record stores:
+
+- canonical local date
+- Daily Recipe version
+
+The codec rejects duplicate completion identities and more than one completion record for the same
+local date. It does not store a completion timestamp, score, duration, action count, display text,
+or puzzle.
+
+The deterministic codec returns typed decoded, unsupported-version, and invalid-data outcomes.
+Malformed active-session data must not fabricate a resumable puzzle or completion. The
+implementation should preserve independently valid completion records where the selected encoding
+can isolate a malformed optional session; otherwise aggregate corruption recovers to an empty
+local Daily state.
+
+---
+
+## Repository Contract
+
+The repository exposes one observable state containing:
+
+- nullable active Daily Session snapshot
+- completed Daily Challenge identities
+
+It owns these atomic mutations:
+
+- `replaceSession(snapshot)` adopts a generated successor only when its date has no completion
+- `updateCurrentPuzzle(expectedSessionId, puzzle)` updates only the owning unsolved session
+- `complete(expectedSessionId, expectedDailyChallengeId, solvedPuzzle)` records one completion and
+  removes the owning active session in the same edit
+
+Every mutation validates stable session identity inside the DataStore edit. A callback from a
+stale screen cannot update or complete a successor.
+
+`complete` additionally requires:
+
+- the supplied puzzle is solved
+- it remains consistent with the active initial puzzle
+- its Daily Challenge identity has no completion
+- its local date has no completion under another recipe version
+
+The operation is idempotent for already completed Daily identity and returns a typed outcome that
+distinguishes completed, already completed, stale session, and invalid puzzle. It never clears a
+session before the completion record is durable.
+
+Daily gameplay forwards only committed domain puzzle changes. Draft text, open selectors,
+dialogs, overlays, highlights, calendar month, scroll position, Sharesheet state, animations, and
+other presentation state are not persisted.
+
+---
+
+## Lifecycle
+
+### Resolve Current Daily State
+
+For the captured local date:
+
+1. If any completion record owns the date, expose completed-today state.
+2. Otherwise, if the active snapshot has the exact current Daily Challenge identity, resolves its
+   recipe, remains valid, and is unsolved, expose continue-today state.
+3. Otherwise, expose start-today state.
+
+A prior-date session is retained safely but is not exposed as resumable.
+
+### Create And Replace
+
+1. Capture local date and resolve the Daily Challenge identity.
+2. Resolve the immutable recipe and selected generated challenge.
+3. Attempt recipe candidate seeds in ascending index order.
+4. Stop at the first generated and validated puzzle.
+5. Build a new snapshot with identical initial and current puzzles.
+6. Store the snapshot through `replaceSession`.
+7. Publish the playable Daily Session.
+
+The previous Daily slot remains intact while generation or storage is pending. Failure,
+cancellation, or exhaustion leaves it intact. A successful stored successor replaces a stale
+prior-date session before the new puzzle is shown.
+
+Normal generated-session state is not consulted or mutated.
+
+### Restore
+
+Restoration requires:
+
+- expected stable Daily Session id
+- identity equal to the captured current Daily Challenge identity
+- supported recipe version
+- seed and candidate index matching that recipe
+- exact puzzle shape matching the recipe challenge
+- valid unsolved current puzzle
+- no completion for the same identity or date
+
+Restoration presents the exact current puzzle without generation, device randomness, remembered
+difficulty lookup, or repository writes.
+
+Missing, stale, prior-date, solved, mismatched, corrupt, completed, or unsupported snapshots are
+not resumable. Prior-date content is not offered through the calendar.
+
+### Progress And Completion
+
+Committed strip values, operand assignments, operator assignments, and tile resets update the
+active current puzzle through the stable Daily Session id.
+
+When the puzzle becomes solved, the presentation owner orders the final mutation after earlier
+progress writes and calls the atomic completion operation. The operation records the Daily
+Challenge identity and removes the active session together. The solved game remains visible in
+memory for Share result, View calendar, and Back to menu.
+
+A late progress or completion callback cannot mutate a later Daily Session because the stable
+session ids differ.
+
+### Local-Date Rollover
+
+An active route keeps its captured Daily Challenge identity when the date changes. Completion is
+recorded for that captured identity.
+
+After returning to Menu on a later local date, the old unfinished session is not resumable.
+Starting the new Daily Challenge uses safe replacement. Moving the device clock back may make an
+exact matching unsolved session visible again if it has not been replaced and its date has no
+completion.
+
+The repository does not maintain a monotonic trusted date or anti-cheat ledger.
+
+---
+
+## Local Storage And Transfer
+
+The versioned aggregate is encoded in one dedicated Preferences DataStore file:
+
+`datastore/daily_challenge.preferences_pb`
+
+One file keeps session replacement, completion recording, and resumability removal within a
+single atomic DataStore edit. Room is not required because the product queries one optional
+session and a small local set of completion identities rather than an independently mutable
+relational history.
+
+The file is excluded from:
+
+- legacy Android Auto Backup in `res/xml/backup_rules.xml`
+- Android cloud backup in `res/xml/data_extraction_rules.xml`
+- Android device-to-device transfer in `res/xml/data_extraction_rules.xml`
+
+Reinstallation or application-data deletion resets both Daily progress and the completion
+calendar. Cache deletion does not.
+
+---
+
+## Verification Boundaries
+
+The non-device test suite must protect:
+
+- deterministic aggregate round trips and malformed or unsupported versions
+- snapshot identity, recipe, seed, candidate-index, shape, and initial/current consistency
+- rejection of duplicate identity and same-date completion records
+- independent normal and Daily repositories
+- one-slot Daily replacement and stale-callback guards
+- exact restoration without regeneration or writes
+- safe prior-date replacement, failure, cancellation, and exhaustion
+- ordered committed progress
+- atomic solved completion and active-session removal
+- idempotent repeated completion
+- DataStore recreation and corruption recovery
+- trusted local-date rollover and clock-back behavior
+
+Instrumented sources should protect the application-composition, Menu, Daily continuation,
+completion, calendar, and process-recreation boundaries where rendering or Android lifecycle
+matters. Local delivery compiles instrumented sources without starting an emulator.

--- a/docs/technical/generated-session-persistence.md
+++ b/docs/technical/generated-session-persistence.md
@@ -6,22 +6,30 @@
 - Product contracts: `docs/product/prd/prd-v7.md` and `docs/product/prd/prd-v8.md`
 - Related generation reference: `docs/product/puzzle-generation.md`
 - Related domain decision: `docs/technical/adr/adr-005-model-sparse-generated-challenges.md`
+- Planned Daily boundary: `docs/technical/daily-challenge-persistence.md`
 
-This document owns the persistence and coordination boundary for the single resumable generated puzzle. It does not redefine puzzle rules, generation profiles, or menu copy.
+This document owns the persistence and coordination boundary for the single resumable normal
+generated puzzle. It does not own Daily Challenge persistence and does not redefine puzzle rules,
+generation profiles, or menu copy.
 
 ---
 
 ## Scope And Ownership
 
-NumPairs stores at most one generated session for the whole application. The slot may belong to
-any challenge in the supported generated-challenge catalog: `4 Pairs Low`, `4 Pairs Medium`,
-`8 Pairs Medium`, or `8 Pairs Hard` in v8. There is no independent save per mode, history,
-account sync, or manual save management.
+NumPairs stores at most one normal generated session for the whole application. The slot may
+belong to any challenge in the supported generated-challenge catalog: `4 Pairs Low`,
+`4 Pairs Medium`, `8 Pairs Medium`, or `8 Pairs Hard` in v8, plus Quick `3 Pairs Low` when v10 is
+implemented. There is no independent normal save per mode, normal generated history, account sync,
+or manual save management.
 
 `MainActivity` creates one application-scoped `GeneratedSessionRepository` from
 application-private storage and passes it only through generated-play and unlocked-navigation
 composition. Tutorial and onboarding do not receive generated-session persistence callbacks and
 cannot replace the slot.
+
+The v10 Daily Challenge owns a separate aggregate and may remain resumable at the same time. Daily
+operations never mutate this repository, and normal generated operations never mutate the Daily
+aggregate. See `docs/technical/daily-challenge-persistence.md`.
 
 The remembered difficulty selections are a separate preference aggregate, not generated-session
 state. Session creation and restoration may read a challenge choice supplied by navigation, but
@@ -150,6 +158,9 @@ The file is excluded from:
 - Android device-to-device transfer in `res/xml/data_extraction_rules.xml`
 
 This keeps the session local to the installation and avoids restoring a transient unfinished puzzle as cross-device progression.
+
+The planned Daily aggregate uses its own separately excluded
+`datastore/daily_challenge.preferences_pb` file.
 
 ---
 

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -54,11 +54,13 @@ assessment policy. Android strings, player preference, lock state, navigation, a
 challenge-specific learning capabilities remain outside the profile.
 
 ## Generated Session
-A playable generated-puzzle lifecycle identified by a stable session identity.
+A normal replayable generated-puzzle lifecycle identified by a stable session identity.
 
 NumPairs owns at most one generated session slot for the application, shared by all generated
 challenges. A generated session carries the mode and profile identities that resolve its exact
 challenge, seed metadata, exact initial puzzle, and exact current puzzle.
+
+Daily Challenge uses a separate Daily Session lifecycle and does not occupy this slot.
 
 ## Resumable Generated Session
 The generated session currently stored in the application-wide slot when its current puzzle is
@@ -71,8 +73,63 @@ The versioned local representation of one generated session.
 
 The snapshot preserves stable session, mode, profile, board, tile, expression, strip-entry, and strip-item identity needed to restore the exact current puzzle. Its seed is metadata; the snapshot is not restored by regenerating from the seed.
 
+## Daily Challenge
+The one date-bound playable puzzle selected by a Daily Recipe for one device-local calendar date.
+
+A Daily Challenge selects an existing generated challenge. It is a play cadence, not a generated
+mode, difficulty tier, generated profile, or normal generated session.
+
+## Daily Challenge Identity
+The stable identity combining one canonical device-local calendar date with one Daily Recipe
+version.
+
+The canonical date uses ISO-8601 `YYYY-MM-DD`. Localized display text, the current clock value, and
+derivable profile parameters are not part of the identity.
+
+## Daily Recipe
+An immutable versioned definition that selects one generated challenge and deterministically maps
+a Daily Challenge identity plus candidate index to an ordered bounded sequence of generation
+seeds.
+
+The v10 Daily Recipe selects `4 Pairs Low`. A recipe change requires a new stable version.
+
+## Daily Session
+The playable lifecycle for one Daily Challenge identity.
+
+NumPairs owns at most one Daily Session slot, separate from the normal generated-session slot. A
+Daily Session carries a stable session identity, recipe and date identity, successful candidate
+metadata, exact initial puzzle, and exact current puzzle.
+
+## Resumable Daily Session
+The Daily Session currently stored in the Daily aggregate when its identity matches the current
+Daily Challenge, its recipe and puzzle remain supported and valid, no completion owns its date, and
+its current puzzle is not solved.
+
+An unfinished prior-date, solved, mismatched, corrupt, completed, unsupported, or missing Daily
+Session is not resumable.
+
+## Daily Session Snapshot
+The versioned local representation of one Daily Session.
+
+The snapshot preserves stable Daily Session, Daily Challenge, candidate, board, tile, expression,
+strip-entry, and strip-item identity needed to restore exact progress. Seed and candidate index are
+metadata verified against the recipe; restoration never regenerates from them.
+
+## Daily Completion
+The local fact that the puzzle for one Daily Challenge identity became solved.
+
+A completion owns its canonical date and recipe version. It contains no score, time, streak,
+reward, display text, or puzzle.
+
+## Daily Completion History
+The local collection of Daily Completion records displayed by the calendar.
+
+The history records at most one completion per local calendar date, remains independent from
+normal generated sessions and preferences, and is not synchronized across installations.
+
 ## Current Puzzle
-The latest committed domain state of the puzzle being played in a generated session.
+The latest committed domain state of the puzzle being played in a normal generated session or
+Daily Session.
 
 Current puzzle changes include committed strip values, operand assignments, operator assignments, and tile resets. Transient presentation state such as drafts, open selectors, dialogs, overlays, highlights, and scroll position is not part of the current puzzle.
 


### PR DESCRIPTION
## Related Issue

Resolves #578

## Summary

- Record Daily Challenge as a versioned local cadence over 4 Pairs Low rather than a generated mode.
- Define the stable v10 recipe, deterministic FNV-1a candidate schedule, local-date boundary, and rollover behavior.
- Specify one independent atomic Daily aggregate for exact session progress and local completion history.
- Align generated-session, generation, and ubiquitous-language references with the separate Daily lifecycle.