### PR TITLE
[283] Share generated learning presentation with Quick

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
@@ -25,6 +25,11 @@ class LocalizationResourceTest {
         )
         assertEquals("Cómo jugar", resources.getString(R.string.menu_tutorial_button))
         assertEquals("Ajustes", resources.getString(R.string.menu_settings_action_content_description))
+        assertEquals("Quick", resources.getString(R.string.quick_screen_title))
+        assertEquals(
+            "Quick · Baja",
+            resources.getString(R.string.generated_challenge_title, "Quick", "Baja")
+        )
         assertEquals("8 pares", resources.getString(R.string.eight_pairs_screen_title))
         assertEquals("Alta", resources.getString(R.string.generated_difficulty_hard))
         assertEquals(
@@ -92,6 +97,11 @@ class LocalizationResourceTest {
         )
         assertEquals("Com jugar", resources.getString(R.string.menu_tutorial_button))
         assertEquals("Configuració", resources.getString(R.string.menu_settings_action_content_description))
+        assertEquals("Quick", resources.getString(R.string.quick_screen_title))
+        assertEquals(
+            "Quick · Baixa",
+            resources.getString(R.string.generated_challenge_title, "Quick", "Baixa")
+        )
         assertEquals("8 parelles", resources.getString(R.string.eight_pairs_screen_title))
         assertEquals("Alta", resources.getString(R.string.generated_difficulty_hard))
         assertEquals(
@@ -159,6 +169,11 @@ class LocalizationResourceTest {
         )
         assertEquals("How to play", resources.getString(R.string.menu_tutorial_button))
         assertEquals("Settings", resources.getString(R.string.menu_settings_action_content_description))
+        assertEquals("Quick", resources.getString(R.string.quick_screen_title))
+        assertEquals(
+            "Quick · Low",
+            resources.getString(R.string.generated_challenge_title, "Quick", "Low")
+        )
         assertEquals("8 pairs", resources.getString(R.string.eight_pairs_screen_title))
         assertEquals("Hard", resources.getString(R.string.generated_difficulty_hard))
         assertEquals(

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/eightpairs/EightPairsModeTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/eightpairs/EightPairsModeTest.kt
@@ -89,6 +89,12 @@ class EightPairsModeTest {
                 )
             )
             .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.RULES_HELPER_ACTION)
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.HINT_ACTION)
+            .assertDoesNotExist()
         assertEquals(1, puzzleProvider.requestCount)
     }
 

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/fourpairs/FourPairsActionDiscoveryTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/fourpairs/FourPairsActionDiscoveryTest.kt
@@ -16,6 +16,8 @@ import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryState
 import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
+import org.cescfe.numpairs.feature.generated.GeneratedLearningRoute
+import org.cescfe.numpairs.feature.generated.GeneratedModes
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationResult
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCase
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
@@ -36,7 +38,9 @@ class FourPairsActionDiscoveryTest {
 
         composeTestRule.setContent {
             NumPairsTheme {
-                FourPairsRoute(
+                GeneratedLearningRoute(
+                    challenge = GeneratedModes.FOUR_PAIRS_LOW,
+                    title = "4 Pairs · Low",
                     generationUseCase = generatedPuzzleUseCase(puzzle = samplePuzzle),
                     generatedSessionRepository = FakeGeneratedSessionRepository(),
                     topAppBarActionDiscoveryRepository = actionDiscoveryRepository
@@ -70,7 +74,9 @@ class FourPairsActionDiscoveryTest {
 
         composeTestRule.setContent {
             NumPairsTheme {
-                FourPairsRoute(
+                GeneratedLearningRoute(
+                    challenge = GeneratedModes.FOUR_PAIRS_LOW,
+                    title = "4 Pairs · Low",
                     generationUseCase = generatedPuzzleUseCase(puzzle = samplePuzzle),
                     generatedSessionRepository = FakeGeneratedSessionRepository(),
                     topAppBarActionDiscoveryRepository = actionDiscoveryRepository

--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionResumeNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionResumeNavigationTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -17,6 +18,10 @@ import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
 import org.cescfe.numpairs.data.preferences.FakePersonalizationPreferencesRepository
 import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.domain.puzzle.model.Board
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.Strip
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
 import org.cescfe.numpairs.feature.generated.GeneratedModes
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationResult
@@ -113,6 +118,59 @@ class GeneratedSessionResumeNavigationTest {
         }
     }
 
+    @Test
+    fun quick_session_resume_uses_quick_title_and_the_shared_learning_route_without_generation() {
+        val initialPuzzle = quickPuzzle()
+        val currentPuzzle = initialPuzzle.copy(
+            strip = initialPuzzle.strip.withUpdatedEntry(index = 1, value = 3)
+        )
+        val snapshot = GeneratedSessionSnapshot(
+            sessionId = GeneratedSessionId("resume-quick"),
+            modeId = GeneratedModes.THREE_PAIRS.id.value,
+            profileId = GeneratedModes.THREE_PAIRS_LOW.profile.id.value,
+            seed = 283,
+            initialPuzzle = initialPuzzle,
+            currentPuzzle = currentPuzzle
+        )
+        val repository = FakeGeneratedSessionRepository(initialSession = snapshot)
+        val generationCounter = GenerationCounter()
+        setContent(repository = repository, generationCounter = generationCounter)
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.RESUME_BUTTON)
+            .assertIsDisplayed()
+            .assertContentDescriptionEquals(
+                string(
+                    R.string.menu_resume_content_description,
+                    challengeName(R.string.quick_screen_title, R.string.generated_difficulty_low)
+                )
+            )
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText(
+                challengeName(R.string.quick_screen_title, R.string.generated_difficulty_low)
+            )
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.RULES_HELPER_ACTION)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.HINT_ACTION)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.stripItem(5))
+            .performScrollTo()
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.stripItem(6))
+            .assertDoesNotExist()
+        composeTestRule.runOnIdle {
+            assertEquals(0, generationCounter.count)
+            assertEquals(snapshot, repository.session.value)
+        }
+    }
+
     private fun setContent(
         repository: FakeGeneratedSessionRepository,
         generationCounter: GenerationCounter = GenerationCounter()
@@ -147,6 +205,20 @@ class GeneratedSessionResumeNavigationTest {
         R.string.generated_challenge_title,
         string(modeNameResource),
         string(difficultyNameResource)
+    )
+
+    private fun quickPuzzle(): Puzzle = Puzzle(
+        board = Board(tiles = samplePuzzle.board.tiles.take(6)),
+        strip = Strip.fromItems(
+            items = listOf(
+                StripItem.Hidden,
+                StripItem.Hidden,
+                StripItem.Known(5),
+                StripItem.Hidden,
+                StripItem.Hidden,
+                StripItem.Known(15)
+            )
+        )
     )
 
     private class GenerationCounter {

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedChallengePresentation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedChallengePresentation.kt
@@ -8,6 +8,7 @@ import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
 
 @StringRes
 internal fun GeneratedModeConfiguration.titleResourceIdOrNull(): Int? = when (id) {
+    GeneratedModes.THREE_PAIRS.id -> R.string.quick_screen_title
     GeneratedModes.FOUR_PAIRS.id -> R.string.four_pairs_screen_title
     GeneratedModes.EIGHT_PAIRS.id -> R.string.eight_pairs_screen_title
     else -> null

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedLearningRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedLearningRoute.kt
@@ -1,4 +1,4 @@
-package org.cescfe.numpairs.feature.fourpairs
+package org.cescfe.numpairs.feature.generated
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -8,31 +8,24 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.launch
-import org.cescfe.numpairs.R
 import org.cescfe.numpairs.data.generated.session.GeneratedSessionRepository
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryRepository
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryState
 import org.cescfe.numpairs.feature.game.ui.actions.HintAction
 import org.cescfe.numpairs.feature.game.ui.help.SolvingTipsDialog
-import org.cescfe.numpairs.feature.generated.GeneratedChallenge
-import org.cescfe.numpairs.feature.generated.GeneratedModeLaunchIntent
-import org.cescfe.numpairs.feature.generated.GeneratedModeRoute
-import org.cescfe.numpairs.feature.generated.GeneratedModes
-import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCase
 import org.cescfe.numpairs.feature.tutorial.TutorialMode
 import org.cescfe.numpairs.feature.tutorial.TutorialOverlayHost
 
 @Composable
-fun FourPairsRoute(
+fun GeneratedLearningRoute(
+    challenge: GeneratedChallenge,
+    title: String,
     topAppBarActionDiscoveryRepository: TopAppBarActionDiscoveryRepository,
     generatedSessionRepository: GeneratedSessionRepository,
     modifier: Modifier = Modifier,
     generationUseCase: GeneratedPuzzleGenerationUseCase,
     launchIntent: GeneratedModeLaunchIntent = GeneratedModeLaunchIntent.DefaultNewPuzzle,
-    challenge: GeneratedChallenge = GeneratedModes.FOUR_PAIRS_LOW,
-    title: String? = null,
     isGeneratedGameHapticsEnabled: Boolean = true,
     tutorialOverlayMode: TutorialMode? = null,
     onTutorialOverlayClosed: () -> Unit = {},
@@ -60,7 +53,7 @@ fun FourPairsRoute(
         GeneratedModeRoute(
             challenge = challenge,
             launchIntent = launchIntent,
-            title = title ?: stringResource(R.string.four_pairs_screen_title),
+            title = title,
             generationUseCase = generationUseCase,
             generatedSessionRepository = generatedSessionRepository,
             isGeneratedGameHapticsEnabled = isGeneratedGameHapticsEnabled,

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -14,10 +14,10 @@ import org.cescfe.numpairs.data.onboarding.OnboardingRepository
 import org.cescfe.numpairs.data.onboarding.OnboardingState
 import org.cescfe.numpairs.data.preferences.PersonalizationPreferencesRepository
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryRepository
-import org.cescfe.numpairs.feature.fourpairs.FourPairsRoute
 import org.cescfe.numpairs.feature.generated.GeneratedChallenge
 import org.cescfe.numpairs.feature.generated.GeneratedChallengeCatalog
 import org.cescfe.numpairs.feature.generated.GeneratedChallengeId
+import org.cescfe.numpairs.feature.generated.GeneratedLearningRoute
 import org.cescfe.numpairs.feature.generated.GeneratedModeLaunchIntent
 import org.cescfe.numpairs.feature.generated.GeneratedModeRoute
 import org.cescfe.numpairs.feature.generated.GeneratedModes
@@ -196,7 +196,8 @@ private fun UnlockedAppNavigation(
             }
 
             when (mode.id) {
-                GeneratedModes.FOUR_PAIRS.id -> FourPairsRoute(
+                GeneratedModes.THREE_PAIRS.id,
+                GeneratedModes.FOUR_PAIRS.id -> GeneratedLearningRoute(
                     modifier = modifier,
                     title = challengeTitle,
                     challenge = challenge,

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -42,10 +42,9 @@
     <string name="personalization_haptics_enabled">Activada</string>
     <string name="personalization_haptics_disabled">Desactivada</string>
 
-    <!-- Four pairs screen -->
+    <!-- Generated mode screens -->
+    <string name="quick_screen_title">Quick</string>
     <string name="four_pairs_screen_title">4 parelles</string>
-
-    <!-- Eight pairs screen -->
     <string name="eight_pairs_screen_title">8 parelles</string>
 
     <!-- Generated puzzle creation -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -42,10 +42,9 @@
     <string name="personalization_haptics_enabled">Activada</string>
     <string name="personalization_haptics_disabled">Desactivada</string>
 
-    <!-- Four pairs screen -->
+    <!-- Generated mode screens -->
+    <string name="quick_screen_title">Quick</string>
     <string name="four_pairs_screen_title">4 pares</string>
-
-    <!-- Eight pairs screen -->
     <string name="eight_pairs_screen_title">8 pares</string>
 
     <!-- Generated puzzle creation -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,10 +42,9 @@
     <string name="personalization_haptics_enabled">Enabled</string>
     <string name="personalization_haptics_disabled">Disabled</string>
 
-    <!-- Four pairs screen -->
+    <!-- Generated mode screens -->
+    <string name="quick_screen_title">Quick</string>
     <string name="four_pairs_screen_title">4 pairs</string>
-
-    <!-- Eight pairs screen -->
     <string name="eight_pairs_screen_title">8 pairs</string>
 
     <!-- Generated puzzle creation -->

--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -6,7 +6,8 @@
 - Implemented profiles: generated `3 Pairs Low`, `4 Pairs Low`, `4 Pairs Medium`,
   `8 Pairs Medium`, and `8 Pairs Hard`
 - Implemented v10 challenge registration: generated `3 Pairs Low` is the only Quick challenge
-- Planned v10 presentation: expose Quick through generated play and the Menu
+- Implemented v10 generated presentation: Quick uses the shared Low learning route
+- Planned v10 Menu exposure: add the direct Quick entry point
 - v8 generated challenge matrix: implemented
 - Related references:
   - `docs/product/prd/prd-v5.md`
@@ -208,7 +209,8 @@ session slot.
 
 ### Quick / `3 Pairs Low`
 
-Status: generated profile and challenge registration implemented; Quick presentation planned.
+Status: generated profile, challenge registration, and shared learning presentation implemented;
+direct Menu exposure planned.
 
 Player-facing identity:
 

--- a/docs/product/visual-design-system.md
+++ b/docs/product/visual-design-system.md
@@ -4,7 +4,7 @@
 
 This document defines the current NumPairs visual design system. It originated in the
 `v4 - Visual Design System & UI Refinement` milestone and is updated through
-`v9 - Game Feel & Personalization`.
+`v9 - Game Feel & Personalization`, with the v10 Quick generated-learning extension.
 
 The goal is to establish a practical design system for implementation, not a speculative brand book. It should guide reusable Compose theme decisions, shared component defaults, and visual QA for the existing product screens.
 
@@ -576,7 +576,7 @@ The implemented v9 generated-game feedback adds:
 - a short entrance for a replacement puzzle only after its successor session is safely
   stored and adopted
 
-Those motions are enabled only by generated `4 Pairs` and `8 Pairs` routes. Tutorial,
+Those motions are enabled only by generated Quick, `4 Pairs`, and `8 Pairs` routes. Tutorial,
 required onboarding, voluntary `How to play`, restored state, and recomposition do not gain
 or replay v9 feedback. Motion does not resize layout or touch targets, block actions, or
 carry meaning that is absent from the final static state.
@@ -591,6 +591,18 @@ Avoid:
 
 When Android animation duration is disabled, each treatment reaches the same usable final
 state immediately.
+
+### Generated Learning Presentation
+
+Quick and `4 Pairs` use the shared `GeneratedLearningRoute` around the generic generated-game
+presentation. It reuses the existing Rules Helper, Solving Tips, authored Tutorial overlay,
+discovery indicators, game feedback, completion actions, and design-system components without
+introducing size-specific visual roles.
+
+`8 Pairs` continues to use the generic generated route without the Low learning actions. The
+shared wrapper changes ownership only: spacing, typography, shapes, semantic colors, motion,
+touch targets, failure handling, and reduced-motion behavior remain those of the established
+generated and game surfaces.
 
 ---
 


### PR DESCRIPTION
## Related Issue

Resolves #586

## Summary

- Replace the size-owned Four Pairs wrapper with a challenge-driven `GeneratedLearningRoute` shared by Quick and 4 Pairs.
- Add localized Quick titles and route exact Quick sessions through normal generated restoration and Low learning actions.
- Preserve generic generated feedback and keep 8 Pairs free of Low-only learning actions, with focused navigation and localization coverage.

## UI Consistency

- Shared components or tokens reused: existing `GeneratedModeRoute`, `GameRoute`, Rules Helper, Solving Tips, Tutorial overlay, discovery indicators, and NumPairs design-system roles.
- Intentional deviations from established visual roles: none; this changes presentation ownership and title resources without changing layout, color, typography, motion, shape, or touch geometry.