### PR TITLE
[282] Register the Quick generated challenge

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/data/generated/selection/DataStoreGeneratedDifficultySelectionRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/generated/selection/DataStoreGeneratedDifficultySelectionRepository.kt
@@ -22,8 +22,8 @@ class DataStoreGeneratedDifficultySelectionRepository(
 ) : GeneratedDifficultySelectionRepository {
     init {
         val configuredModeIds = catalog.all.map { mode -> mode.id }.toSet()
-        require(fallbackDifficultyByMode.keys == configuredModeIds) {
-            "Every configured generated mode must have exactly one difficulty fallback."
+        require(fallbackDifficultyByMode.keys.all(configuredModeIds::contains)) {
+            "Every difficulty fallback must belong to a configured generated mode."
         }
         fallbackDifficultyByMode.forEach { (modeId, difficulty) ->
             require(catalog.supports(modeId = modeId, difficulty = difficulty)) {
@@ -53,6 +53,9 @@ class DataStoreGeneratedDifficultySelectionRepository(
     }
 
     override suspend fun selectDifficulty(modeId: GeneratedModeId, difficulty: DifficultyTier) {
+        require(modeId in fallbackDifficultyByMode) {
+            "Generated mode ${modeId.value} does not support remembered difficulty selection."
+        }
         require(catalog.supports(modeId = modeId, difficulty = difficulty)) {
             "Difficulty ${difficulty.name} is not supported for generated mode ${modeId.value}."
         }

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeConfiguration.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeConfiguration.kt
@@ -133,9 +133,16 @@ class GeneratedChallengeCatalog(configurations: Collection<GeneratedModeConfigur
 }
 
 object GeneratedModes {
+    private val threePairsId = GeneratedModeId("three-pairs")
     private val fourPairsId = GeneratedModeId("four-pairs")
     private val eightPairsId = GeneratedModeId("eight-pairs")
 
+    val THREE_PAIRS_LOW: GeneratedChallenge = GeneratedChallenge(
+        id = GeneratedChallengeId("three-pairs-low"),
+        modeId = threePairsId,
+        difficulty = DifficultyTier.LOW,
+        profile = GeneratedPuzzleProfiles.THREE_PAIRS_LOW
+    )
     val FOUR_PAIRS_LOW: GeneratedChallenge = GeneratedChallenge(
         id = GeneratedChallengeId("four-pairs-low"),
         modeId = fourPairsId,
@@ -160,6 +167,11 @@ object GeneratedModes {
         difficulty = DifficultyTier.HARD,
         profile = GeneratedPuzzleProfiles.EIGHT_PAIRS_HARD
     )
+    val THREE_PAIRS: GeneratedModeConfiguration = GeneratedModeConfiguration(
+        id = threePairsId,
+        size = GeneratedPuzzleProfiles.THREE_PAIRS_LOW.size,
+        challenges = listOf(THREE_PAIRS_LOW)
+    )
     val FOUR_PAIRS: GeneratedModeConfiguration = GeneratedModeConfiguration(
         id = fourPairsId,
         size = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW.size,
@@ -171,6 +183,6 @@ object GeneratedModes {
         challenges = listOf(EIGHT_PAIRS_MEDIUM, EIGHT_PAIRS_HARD)
     )
     val catalog: GeneratedChallengeCatalog = GeneratedChallengeCatalog(
-        configurations = listOf(FOUR_PAIRS, EIGHT_PAIRS)
+        configurations = listOf(THREE_PAIRS, FOUR_PAIRS, EIGHT_PAIRS)
     )
 }

--- a/app/src/test/java/org/cescfe/numpairs/data/generated/selection/DataStoreGeneratedDifficultySelectionRepositoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/generated/selection/DataStoreGeneratedDifficultySelectionRepositoryTest.kt
@@ -43,6 +43,7 @@ class DataStoreGeneratedDifficultySelectionRepositoryTest {
     fun fresh_preferences_expose_mode_specific_fallbacks_without_persisting_them() = runBlocking {
         val fixture = createRepository()
 
+        assertNull(fixture.repository.selectedDifficulty(GeneratedModes.THREE_PAIRS.id).first())
         assertEquals(
             DifficultyTier.LOW,
             fixture.repository.selectedDifficulty(GeneratedModes.FOUR_PAIRS.id).first()
@@ -52,6 +53,25 @@ class DataStoreGeneratedDifficultySelectionRepositoryTest {
             fixture.repository.selectedDifficulty(GeneratedModes.EIGHT_PAIRS.id).first()
         )
         assertTrue(fixture.dataStore.data.first().asMap().isEmpty())
+    }
+
+    @Test
+    fun quick_has_no_remembered_difficulty_selection_or_writable_preference() {
+        val fixture = createRepository()
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                fixture.repository.selectDifficulty(
+                    GeneratedModes.THREE_PAIRS.id,
+                    DifficultyTier.LOW
+                )
+            }
+        }
+
+        runBlocking {
+            assertNull(fixture.repository.selectedDifficulty(GeneratedModes.THREE_PAIRS.id).first())
+            assertTrue(fixture.dataStore.data.first().asMap().isEmpty())
+        }
     }
 
     @Test

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/ConfiguredGeneratedPuzzleGenerationUseCaseFactoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/ConfiguredGeneratedPuzzleGenerationUseCaseFactoryTest.kt
@@ -29,6 +29,23 @@ import org.junit.Test
 
 class ConfiguredGeneratedPuzzleGenerationUseCaseFactoryTest {
     @Test
+    fun quick_challenge_generates_through_its_immutable_profile_context() = runBlocking {
+        val challenge = GeneratedModes.THREE_PAIRS_LOW
+        val factory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
+            generationDispatcher = Dispatchers.Unconfined
+        )
+        val context = factory.contextFor(challenge)
+
+        val result = factory.create(challenge).generate(
+            GeneratedPuzzleGenerationRequest(profile = challenge.profile, seed = 2026)
+        ) as GeneratedPuzzleGenerationResult.Generated
+
+        assertSame(challenge.profile, context.profile)
+        assertEquals(challenge.profile.size.stripEntryCount, result.initialPuzzle.strip.entries.size)
+        assertEquals(challenge.profile.size.boardTileCount, result.initialPuzzle.board.tiles.size)
+    }
+
+    @Test
     fun every_registered_challenge_uses_its_profile_and_a_shared_context() = runBlocking {
         val factory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
             generationDispatcher = Dispatchers.Unconfined

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedChallengeCatalogTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedChallengeCatalogTest.kt
@@ -26,6 +26,7 @@ class GeneratedChallengeCatalogTest {
             listOf(DifficultyTier.LOW, DifficultyTier.MEDIUM, DifficultyTier.HARD),
             DifficultyTier.entries
         )
+        assertEquals(DifficultyTier.LOW, GeneratedPuzzleProfiles.THREE_PAIRS_LOW.difficulty)
         assertEquals(DifficultyTier.LOW, GeneratedPuzzleProfiles.FOUR_PAIRS_LOW.difficulty)
         assertEquals(DifficultyTier.MEDIUM, GeneratedPuzzleProfiles.FOUR_PAIRS_MEDIUM.difficulty)
         assertEquals(DifficultyTier.MEDIUM, GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM.difficulty)
@@ -33,21 +34,49 @@ class GeneratedChallengeCatalogTest {
     }
 
     @Test
-    fun configured_catalog_registers_low_and_medium_for_four_pairs() {
+    fun configured_catalog_registers_only_the_supported_sparse_challenges() {
+        assertEquals("three-pairs", GeneratedModes.THREE_PAIRS.id.value)
         assertEquals("four-pairs", GeneratedModes.FOUR_PAIRS.id.value)
         assertEquals("eight-pairs", GeneratedModes.EIGHT_PAIRS.id.value)
+        assertEquals("three-pairs-low", GeneratedModes.THREE_PAIRS_LOW.id.value)
+        assertEquals("3-pairs-low", GeneratedModes.THREE_PAIRS_LOW.profile.id.value)
         assertEquals("4-pairs-low", GeneratedModes.FOUR_PAIRS_LOW.profile.id.value)
         assertEquals("4-pairs-medium", GeneratedModes.FOUR_PAIRS_MEDIUM.profile.id.value)
         assertEquals("8-pairs-medium", GeneratedModes.EIGHT_PAIRS_MEDIUM.profile.id.value)
         assertEquals("8-pairs-hard", GeneratedModes.EIGHT_PAIRS_HARD.profile.id.value)
         assertEquals(
             listOf(
+                GeneratedModes.THREE_PAIRS_LOW,
                 GeneratedModes.FOUR_PAIRS_LOW,
                 GeneratedModes.FOUR_PAIRS_MEDIUM,
                 GeneratedModes.EIGHT_PAIRS_MEDIUM,
                 GeneratedModes.EIGHT_PAIRS_HARD
             ),
             GeneratedModes.catalog.allChallenges
+        )
+        assertEquals(
+            listOf(GeneratedModes.THREE_PAIRS, GeneratedModes.FOUR_PAIRS, GeneratedModes.EIGHT_PAIRS),
+            GeneratedModes.catalog.all
+        )
+        assertEquals(listOf(GeneratedModes.THREE_PAIRS_LOW), GeneratedModes.THREE_PAIRS.challenges)
+        assertEquals(3, GeneratedModes.THREE_PAIRS.size.pairCount)
+        assertSame(
+            GeneratedModes.THREE_PAIRS_LOW,
+            GeneratedModes.catalog.resolveChallenge(
+                modeId = GeneratedModes.THREE_PAIRS.id,
+                difficulty = DifficultyTier.LOW
+            )
+        )
+        assertSame(
+            GeneratedModes.THREE_PAIRS_LOW,
+            GeneratedModes.catalog.resolveChallenge(
+                modeId = GeneratedModes.THREE_PAIRS.id,
+                profileId = GeneratedPuzzleProfiles.THREE_PAIRS_LOW.id
+            )
+        )
+        assertSame(
+            GeneratedModes.THREE_PAIRS_LOW,
+            GeneratedModes.catalog.resolveChallenge(GeneratedChallengeId("three-pairs-low"))
         )
         assertSame(
             GeneratedModes.FOUR_PAIRS_MEDIUM,
@@ -204,6 +233,24 @@ class GeneratedChallengeCatalogTest {
     fun unsupported_mode_difficulty_profile_and_challenge_resolutions_are_rejected() {
         assertThrows(IllegalArgumentException::class.java) {
             GeneratedModes.catalog.resolveChallenge(GeneratedChallengeId("unknown"))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedModes.catalog.resolveChallenge(
+                modeId = GeneratedModes.THREE_PAIRS.id,
+                difficulty = DifficultyTier.MEDIUM
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedModes.catalog.resolveChallenge(
+                modeId = GeneratedModes.THREE_PAIRS.id,
+                difficulty = DifficultyTier.HARD
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedModes.catalog.resolveChallenge(
+                modeId = GeneratedModes.THREE_PAIRS.id,
+                profileId = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW.id
+            )
         }
         assertThrows(IllegalArgumentException::class.java) {
             GeneratedModes.catalog.resolveChallenge(

--- a/app/src/test/java/org/cescfe/numpairs/ui/navigation/ResumableGeneratedSessionTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/ui/navigation/ResumableGeneratedSessionTest.kt
@@ -15,15 +15,21 @@ import org.junit.Test
 class ResumableGeneratedSessionTest {
     @Test
     fun `valid unfinished snapshot resolves its exact configured challenge`() {
-        val snapshot = snapshot()
-
-        assertEquals(
-            ResumableGeneratedSession(
-                sessionId = snapshot.sessionId,
-                challenge = GeneratedModes.FOUR_PAIRS_LOW
-            ),
-            snapshot.toResumableGeneratedSessionOrNull(GeneratedModes.catalog)
-        )
+        listOf(
+            snapshot() to GeneratedModes.FOUR_PAIRS_LOW,
+            snapshot(
+                modeId = GeneratedModes.THREE_PAIRS.id.value,
+                profileId = GeneratedModes.THREE_PAIRS_LOW.profile.id.value
+            ) to GeneratedModes.THREE_PAIRS_LOW
+        ).forEach { (snapshot, expectedChallenge) ->
+            assertEquals(
+                ResumableGeneratedSession(
+                    sessionId = snapshot.sessionId,
+                    challenge = expectedChallenge
+                ),
+                snapshot.toResumableGeneratedSessionOrNull(GeneratedModes.catalog)
+            )
+        }
     }
 
     @Test
@@ -33,6 +39,18 @@ class ResumableGeneratedSessionTest {
             null,
             snapshot(modeId = "unknown-mode"),
             snapshot(profileId = GeneratedModes.EIGHT_PAIRS_MEDIUM.profile.id.value),
+            snapshot(
+                modeId = GeneratedModes.THREE_PAIRS.id.value,
+                profileId = GeneratedModes.FOUR_PAIRS_LOW.profile.id.value
+            ),
+            snapshot(
+                modeId = GeneratedModes.FOUR_PAIRS.id.value,
+                profileId = GeneratedModes.THREE_PAIRS_LOW.profile.id.value
+            ),
+            snapshot(
+                modeId = GeneratedModes.THREE_PAIRS.id.value,
+                profileId = "three-pairs-medium"
+            ),
             snapshot(
                 initialPuzzle = initialPuzzleFor(solvedPuzzle),
                 currentPuzzle = solvedPuzzle

--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -5,7 +5,8 @@
 - Status: product reference for generated puzzle construction
 - Implemented profiles: generated `3 Pairs Low`, `4 Pairs Low`, `4 Pairs Medium`,
   `8 Pairs Medium`, and `8 Pairs Hard`
-- Planned v10 mode registration: present generated `3 Pairs Low` to players as Quick
+- Implemented v10 challenge registration: generated `3 Pairs Low` is the only Quick challenge
+- Planned v10 presentation: expose Quick through generated play and the Menu
 - v8 generated challenge matrix: implemented
 - Related references:
   - `docs/product/prd/prd-v5.md`
@@ -54,11 +55,11 @@ assessment policy, and validation expectations for one challenge. Absolute profi
 calibrated per challenge: Medium has shared product meaning, but `4 Pairs Medium` does not copy raw
 sixteen-entry counts from `8 Pairs Medium`.
 
-The implemented v8 catalog and planned v10 Quick addition form a sparse catalog:
+The implemented generated-challenge catalog is sparse:
 
 | Generated mode | Low | Medium | Hard |
 | --- | --- | --- | --- |
-| `Quick` (`3 Pairs`) | Profile implemented; mode registration planned | Unsupported | Unsupported |
+| `Quick` (`3 Pairs`) | Supported | Unsupported | Unsupported |
 | `4 Pairs` | Supported | Supported | Unsupported |
 | `8 Pairs` | Unsupported | Supported | Supported |
 
@@ -207,7 +208,7 @@ session slot.
 
 ### Quick / `3 Pairs Low`
 
-Status: generated profile implemented; Quick mode registration planned for v10.
+Status: generated profile and challenge registration implemented; Quick presentation planned.
 
 Player-facing identity:
 

--- a/docs/technical/generated-session-persistence.md
+++ b/docs/technical/generated-session-persistence.md
@@ -2,8 +2,10 @@
 
 ## Document Status
 
-- Status: implemented v7 session persistence and v8 remembered-difficulty preference boundaries
-- Product contracts: `docs/product/prd/prd-v7.md` and `docs/product/prd/prd-v8.md`
+- Status: implemented normal generated-session persistence, remembered selectors, and v10 Quick
+  challenge identity
+- Product contracts: `docs/product/prd/prd-v7.md`, `docs/product/prd/prd-v8.md`, and
+  `docs/product/prd/prd-v10.md`
 - Related generation reference: `docs/product/puzzle-generation.md`
 - Related domain decision: `docs/technical/adr/adr-005-model-sparse-generated-challenges.md`
 - Planned Daily boundary: `docs/technical/daily-challenge-persistence.md`
@@ -17,10 +19,9 @@ generation profiles, or menu copy.
 ## Scope And Ownership
 
 NumPairs stores at most one normal generated session for the whole application. The slot may
-belong to any challenge in the supported generated-challenge catalog: `4 Pairs Low`,
-`4 Pairs Medium`, `8 Pairs Medium`, or `8 Pairs Hard` in v8, plus Quick `3 Pairs Low` when v10 is
-implemented. There is no independent normal save per mode, normal generated history, account sync,
-or manual save management.
+belong to any challenge in the supported generated-challenge catalog: Quick `3 Pairs Low`,
+`4 Pairs Low`, `4 Pairs Medium`, `8 Pairs Medium`, or `8 Pairs Hard`. There is no independent
+normal save per mode, normal generated history, account sync, or manual save management.
 
 `MainActivity` creates one application-scoped `GeneratedSessionRepository` from
 application-private storage and passes it only through generated-play and unlocked-navigation
@@ -39,14 +40,17 @@ the generated-session repository never owns or mutates selector defaults.
 
 ## Remembered Difficulty Selection
 
-The application keeps one stable difficulty id for each generated mode in local preference
-storage. The preference boundary exposes an observable effective selection per mode and accepts
-only mode/difficulty pairs present in the supported challenge catalog.
+The application keeps one stable difficulty id for each generated mode that exposes a difficulty
+selector in local preference storage. The preference boundary exposes an observable effective
+selection only for configured selector modes and accepts only configured mode/difficulty pairs
+present in the supported challenge catalog.
 
-The effective fallback is `Low` for `4 Pairs` and `Medium` for `8 Pairs`. Missing, corrupt,
-unknown, and no-longer-supported stored values resolve to that fallback without writing it back.
-The only operation that writes a remembered selection is an explicit supported option choice made
-by the player in that mode's anchored difficulty popup in the normal menu.
+The effective fallback is `Low` for `4 Pairs` and `Medium` for `8 Pairs`. Quick exposes only Low,
+has no selector fallback or remembered preference, and rejects preference writes. Missing,
+corrupt, unknown, and no-longer-supported stored values resolve to the selector mode's fallback
+without writing it back. The only operation that writes a remembered selection is an explicit
+supported option choice made by the player in that mode's anchored difficulty popup in the normal
+menu.
 
 Opening or dismissing the popup, showing a fallback, pressing a mode's play region, resuming or
 restoring a session, replacing a session, completing a puzzle, and using `Play another` do not
@@ -56,8 +60,9 @@ other v8 behavior stores progression, locks, completion counts, rewards, or stat
 The remembered values live in the dedicated Preferences DataStore file
 `datastore/generated_difficulty_selection.preferences_pb`. This keeps the aggregate and its
 corruption recovery independent from personalization, onboarding, and the resumable generated
-session. The file stores one stable difficulty id under each stable generated-mode identity; it
-does not store display copy, profile parameters, completion data, or transient selector state.
+session. The file stores one stable difficulty id under each selector-enabled generated-mode
+identity; it does not store a Quick value, display copy, profile parameters, completion data, or
+transient selector state.
 
 `MainActivity` creates one application-scoped remembered-difficulty repository. The unlocked Menu
 route observes both effective selections and receives the write operation used by its
@@ -80,11 +85,12 @@ Schema version `1` continues to store:
 The seed is diagnostic and generation metadata. Restoration never reruns the generator because a
 generator or profile implementation may change after the session was created.
 
-The stored mode/profile pair resolves one exact supported `GeneratedChallenge`; v8 does not assume
-that a mode has only one profile. The existing `4 Pairs Low` and `8 Pairs Medium` ids retain their
-meaning, so valid schema-1 snapshots for those challenges remain compatible. An unknown mode,
-unknown profile, unsupported pair, or profile whose declared mode differs from the stored mode is
-invalid session data and is exposed as an empty slot.
+The stored mode/profile pair resolves one exact supported `GeneratedChallenge`; restoration does
+not assume that a mode has only one profile. Quick uses `three-pairs` with `3-pairs-low`; the
+existing `4 Pairs Low` and `8 Pairs Medium` ids retain their meaning, so valid schema-1 snapshots
+for those challenges remain compatible. An unknown mode, unknown profile, unsupported pair, or
+profile whose declared mode differs from the stored mode is invalid session data and is exposed
+as an empty slot.
 
 The initial and current puzzles preserve:
 


### PR DESCRIPTION
## Related Issue

Resolves #585

## Summary

- Register `three-pairs` and its single `three-pairs-low` challenge before the existing generated modes.
- Resolve Quick through generic generation and normal-session restoration while rejecting unsupported identities.
- Keep remembered difficulty selection limited to the selector-enabled 4 Pairs and 8 Pairs modes.