### PR TITLE
[281] Add the 3 Pairs Low generated profile

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfiles.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfiles.kt
@@ -4,12 +4,53 @@ import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficulty
 import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficultyAssessmentPolicy
 
 object GeneratedPuzzleProfiles {
+    val THREE_PAIRS_LOW: GeneratedPuzzleProfile = threePairsLow()
     val FOUR_PAIRS_LOW: GeneratedPuzzleProfile = fourPairsLow()
     val FOUR_PAIRS_MEDIUM: GeneratedPuzzleProfile = fourPairsMedium()
     val EIGHT_PAIRS_MEDIUM: GeneratedPuzzleProfile = eightPairsMedium()
     val EIGHT_PAIRS_HARD: GeneratedPuzzleProfile = eightPairsHard()
     val ALL: List<GeneratedPuzzleProfile> =
-        listOf(FOUR_PAIRS_LOW, FOUR_PAIRS_MEDIUM, EIGHT_PAIRS_MEDIUM, EIGHT_PAIRS_HARD)
+        listOf(THREE_PAIRS_LOW, FOUR_PAIRS_LOW, FOUR_PAIRS_MEDIUM, EIGHT_PAIRS_MEDIUM, EIGHT_PAIRS_HARD)
+
+    private fun threePairsLow(): GeneratedPuzzleProfile {
+        val size = GeneratedPuzzleSize(pairCount = 3)
+
+        return GeneratedPuzzleProfile.create(
+            definition = GeneratedPuzzleProfileDefinition(
+                id = GeneratedPuzzleProfileId("3-pairs-low"),
+                difficulty = DifficultyTier.LOW,
+                size = size,
+                stripValuePolicy = StripValuePolicy(
+                    valueRange = 2..15,
+                    maxOccurrencesPerValue = 1
+                ),
+                resultConstraints = ResultConstraints(
+                    maxMultiplicationResult = 100,
+                    allowsDuplicateBoardResults = false
+                ),
+                initialStripMaskPolicy = InitialStripMaskPolicy(
+                    knownEntryCountRange = 2..2,
+                    requiredAnchors = setOf(RequiredKnownStripAnchor.HIGHEST_STRIP_ENTRY),
+                    distributionPolicy = StripKnownEntryDistributionPolicy.SpreadAcrossStripAndPairsWhenPossible,
+                    maxConsecutiveHiddenEntries = 2
+                ),
+                generationPolicy = GenerationPolicy(
+                    isBoardTileShufflingEnabled = true
+                ),
+                difficultyAssessmentPolicy = GeneratedPuzzleDifficultyAssessmentPolicy(
+                    executionPolicy = GeneratedPuzzleDifficultyAssessmentExecutionPolicy(
+                        maxCandidateExpansions = 10_000,
+                        validSolutionCountLimit = 10
+                    ),
+                    minimumInitialPlausibleCandidateCount = 3,
+                    minimumInitialForcedDeductionCount = 3,
+                    minimumFirstForcedDeductionDepth = 1,
+                    minimumPlausibleDecoyCount = 0,
+                    minimumValidSolutionCount = 1
+                )
+            )
+        ).getOrThrow()
+    }
 
     private fun fourPairsLow(): GeneratedPuzzleProfile {
         val size = GeneratedPuzzleSize(pairCount = 4)

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleProfileContractTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleProfileContractTest.kt
@@ -21,7 +21,7 @@ class GeneratedPuzzleProfileContractTest {
     @Test
     fun every_registered_profile_satisfies_the_shared_generation_contract() {
         assertEquals(
-            listOf("4-pairs-low", "4-pairs-medium", "8-pairs-medium", "8-pairs-hard"),
+            listOf("3-pairs-low", "4-pairs-low", "4-pairs-medium", "8-pairs-medium", "8-pairs-hard"),
             GeneratedPuzzleProfiles.ALL.map { profile -> profile.id.value }
         )
 

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/ThreePairsLowGeneratedPairsPuzzleGeneratorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/ThreePairsLowGeneratedPairsPuzzleGeneratorTest.kt
@@ -1,0 +1,188 @@
+package org.cescfe.numpairs.domain.generated.generation
+
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPairsDifficultyAssessor
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficultyAssessmentOutcome
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfiles
+import org.cescfe.numpairs.domain.generated.puzzle.GeneratedPairsPuzzle
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.cescfe.numpairs.domain.puzzle.model.Tile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThreePairsLowGeneratedPairsPuzzleGeneratorTest {
+    @Test
+    fun three_pairs_low_generation_satisfies_the_documented_profile() {
+        val generatedPuzzle = generatedPuzzle(profile = GeneratedPuzzleProfiles.THREE_PAIRS_LOW, seed = 42)
+
+        assertDocumentedProfile(generatedPuzzle)
+    }
+
+    private fun assertDocumentedProfile(generatedPuzzle: GeneratedPairsPuzzle) {
+        val profile = GeneratedPuzzleProfiles.THREE_PAIRS_LOW
+        val solvedPuzzle = generatedPuzzle.solvedPuzzle
+        val initialPuzzle = generatedPuzzle.initialPuzzle
+        val solvedValues = solvedPuzzle.requireKnownStripValues()
+
+        assertEquals(3, profile.size.pairCount)
+        assertEquals(6, solvedPuzzle.strip.entries.size)
+        assertEquals(6, solvedPuzzle.board.tiles.size)
+        assertEquals(solvedValues.sorted(), solvedValues)
+        assertTrue(solvedValues.all { value -> value in 2..15 })
+        assertEquals(solvedValues.size, solvedValues.toSet().size)
+        assertFalse(1 in solvedValues)
+        assertTrue(solvedPuzzle.multiplicationTiles().all { tile -> tile.result <= 100 })
+        assertEquals(6, solvedPuzzle.board.tiles.map(Tile::result).toSet().size)
+
+        assertEquals(2, initialPuzzle.knownEntryIds().size)
+        assertEquals(4, initialPuzzle.strip.entries.count { entry -> entry.item == StripItem.Hidden })
+        assertTrue(profile.requiredHighestStripEntryId in initialPuzzle.knownEntryIds())
+        assertEquals(2, initialPuzzle.knownEntryIds().distinctSolutionPairCount(generatedPuzzle))
+        assertTrue(initialPuzzle.knownEntryIds().maxConsecutiveHiddenEntries(6) <= 2)
+        assertGeneratedInitialPuzzleStructure(puzzle = initialPuzzle, profile = profile)
+    }
+
+    @Test
+    fun three_pairs_low_generation_is_deterministic_for_the_same_seed() {
+        val profile = GeneratedPuzzleProfiles.THREE_PAIRS_LOW
+
+        assertEquals(
+            generatedPuzzle(profile = profile, seed = 1234),
+            generatedPuzzle(profile = profile, seed = 1234)
+        )
+    }
+
+    @Test
+    fun corpus_characterizes_reliable_generation_and_low_difficulty_assessment() {
+        val profile = GeneratedPuzzleProfiles.THREE_PAIRS_LOW
+        val assessmentPolicy = requireNotNull(profile.difficultyAssessmentPolicy)
+        val assessor = GeneratedPairsDifficultyAssessor()
+        val observations = CORPUS_SEEDS.map { seed ->
+            val outcome = GeneratedPairsPuzzleGenerator(profile).generate(
+                request = GeneratedPuzzleGenerationRequest(profile = profile, seed = seed)
+            )
+            val generated = outcome as GeneratedPairsPuzzleGenerationOutcome.Generated
+            assertDocumentedProfile(generated.puzzle)
+            val assessed = assessor.assess(
+                initialPuzzle = generated.puzzle.initialPuzzle,
+                profile = profile,
+                executionPolicy = assessmentPolicy.executionPolicy
+            ) as GeneratedPuzzleDifficultyAssessmentOutcome.Assessed
+
+            assertTrue(
+                "Assessment policy must accept seed $seed.",
+                assessmentPolicy.evaluate(assessed.report).isAccepted
+            )
+            assertFalse(
+                "Assessment solution count must stay below the configured limit for seed $seed.",
+                assessed.report.isValidSolutionCountLimitReached
+            )
+            CorpusObservation(
+                attemptsUsed = generated.attemptsUsed,
+                searchWorkConsumed = generated.searchWorkConsumed,
+                assessmentWorkConsumed = assessed.workConsumed,
+                initialPlausibleCandidateCount = assessed.report.initialPlausibleCandidateCount,
+                initialForcedDeductionCount = assessed.report.initialForcedDeductionCount,
+                forcedDeductionCount = assessed.report.forcedDeductionCount,
+                boundedValidSolutionCount = assessed.report.boundedValidSolutionCount,
+                knownStripAnchorCount = assessed.report.structuralObservations.knownStripAnchorCount,
+                unambiguousResultAnchorCount =
+                assessed.report.structuralObservations.unambiguousResultAnchorCount,
+                longestHiddenRun = assessed.report.structuralObservations.longestHiddenRun
+            )
+        }
+
+        assertEquals(
+            CorpusCharacterization(
+                attemptsUsed = 1..6,
+                searchWorkConsumed = 8..80,
+                assessmentWorkConsumed = 108..108,
+                initialPlausibleCandidateCount = 3..5,
+                initialForcedDeductionCount = 3..3,
+                forcedDeductionCount = 3..3,
+                boundedValidSolutionCount = 1..1,
+                knownStripAnchorCount = 1..1,
+                unambiguousResultAnchorCount = 2..6,
+                longestHiddenRun = 2..2
+            ),
+            observations.characterization()
+        )
+    }
+
+    @Test
+    fun three_pairs_low_preserves_bounded_failure_and_cancellation() {
+        val profile = GeneratedPuzzleProfiles.THREE_PAIRS_LOW
+        val budgetFailure = GeneratedPairsPuzzleGenerator(profile).generate(
+            request = GeneratedPuzzleGenerationRequest(
+                profile = profile,
+                seed = 2026,
+                executionPolicy = GeneratedPuzzleGenerationExecutionPolicy(
+                    maxAttempts = 1,
+                    maxSearchWork = 1
+                )
+            )
+        ) as GeneratedPairsPuzzleGenerationOutcome.Failed
+        assertEquals(GeneratedPairsPuzzleGenerationFailureReason.SearchBudgetExhausted, budgetFailure.reason)
+
+        val cancellation = GeneratedPairsPuzzleGenerator(profile).generate(
+            request = GeneratedPuzzleGenerationRequest(profile = profile, seed = 2026),
+            cancellation = { true }
+        ) as GeneratedPairsPuzzleGenerationOutcome.Failed
+        assertEquals(GeneratedPairsPuzzleGenerationFailureReason.Cancelled, cancellation.reason)
+        assertEquals(0, cancellation.searchWorkConsumed)
+    }
+
+    private companion object {
+        val CORPUS_SEEDS = 1..500
+    }
+}
+
+private data class CorpusObservation(
+    val attemptsUsed: Int,
+    val searchWorkConsumed: Int,
+    val assessmentWorkConsumed: Int,
+    val initialPlausibleCandidateCount: Int,
+    val initialForcedDeductionCount: Int,
+    val forcedDeductionCount: Int,
+    val boundedValidSolutionCount: Int,
+    val knownStripAnchorCount: Int,
+    val unambiguousResultAnchorCount: Int,
+    val longestHiddenRun: Int
+)
+
+private data class CorpusCharacterization(
+    val attemptsUsed: IntRange,
+    val searchWorkConsumed: IntRange,
+    val assessmentWorkConsumed: IntRange,
+    val initialPlausibleCandidateCount: IntRange,
+    val initialForcedDeductionCount: IntRange,
+    val forcedDeductionCount: IntRange,
+    val boundedValidSolutionCount: IntRange,
+    val knownStripAnchorCount: IntRange,
+    val unambiguousResultAnchorCount: IntRange,
+    val longestHiddenRun: IntRange
+)
+
+private fun List<CorpusObservation>.characterization(): CorpusCharacterization = CorpusCharacterization(
+    attemptsUsed = minOf(CorpusObservation::attemptsUsed)..maxOf(CorpusObservation::attemptsUsed),
+    searchWorkConsumed =
+    minOf(CorpusObservation::searchWorkConsumed)..maxOf(CorpusObservation::searchWorkConsumed),
+    assessmentWorkConsumed =
+    minOf(CorpusObservation::assessmentWorkConsumed)..maxOf(CorpusObservation::assessmentWorkConsumed),
+    initialPlausibleCandidateCount =
+    minOf(
+        CorpusObservation::initialPlausibleCandidateCount
+    )..maxOf(CorpusObservation::initialPlausibleCandidateCount),
+    initialForcedDeductionCount =
+    minOf(CorpusObservation::initialForcedDeductionCount)..maxOf(CorpusObservation::initialForcedDeductionCount),
+    forcedDeductionCount =
+    minOf(CorpusObservation::forcedDeductionCount)..maxOf(CorpusObservation::forcedDeductionCount),
+    boundedValidSolutionCount =
+    minOf(CorpusObservation::boundedValidSolutionCount)..maxOf(CorpusObservation::boundedValidSolutionCount),
+    knownStripAnchorCount =
+    minOf(CorpusObservation::knownStripAnchorCount)..maxOf(CorpusObservation::knownStripAnchorCount),
+    unambiguousResultAnchorCount =
+    minOf(CorpusObservation::unambiguousResultAnchorCount)..maxOf(CorpusObservation::unambiguousResultAnchorCount),
+    longestHiddenRun = minOf(CorpusObservation::longestHiddenRun)..maxOf(CorpusObservation::longestHiddenRun)
+)

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfilesTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfilesTest.kt
@@ -8,6 +8,51 @@ import org.junit.Test
 
 class GeneratedPuzzleProfilesTest {
     @Test
+    fun three_pairs_low_profile_matches_documented_rules() {
+        val profile = GeneratedPuzzleProfiles.THREE_PAIRS_LOW
+
+        assertEquals(GeneratedPuzzleProfileId("3-pairs-low"), profile.id)
+        assertEquals(DifficultyTier.LOW, profile.difficulty)
+        assertEquals(3, profile.size.pairCount)
+        assertEquals(6, profile.size.stripEntryCount)
+        assertEquals(6, profile.size.boardTileCount)
+
+        assertEquals(2..15, profile.stripValuePolicy.valueRange)
+        assertEquals(1, profile.stripValuePolicy.maxOccurrencesPerValue)
+        assertFalse(profile.stripValuePolicy.allowsOne)
+
+        assertEquals(100, profile.resultConstraints.maxMultiplicationResult)
+        assertFalse(profile.resultConstraints.allowsDuplicateBoardResults)
+        assertNull(profile.resultConstraints.productAnchorMix)
+
+        assertEquals(2..2, profile.initialStripMaskPolicy.knownEntryCountRange)
+        assertEquals(4..4, profile.hiddenEntryCountRange)
+        assertEquals(
+            setOf(RequiredKnownStripAnchor.HIGHEST_STRIP_ENTRY),
+            profile.initialStripMaskPolicy.requiredAnchors
+        )
+        assertEquals(
+            StripKnownEntryDistributionPolicy.SpreadAcrossStripAndPairsWhenPossible,
+            profile.initialStripMaskPolicy.distributionPolicy
+        )
+        assertEquals(2, profile.initialStripMaskPolicy.maxConsecutiveHiddenEntries)
+
+        assertTrue(profile.generationPolicy.isBoardTileShufflingEnabled)
+        assertTrue(profile.varietyPolicy.highValueMaskTargets.isEmpty())
+        assertNull(profile.varietyPolicy.primeProductDecoyTarget)
+        assertNull(profile.varietyPolicy.repeatedValueGroupTarget)
+
+        val assessmentPolicy = requireNotNull(profile.difficultyAssessmentPolicy)
+        assertEquals(10_000, assessmentPolicy.executionPolicy.maxCandidateExpansions)
+        assertEquals(10, assessmentPolicy.executionPolicy.validSolutionCountLimit)
+        assertEquals(3, assessmentPolicy.minimumInitialPlausibleCandidateCount)
+        assertEquals(3, assessmentPolicy.minimumInitialForcedDeductionCount)
+        assertEquals(1, assessmentPolicy.minimumFirstForcedDeductionDepth)
+        assertEquals(0, assessmentPolicy.minimumPlausibleDecoyCount)
+        assertEquals(1, assessmentPolicy.minimumValidSolutionCount)
+    }
+
+    @Test
     fun four_pairs_low_profile_matches_documented_rules() {
         val profile = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW
 

--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -3,9 +3,9 @@
 ## Document Status
 
 - Status: product reference for generated puzzle construction
-- Implemented profiles: generated `4 Pairs Low`, `4 Pairs Medium`, `8 Pairs Medium`, and
-  `8 Pairs Hard`
-- Planned v10 profile: generated `3 Pairs Low`, presented as Quick
+- Implemented profiles: generated `3 Pairs Low`, `4 Pairs Low`, `4 Pairs Medium`,
+  `8 Pairs Medium`, and `8 Pairs Hard`
+- Planned v10 mode registration: present generated `3 Pairs Low` to players as Quick
 - v8 generated challenge matrix: implemented
 - Related references:
   - `docs/product/prd/prd-v5.md`
@@ -58,7 +58,7 @@ The implemented v8 catalog and planned v10 Quick addition form a sparse catalog:
 
 | Generated mode | Low | Medium | Hard |
 | --- | --- | --- | --- |
-| `Quick` (`3 Pairs`) | Planned in v10 | Unsupported | Unsupported |
+| `Quick` (`3 Pairs`) | Profile implemented; mode registration planned | Unsupported | Unsupported |
 | `4 Pairs` | Supported | Supported | Unsupported |
 | `8 Pairs` | Unsupported | Supported | Supported |
 
@@ -207,7 +207,7 @@ session slot.
 
 ### Quick / `3 Pairs Low`
 
-Status: planned for v10.
+Status: generated profile implemented; Quick mode registration planned for v10.
 
 Player-facing identity:
 
@@ -261,6 +261,14 @@ Assessment and characterization expectations:
   speculative commitment
 - characterization must record plausible-candidate, forced-deduction, solution-count, anchor, and
   hidden-run metrics for corpus `1..500`
+- the implemented corpus completes in 1 to 6 attempts and consumes 8 to 80 generation-search
+  units per puzzle
+- assessment consumes 108 candidate expansions per puzzle, reports 3 to 5 opening plausible
+  candidates, and derives all 3 solution-pair facts at the opening
+- the bounded valid-solution count is 1 throughout the corpus without reaching the configured
+  count limit
+- the required known-strip anchor count is 1, unambiguous result anchors range from 2 to 6, and
+  the longest hidden run is 2 throughout the corpus
 - thresholds may be tightened only when the deterministic corpus provides evidence; Low does not
   require decoys, branching, or an ambiguous opening
 


### PR DESCRIPTION
## Related Issue

Resolves #584

## Summary

- Add the validated `3-pairs-low` generated profile and include it in the built-in profile collection.
- Protect deterministic generation, bounded failure, cancellation, and every documented constraint across seeds `1..500`.
- Record the implemented profile status and deterministic corpus characterization while keeping Quick mode registration planned.