### PR TITLE
[284] Launch Quick directly from Menu

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/LocalizationResourceTest.kt
@@ -30,6 +30,10 @@ class LocalizationResourceTest {
             "Quick · Baja",
             resources.getString(R.string.generated_challenge_title, "Quick", "Baja")
         )
+        assertEquals(
+            "Jugar puzle Quick, 3 pares, dificultad Baja",
+            resources.getString(R.string.menu_play_quick_content_description, "Quick", "3 pares", "Baja")
+        )
         assertEquals("8 pares", resources.getString(R.string.eight_pairs_screen_title))
         assertEquals("Alta", resources.getString(R.string.generated_difficulty_hard))
         assertEquals(
@@ -102,6 +106,15 @@ class LocalizationResourceTest {
             "Quick · Baixa",
             resources.getString(R.string.generated_challenge_title, "Quick", "Baixa")
         )
+        assertEquals(
+            "Juga al puzle Quick, 3 parelles, dificultat Baixa",
+            resources.getString(
+                R.string.menu_play_quick_content_description,
+                "Quick",
+                "3 parelles",
+                "Baixa"
+            )
+        )
         assertEquals("8 parelles", resources.getString(R.string.eight_pairs_screen_title))
         assertEquals("Alta", resources.getString(R.string.generated_difficulty_hard))
         assertEquals(
@@ -173,6 +186,10 @@ class LocalizationResourceTest {
         assertEquals(
             "Quick · Low",
             resources.getString(R.string.generated_challenge_title, "Quick", "Low")
+        )
+        assertEquals(
+            "Play Quick puzzle, 3 pairs, Low difficulty",
+            resources.getString(R.string.menu_play_quick_content_description, "Quick", "3 pairs", "Low")
         )
         assertEquals("8 pairs", resources.getString(R.string.eight_pairs_screen_title))
         assertEquals("Hard", resources.getString(R.string.generated_difficulty_hard))

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTest.kt
@@ -79,6 +79,52 @@ class MenuScreenTest {
     }
 
     @Test
+    fun quick_is_one_accessible_primary_action_without_a_difficulty_selector() {
+        var quickClickCount = 0
+        setContent(
+            onQuickSelected = {
+                quickClickCount += 1
+            }
+        )
+
+        val quickNode = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.QUICK_BUTTON)
+            .assertIsDisplayed()
+            .assertTextEquals(string(R.string.quick_screen_title))
+            .assertContentDescriptionEquals(
+                string(
+                    R.string.menu_play_quick_content_description,
+                    string(R.string.quick_screen_title),
+                    string(R.string.three_pairs_accessibility_name),
+                    string(R.string.generated_difficulty_low)
+                )
+            )
+            .assertHasClickAction()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.QUICK_DIFFICULTY_BUTTON)
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_DIFFICULTY_BUTTON)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.EIGHT_PAIRS_DIFFICULTY_BUTTON)
+            .assertIsDisplayed()
+
+        val quickTop = quickNode.fetchSemanticsNode().boundsInRoot.top
+        val fourPairsTop = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
+            .fetchSemanticsNode()
+            .boundsInRoot
+            .top
+        assertTrue(quickTop < fourPairsTop)
+
+        quickNode.performClick()
+        composeTestRule.runOnIdle {
+            assertEquals(1, quickClickCount)
+        }
+    }
+
+    @Test
     fun generated_mode_rows_identify_the_selected_challenge_and_emit_distinct_actions() {
         var playCount = 0
         var selectedDifficulty: GeneratedDifficultyMenuOptionId? = null
@@ -288,6 +334,14 @@ class MenuScreenTest {
             .assertIsDisplayed()
             .fetchSemanticsNode()
             .boundsInRoot
+        val quickBounds = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.QUICK_BUTTON)
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+            .boundsInRoot
+        assertEquals(tutorialBounds.left, quickBounds.left, 0.5f)
+        assertEquals(tutorialBounds.right, quickBounds.right, 0.5f)
+        assertEquals(tutorialBounds.height, quickBounds.height, 0.5f)
         val dividerWidth = with(composeTestRule.density) {
             NumPairsComponents.ThinBorderWidth.toPx()
         }
@@ -344,12 +398,43 @@ class MenuScreenTest {
 
         val tutorialStyle = textStyle(string(R.string.menu_tutorial_button))
         assertEquals(22.sp, tutorialStyle.fontSize)
-        listOf(fourPairsState.challengeName, eightPairsState.challengeName).forEach { challengeName ->
-            val challengeStyle = textStyle(challengeName)
+        listOf(
+            string(R.string.quick_screen_title),
+            fourPairsState.challengeName,
+            eightPairsState.challengeName
+        ).forEach { actionName ->
+            val challengeStyle = textStyle(actionName)
 
             assertEquals(tutorialStyle.fontSize, challengeStyle.fontSize)
             assertEquals(tutorialStyle.fontWeight, challengeStyle.fontWeight)
         }
+    }
+
+    @Test
+    fun compact_height_large_text_and_rtl_keep_quick_scrollable_and_full_width() {
+        setContent(
+            width = 320.dp,
+            height = 360.dp,
+            fontScale = 2f,
+            layoutDirection = LayoutDirection.Rtl
+        )
+
+        val quickBounds = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.QUICK_BUTTON)
+            .performScrollTo()
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val fourPairsBounds = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_SPLIT_CTA)
+            .performScrollTo()
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+            .boundsInRoot
+
+        assertEquals(fourPairsBounds.left, quickBounds.left, 0.5f)
+        assertEquals(fourPairsBounds.right, quickBounds.right, 0.5f)
+        assertEquals(fourPairsBounds.height, quickBounds.height, 0.5f)
     }
 
     private fun assertSelectorEndAlignment(layoutDirection: LayoutDirection) {
@@ -385,6 +470,7 @@ class MenuScreenTest {
         fontScale: Float = 1f,
         layoutDirection: LayoutDirection = LayoutDirection.Ltr,
         onPersonalizationSelected: () -> Unit = {},
+        onQuickSelected: () -> Unit = {},
         onFourPairsSelected: () -> Unit = {},
         onFourPairsDifficultySelected: (GeneratedDifficultyMenuOptionId) -> Unit = {}
     ) {
@@ -402,6 +488,7 @@ class MenuScreenTest {
                         Box(modifier = Modifier.size(width = width, height = height)) {
                             MenuContent(
                                 onPersonalizationSelected = onPersonalizationSelected,
+                                onQuickSelected = onQuickSelected,
                                 onFourPairsSelected = onFourPairsSelected,
                                 onFourPairsDifficultySelected = onFourPairsDifficultySelected
                             )
@@ -409,6 +496,7 @@ class MenuScreenTest {
                     } else {
                         MenuContent(
                             onPersonalizationSelected = onPersonalizationSelected,
+                            onQuickSelected = onQuickSelected,
                             onFourPairsSelected = onFourPairsSelected,
                             onFourPairsDifficultySelected = onFourPairsDifficultySelected
                         )
@@ -421,6 +509,7 @@ class MenuScreenTest {
     @Composable
     private fun MenuContent(
         onPersonalizationSelected: () -> Unit,
+        onQuickSelected: () -> Unit,
         onFourPairsSelected: () -> Unit,
         onFourPairsDifficultySelected: (GeneratedDifficultyMenuOptionId) -> Unit
     ) {
@@ -428,6 +517,7 @@ class MenuScreenTest {
             fourPairsMode = fourPairsState,
             eightPairsMode = eightPairsState,
             onPersonalizationSelected = onPersonalizationSelected,
+            onQuickSelected = onQuickSelected,
             onFourPairsSelected = onFourPairsSelected,
             onFourPairsDifficultySelected = onFourPairsDifficultySelected
         )

--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionChoiceNavigationTest.kt
@@ -67,6 +67,39 @@ class GeneratedSessionChoiceNavigationTest {
     }
 
     @Test
+    fun quick_starts_its_only_challenge_directly_without_writing_difficulty() {
+        val repository = FakeGeneratedSessionRepository()
+        val difficultyRepository = FakeGeneratedDifficultySelectionRepository()
+        val recorder = setContent(
+            repository = repository,
+            difficultyRepository = difficultyRepository
+        )
+
+        composeTestRule.navigateToSelectedGeneratedChallenge(MenuScreenTestTags.QUICK_BUTTON)
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SESSION_CHOICE_DIALOG)
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                challengeName(R.string.quick_screen_title, R.string.generated_difficulty_low)
+            )
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(listOf(GeneratedModes.THREE_PAIRS_LOW), recorder.generatedChallenges)
+            assertEquals(GeneratedModes.THREE_PAIRS.id.value, repository.session.value?.modeId)
+            assertEquals(
+                GeneratedModes.THREE_PAIRS_LOW.profile.id.value,
+                repository.session.value?.profileId
+            )
+            assertTrue(difficultyRepository.explicitSelections.isEmpty())
+        }
+    }
+
+    @Test
     fun same_mode_choice_keeps_resume_primary_and_opens_the_stored_session() {
         val snapshot = resumableFourPairsSnapshot()
         val repository = FakeGeneratedSessionRepository(initialSession = snapshot)
@@ -203,6 +236,49 @@ class GeneratedSessionChoiceNavigationTest {
     }
 
     @Test
+    fun quick_uses_the_shared_choice_dialog_and_a_new_quick_replacement_action() {
+        val snapshot = resumableFourPairsSnapshot()
+        val repository = FakeGeneratedSessionRepository(initialSession = snapshot)
+        val difficultyRepository = FakeGeneratedDifficultySelectionRepository()
+        val recorder = setContent(
+            repository = repository,
+            difficultyRepository = difficultyRepository
+        )
+
+        composeTestRule.navigateToSelectedGeneratedChallenge(MenuScreenTestTags.QUICK_BUTTON)
+
+        assertChoiceDialogVisible()
+        composeTestRule
+            .onNodeWithText(
+                string(
+                    R.string.generated_session_choice_challenge_message,
+                    challengeName(R.string.four_pairs_screen_title, R.string.generated_difficulty_low)
+                )
+            )
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                string(
+                    R.string.generated_session_choice_new_challenge_button,
+                    string(R.string.quick_screen_title)
+                )
+            )
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SESSION_CHOICE_NEW_PUZZLE_BUTTON)
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(listOf(GeneratedModes.THREE_PAIRS_LOW), recorder.generatedChallenges)
+            assertEquals(GeneratedModes.THREE_PAIRS.id.value, repository.session.value?.modeId)
+            assertTrue(difficultyRepository.explicitSelections.isEmpty())
+        }
+    }
+
+    @Test
     fun system_back_and_outside_tap_dismiss_without_side_effects() {
         val snapshot = resumableFourPairsSnapshot()
         val repository = FakeGeneratedSessionRepository(initialSession = snapshot)
@@ -281,10 +357,25 @@ class GeneratedSessionChoiceNavigationTest {
     }
 
     private fun initialPuzzleFor(challenge: GeneratedChallenge): Puzzle = when (challenge.modeId) {
+        GeneratedModes.THREE_PAIRS.id -> quickPuzzle()
         GeneratedModes.FOUR_PAIRS.id -> samplePuzzle
         GeneratedModes.EIGHT_PAIRS.id -> eightPairsPuzzle()
         else -> error("Unsupported test mode ${challenge.modeId.value}.")
     }
+
+    private fun quickPuzzle(): Puzzle = Puzzle(
+        board = Board(tiles = samplePuzzle.board.tiles.take(6)),
+        strip = Strip.fromItems(
+            items = listOf(
+                StripItem.Hidden,
+                StripItem.Hidden,
+                StripItem.Known(5),
+                StripItem.Hidden,
+                StripItem.Hidden,
+                StripItem.Known(15)
+            )
+        )
+    )
 
     private fun eightPairsPuzzle(): Puzzle = Puzzle(
         board = Board(

--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionResumeNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedSessionResumeNavigationTest.kt
@@ -76,6 +76,11 @@ class GeneratedSessionResumeNavigationTest {
                 )
             )
         val resumeTop = resumeNode.fetchSemanticsNode().boundsInRoot.top
+        val quickTop = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.QUICK_BUTTON)
+            .fetchSemanticsNode()
+            .boundsInRoot
+            .top
         val fourPairsTop = composeTestRule
             .onNodeWithTag(MenuScreenTestTags.FOUR_PAIRS_BUTTON)
             .fetchSemanticsNode()
@@ -97,7 +102,8 @@ class GeneratedSessionResumeNavigationTest {
             .boundsInRoot
             .top
         assertTrue(settingsTop < resumeTop)
-        assertTrue(resumeTop < fourPairsTop)
+        assertTrue(resumeTop < quickTop)
+        assertTrue(quickTop < fourPairsTop)
         assertTrue(fourPairsTop < eightPairsTop)
         assertTrue(eightPairsTop < tutorialTop)
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedChallengePresentation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedChallengePresentation.kt
@@ -34,3 +34,11 @@ internal fun GeneratedChallenge.localizedTitle(catalog: GeneratedChallengeCatalo
     catalog.modeFor(this).localizedTitle(),
     difficulty.localizedTitle()
 )
+
+@Composable
+internal fun GeneratedChallenge.localizedNewPuzzleName(catalog: GeneratedChallengeCatalog): String =
+    if (modeId == GeneratedModes.THREE_PAIRS.id) {
+        catalog.modeFor(this).localizedTitle()
+    } else {
+        localizedTitle(catalog)
+    }

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/MenuRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/MenuRoute.kt
@@ -30,6 +30,7 @@ fun MenuRoute(
     onPersonalizationSelected: () -> Unit = {},
     onGeneratedChallengeSelected: (GeneratedChallenge) -> Unit = {}
 ) {
+    val quickChallenge = generatedChallengeCatalog.resolveChallenge(GeneratedModes.THREE_PAIRS_LOW.id)
     val fourPairsMode = generatedChallengeCatalog.resolve(GeneratedModes.FOUR_PAIRS.id)
     val eightPairsMode = generatedChallengeCatalog.resolve(GeneratedModes.EIGHT_PAIRS.id)
     val fourPairsChallenge = fourPairsMode.selectedChallenge(
@@ -57,6 +58,9 @@ fun MenuRoute(
     MenuScreen(
         modifier = modifier,
         resumeChallengeName = resumeChallengeName,
+        onQuickSelected = {
+            onGeneratedChallengeSelected(quickChallenge)
+        },
         fourPairsMode = fourPairsMode.menuUiState(
             selectedChallenge = fourPairsChallenge,
             catalog = generatedChallengeCatalog

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreen.kt
@@ -63,6 +63,7 @@ fun MenuScreen(
     modifier: Modifier = Modifier,
     resumeChallengeName: String? = null,
     onResumeSelected: () -> Unit = {},
+    onQuickSelected: () -> Unit = {},
     onTutorialSelected: () -> Unit = {},
     onPersonalizationSelected: () -> Unit = {},
     onFourPairsSelected: () -> Unit = {},
@@ -120,6 +121,7 @@ fun MenuScreen(
                             MenuButtonText(text = stringResource(R.string.menu_resume_button))
                         }
                     }
+                    QuickMenuButton(onClick = onQuickSelected)
                     GeneratedModeMenuRow(
                         state = fourPairsMode,
                         onPlay = onFourPairsSelected,
@@ -171,6 +173,29 @@ fun MenuScreen(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun QuickMenuButton(onClick: () -> Unit) {
+    val contentDescription = stringResource(
+        R.string.menu_play_quick_content_description,
+        stringResource(R.string.quick_screen_title),
+        stringResource(R.string.three_pairs_accessibility_name),
+        stringResource(R.string.generated_difficulty_low)
+    )
+
+    NumPairsComponents.PrimaryCtaButton(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(NumPairsComponents.ButtonHeight)
+            .semantics {
+                this.contentDescription = contentDescription
+            }
+            .testTag(MenuScreenTestTags.QUICK_BUTTON)
+    ) {
+        MenuButtonText(text = stringResource(R.string.quick_screen_title))
     }
 }
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTestTags.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTestTags.kt
@@ -3,6 +3,8 @@ package org.cescfe.numpairs.feature.menu.ui
 object MenuScreenTestTags {
     const val SCREEN = "menu_screen"
     const val RESUME_BUTTON = "menu_resume_button"
+    const val QUICK_BUTTON = "menu_quick_button"
+    const val QUICK_DIFFICULTY_BUTTON = "menu_quick_difficulty_button"
     const val TUTORIAL_BUTTON = "menu_tutorial_button"
     const val SETTINGS_ACTION = "menu_settings_action"
     const val FOUR_PAIRS_SPLIT_CTA = "menu_four_pairs_split_cta"

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -22,6 +22,7 @@ import org.cescfe.numpairs.feature.generated.GeneratedModeLaunchIntent
 import org.cescfe.numpairs.feature.generated.GeneratedModeRoute
 import org.cescfe.numpairs.feature.generated.GeneratedModes
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
+import org.cescfe.numpairs.feature.generated.localizedNewPuzzleName
 import org.cescfe.numpairs.feature.generated.localizedTitle
 import org.cescfe.numpairs.feature.menu.MenuRoute
 import org.cescfe.numpairs.feature.menu.ui.GeneratedSessionChoiceDialog
@@ -232,7 +233,7 @@ private fun UnlockedAppNavigation(
         }
         GeneratedSessionChoiceDialog(
             savedChallengeName = resumableSession.challenge.localizedTitle(generatedChallengeCatalog),
-            selectedChallengeName = selectedChallenge.localizedTitle(generatedChallengeCatalog),
+            selectedChallengeName = selectedChallenge.localizedNewPuzzleName(generatedChallengeCatalog),
             onResume = {
                 actionGuard.handle {
                     pendingGeneratedChallengeChoice = null

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -6,6 +6,7 @@
     <!-- Menu screen -->
     <string name="menu_resume_button">Continua</string>
     <string name="menu_resume_content_description">Continua el puzle de %1$s</string>
+    <string name="menu_play_quick_content_description">Juga al puzle %1$s, %2$s, dificultat %3$s</string>
     <string name="menu_tutorial_button">Com jugar</string>
     <string name="menu_settings_action_content_description">Configuració</string>
     <string name="menu_play_generated_challenge_content_description">Juga al puzle de %1$s</string>
@@ -44,6 +45,7 @@
 
     <!-- Generated mode screens -->
     <string name="quick_screen_title">Quick</string>
+    <string name="three_pairs_accessibility_name">3 parelles</string>
     <string name="four_pairs_screen_title">4 parelles</string>
     <string name="eight_pairs_screen_title">8 parelles</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -6,6 +6,7 @@
     <!-- Menu screen -->
     <string name="menu_resume_button">Continuar</string>
     <string name="menu_resume_content_description">Continuar puzle de %1$s</string>
+    <string name="menu_play_quick_content_description">Jugar puzle %1$s, %2$s, dificultad %3$s</string>
     <string name="menu_tutorial_button">Cómo jugar</string>
     <string name="menu_settings_action_content_description">Ajustes</string>
     <string name="menu_play_generated_challenge_content_description">Jugar puzle de %1$s</string>
@@ -44,6 +45,7 @@
 
     <!-- Generated mode screens -->
     <string name="quick_screen_title">Quick</string>
+    <string name="three_pairs_accessibility_name">3 pares</string>
     <string name="four_pairs_screen_title">4 pares</string>
     <string name="eight_pairs_screen_title">8 pares</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <!-- Menu screen -->
     <string name="menu_resume_button">Resume</string>
     <string name="menu_resume_content_description">Resume %1$s puzzle</string>
+    <string name="menu_play_quick_content_description">Play %1$s puzzle, %2$s, %3$s difficulty</string>
     <string name="menu_tutorial_button">How to play</string>
     <string name="menu_settings_action_content_description">Settings</string>
     <string name="menu_play_generated_challenge_content_description">Play %1$s puzzle</string>
@@ -44,6 +45,7 @@
 
     <!-- Generated mode screens -->
     <string name="quick_screen_title">Quick</string>
+    <string name="three_pairs_accessibility_name">3 pairs</string>
     <string name="four_pairs_screen_title">4 pairs</string>
     <string name="eight_pairs_screen_title">8 pairs</string>
 

--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -7,7 +7,7 @@
   `8 Pairs Medium`, and `8 Pairs Hard`
 - Implemented v10 challenge registration: generated `3 Pairs Low` is the only Quick challenge
 - Implemented v10 generated presentation: Quick uses the shared Low learning route
-- Planned v10 Menu exposure: add the direct Quick entry point
+- Implemented v10 Menu exposure: direct Quick entry through the normal generated-session flow
 - v8 generated challenge matrix: implemented
 - Related references:
   - `docs/product/prd/prd-v5.md`
@@ -209,8 +209,8 @@ session slot.
 
 ### Quick / `3 Pairs Low`
 
-Status: generated profile, challenge registration, and shared learning presentation implemented;
-direct Menu exposure planned.
+Status: generated profile, challenge registration, shared learning presentation, and direct Menu
+exposure implemented.
 
 Player-facing identity:
 

--- a/docs/product/visual-design-system.md
+++ b/docs/product/visual-design-system.md
@@ -604,6 +604,11 @@ shared wrapper changes ownership only: spacing, typography, shapes, semantic col
 touch targets, failure handling, and reduced-motion behavior remain those of the established
 generated and game surfaces.
 
+The unlocked Menu presents Quick with the same full-width `PrimaryCtaButton`, button height,
+typography, shape, gradient, border, elevation, and spacing used by normal Resume. It adds no
+one-option trailing selector; the existing `4 Pairs` and `8 Pairs` split CTAs retain their
+independent action geometry.
+
 ---
 
 ## Accessibility Requirements

--- a/docs/ui-behavior.md
+++ b/docs/ui-behavior.md
@@ -154,6 +154,8 @@ difficulty. Normal generated actions do not read or write Daily state.
 
 ### Quick Action
 
+Status: implemented.
+
 Quick uses one full-width primary CTA labelled `Quick`. It has no trailing difficulty action while
 `3 Pairs Low` is its only supported challenge.
 


### PR DESCRIPTION
## Related Issue

Resolves #587

## Summary

- Add a direct full-width Quick primary CTA between normal Resume and the 4 Pairs split action.
- Launch `3 Pairs Low` directly or use the shared resume-or-replace dialog with a localized `New Quick` action.
- Protect accessibility, selector independence, action order, localization, compact layout, RTL behavior, and existing Menu flows.

## UI Consistency

- Shared components or tokens reused: `NumPairsComponents.PrimaryCtaButton`, shared Menu text style, button height, spacing, generated session-choice dialog, and established generated navigation.
- Intentional deviations from established visual roles: Quick omits the split CTA trailing region because it has exactly one supported difficulty; all primary-button visual roles remain unchanged.