### PR TITLE
[285] Implement Daily Challenge identity and seed schedule

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/domain/daily/DailyChallengeIdentity.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/daily/DailyChallengeIdentity.kt
@@ -1,0 +1,54 @@
+package org.cescfe.numpairs.domain.daily
+
+import java.time.LocalDate
+
+@JvmInline
+value class DailyRecipeVersion(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "Daily recipe version must not be blank."
+        }
+        require('|' !in value) {
+            "Daily recipe version must not contain the seed-payload delimiter."
+        }
+    }
+}
+
+@JvmInline
+value class DailyCandidateIndex(val value: Int) {
+    init {
+        require(value >= 0) {
+            "Daily candidate index must be zero or greater."
+        }
+    }
+}
+
+data class DailyChallengeId(val localDate: LocalDate, val recipeVersion: DailyRecipeVersion) {
+    val canonicalLocalDate: String
+        get() = localDate.toString()
+}
+
+fun interface DailyCandidateSeedSchedule {
+    fun seedFor(identity: DailyChallengeId, candidateIndex: DailyCandidateIndex): Int
+}
+
+object Fnv1a32DailyCandidateSeedSchedule : DailyCandidateSeedSchedule {
+    override fun seedFor(identity: DailyChallengeId, candidateIndex: DailyCandidateIndex): Int {
+        val payload = buildString {
+            append(identity.recipeVersion.value)
+            append(PAYLOAD_DELIMITER)
+            append(identity.canonicalLocalDate)
+            append(PAYLOAD_DELIMITER)
+            append(candidateIndex.value)
+        }
+        var hash = FNV_OFFSET_BASIS
+        payload.encodeToByteArray().forEach { byte ->
+            hash = (hash xor byte.toUByte().toUInt()) * FNV_PRIME
+        }
+        return hash.toInt()
+    }
+
+    private const val PAYLOAD_DELIMITER: Char = '|'
+    private const val FNV_OFFSET_BASIS: UInt = 0x811C9DC5u
+    private const val FNV_PRIME: UInt = 0x01000193u
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyRecipe.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyRecipe.kt
@@ -1,0 +1,82 @@
+package org.cescfe.numpairs.feature.daily
+
+import java.time.LocalDate
+import org.cescfe.numpairs.domain.daily.DailyCandidateIndex
+import org.cescfe.numpairs.domain.daily.DailyCandidateSeedSchedule
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
+import org.cescfe.numpairs.domain.daily.Fnv1a32DailyCandidateSeedSchedule
+import org.cescfe.numpairs.feature.generated.GeneratedChallenge
+import org.cescfe.numpairs.feature.generated.GeneratedChallengeCatalog
+import org.cescfe.numpairs.feature.generated.GeneratedModes
+
+data class DailyRecipe(
+    val version: DailyRecipeVersion,
+    val challenge: GeneratedChallenge,
+    val candidateIndices: List<DailyCandidateIndex>,
+    private val seedSchedule: DailyCandidateSeedSchedule
+) {
+    init {
+        require(candidateIndices.isNotEmpty()) {
+            "A Daily recipe must configure at least one candidate."
+        }
+        require(candidateIndices == List(candidateIndices.size, ::DailyCandidateIndex)) {
+            "Daily recipe candidate indexes must be contiguous and start at zero."
+        }
+    }
+
+    fun identityFor(localDate: LocalDate): DailyChallengeId = DailyChallengeId(
+        localDate = localDate,
+        recipeVersion = version
+    )
+
+    fun seedFor(identity: DailyChallengeId, candidateIndex: DailyCandidateIndex): Int {
+        require(identity.recipeVersion == version) {
+            "Daily Challenge identity must use recipe ${version.value}."
+        }
+        require(candidateIndex in candidateIndices) {
+            "Daily candidate index ${candidateIndex.value} is not configured by recipe ${version.value}."
+        }
+        return seedSchedule.seedFor(identity = identity, candidateIndex = candidateIndex)
+    }
+}
+
+class DailyRecipeCatalog(recipes: Collection<DailyRecipe>, generatedChallengeCatalog: GeneratedChallengeCatalog) {
+    val all: List<DailyRecipe> = recipes.toList()
+    private val recipesByVersion: Map<DailyRecipeVersion, DailyRecipe> = all.associateBy(DailyRecipe::version)
+
+    init {
+        require(all.isNotEmpty()) {
+            "At least one Daily recipe must be configured."
+        }
+        require(recipesByVersion.size == all.size) {
+            "Daily recipe versions must be unique."
+        }
+        require(
+            all.all { recipe ->
+                generatedChallengeCatalog.resolveChallenge(recipe.challenge.id) == recipe.challenge
+            }
+        ) {
+            "Every Daily recipe challenge must belong to the configured generated-challenge catalog."
+        }
+    }
+
+    fun resolve(version: DailyRecipeVersion): DailyRecipe = requireNotNull(recipesByVersion[version]) {
+        "No Daily recipe is configured for version ${version.value}."
+    }
+
+    fun resolveOrNull(version: DailyRecipeVersion): DailyRecipe? = recipesByVersion[version]
+}
+
+object DailyRecipes {
+    val FOUR_PAIRS_LOW_V1: DailyRecipe = DailyRecipe(
+        version = DailyRecipeVersion("daily-4-pairs-low-v1"),
+        challenge = GeneratedModes.FOUR_PAIRS_LOW,
+        candidateIndices = List(4, ::DailyCandidateIndex),
+        seedSchedule = Fnv1a32DailyCandidateSeedSchedule
+    )
+    val catalog: DailyRecipeCatalog = DailyRecipeCatalog(
+        recipes = listOf(FOUR_PAIRS_LOW_V1),
+        generatedChallengeCatalog = GeneratedModes.catalog
+    )
+}

--- a/app/src/test/java/org/cescfe/numpairs/domain/daily/DailyChallengeIdentityTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/daily/DailyChallengeIdentityTest.kt
@@ -1,0 +1,58 @@
+package org.cescfe.numpairs.domain.daily
+
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class DailyChallengeIdentityTest {
+    @Test
+    fun identity_exposes_only_recipe_version_and_canonical_iso_local_date() {
+        val identity = DailyChallengeId(
+            localDate = LocalDate.of(2028, 2, 29),
+            recipeVersion = DailyRecipeVersion("daily-4-pairs-low-v1")
+        )
+
+        assertEquals("2028-02-29", identity.canonicalLocalDate)
+        assertEquals("daily-4-pairs-low-v1", identity.recipeVersion.value)
+    }
+
+    @Test
+    fun recipe_version_and_candidate_index_reject_invalid_identity_components() {
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyRecipeVersion(" ")
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyRecipeVersion("daily|v1")
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyCandidateIndex(-1)
+        }
+    }
+
+    @Test
+    fun fnv1a_seed_vectors_are_stable_across_dates_and_every_configured_index() {
+        val expectedSeedsByDate = mapOf(
+            LocalDate.of(2026, 1, 1) to listOf(-142727284, -125949665, -109172046, -92394427),
+            LocalDate.of(2026, 12, 31) to listOf(192004267, 175226648, 225559505, 208781886),
+            LocalDate.of(2028, 2, 29) to listOf(626215115, 609437496, 659770353, 642992734)
+        )
+
+        expectedSeedsByDate.forEach { (date, expectedSeeds) ->
+            val identity = DailyChallengeId(
+                localDate = date,
+                recipeVersion = DailyRecipeVersion("daily-4-pairs-low-v1")
+            )
+
+            assertEquals(
+                expectedSeeds,
+                List(4) { candidateIndex ->
+                    Fnv1a32DailyCandidateSeedSchedule.seedFor(
+                        identity = identity,
+                        candidateIndex = DailyCandidateIndex(candidateIndex)
+                    )
+                }
+            )
+        }
+    }
+}

--- a/app/src/test/java/org/cescfe/numpairs/feature/daily/DailyRecipeTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/daily/DailyRecipeTest.kt
@@ -1,0 +1,84 @@
+package org.cescfe.numpairs.feature.daily
+
+import java.time.LocalDate
+import org.cescfe.numpairs.domain.daily.DailyCandidateIndex
+import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
+import org.cescfe.numpairs.domain.daily.Fnv1a32DailyCandidateSeedSchedule
+import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
+import org.cescfe.numpairs.feature.generated.GeneratedChallengeCatalog
+import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class DailyRecipeTest {
+    @Test
+    fun v10_catalog_resolves_the_exact_four_pairs_low_recipe() {
+        val recipe = DailyRecipes.catalog.resolve(DailyRecipeVersion("daily-4-pairs-low-v1"))
+
+        assertSame(DailyRecipes.FOUR_PAIRS_LOW_V1, recipe)
+        assertSame(GeneratedModes.FOUR_PAIRS_LOW, recipe.challenge)
+        assertEquals(GeneratedModes.FOUR_PAIRS.id, recipe.challenge.modeId)
+        assertEquals(DifficultyTier.LOW, recipe.challenge.difficulty)
+        assertEquals(GeneratedModes.FOUR_PAIRS_LOW.profile, recipe.challenge.profile)
+        assertEquals(listOf(0, 1, 2, 3), recipe.candidateIndices.map(DailyCandidateIndex::value))
+    }
+
+    @Test
+    fun catalog_exposes_typed_absence_and_rejects_unknown_recipe_versions() {
+        val unknownVersion = DailyRecipeVersion("unknown-daily-recipe")
+
+        assertNull(DailyRecipes.catalog.resolveOrNull(unknownVersion))
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyRecipes.catalog.resolve(unknownVersion)
+        }
+    }
+
+    @Test
+    fun recipe_derives_identity_and_seed_only_for_its_configured_version_and_candidates() {
+        val recipe = DailyRecipes.FOUR_PAIRS_LOW_V1
+        val identity = recipe.identityFor(LocalDate.of(2028, 2, 29))
+
+        assertEquals(recipe.version, identity.recipeVersion)
+        assertEquals(626215115, recipe.seedFor(identity, DailyCandidateIndex(0)))
+        assertThrows(IllegalArgumentException::class.java) {
+            recipe.seedFor(
+                identity = identity.copy(recipeVersion = DailyRecipeVersion("different-version")),
+                candidateIndex = DailyCandidateIndex(0)
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            recipe.seedFor(identity = identity, candidateIndex = DailyCandidateIndex(4))
+        }
+    }
+
+    @Test
+    fun recipe_and_catalog_reject_invalid_candidate_and_challenge_configuration() {
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyRecipe(
+                version = DailyRecipeVersion("daily-empty"),
+                challenge = GeneratedModes.FOUR_PAIRS_LOW,
+                candidateIndices = emptyList(),
+                seedSchedule = Fnv1a32DailyCandidateSeedSchedule
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyRecipe(
+                version = DailyRecipeVersion("daily-non-contiguous"),
+                challenge = GeneratedModes.FOUR_PAIRS_LOW,
+                candidateIndices = listOf(DailyCandidateIndex(0), DailyCandidateIndex(2)),
+                seedSchedule = Fnv1a32DailyCandidateSeedSchedule
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyRecipeCatalog(
+                recipes = listOf(DailyRecipes.FOUR_PAIRS_LOW_V1),
+                generatedChallengeCatalog = GeneratedChallengeCatalog(
+                    configurations = listOf(GeneratedModes.THREE_PAIRS)
+                )
+            )
+        }
+    }
+}

--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -8,6 +8,8 @@
 - Implemented v10 challenge registration: generated `3 Pairs Low` is the only Quick challenge
 - Implemented v10 generated presentation: Quick uses the shared Low learning route
 - Implemented v10 Menu exposure: direct Quick entry through the normal generated-session flow
+- Implemented v10 Daily foundation: versioned identity, `4 Pairs Low` recipe resolution, and
+  deterministic four-candidate seed schedule
 - v8 generated challenge matrix: implemented
 - Related references:
   - `docs/product/prd/prd-v5.md`
@@ -179,6 +181,10 @@ Committed puzzle changes update the current snapshot through the stable session 
 
 The v10 Daily Challenge reuses the existing generated-puzzle pipeline without making the generator
 aware of dates, calendars, completion history, Android clocks, or presentation state.
+
+Status: identity, immutable v10 recipe resolution, and the FNV-1a candidate seed schedule are
+implemented. Device-local date capture, candidate execution, persistence, gameplay, and
+presentation remain planned.
 
 One immutable Daily Recipe version:
 

--- a/docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md
+++ b/docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md
@@ -79,6 +79,10 @@ Candidate indexes `0..3` are attempted in ascending order.
 The payload format, hash algorithm, constants, selected challenge, and four-candidate limit cannot
 change without a new recipe version.
 
+This identity, immutable v10 recipe binding, configured-version resolver, and four-candidate seed
+schedule are implemented. Current device-local date capture and candidate generation are separate
+delivery boundaries.
+
 The generator remains unaware of dates and Daily semantics. It receives ordinary explicit
 generated-puzzle requests. Daily coordination never falls back to device randomness, current
 time-of-day entropy, or a different profile.

--- a/docs/technical/daily-challenge-persistence.md
+++ b/docs/technical/daily-challenge-persistence.md
@@ -2,7 +2,8 @@
 
 ## Document Status
 
-- Status: planned v10 Daily identity, session, and local completion-history contract
+- Status: Daily identity, recipe resolution, and deterministic seed schedule implemented; local
+  date access, session persistence, and completion history planned
 - Product contract: `docs/product/prd/prd-v10.md`
 - Architecture decision:
   `docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md`
@@ -55,6 +56,10 @@ identity of an in-flight or visible request.
 The recipe resolver accepts only configured recipe versions. An unknown recipe makes an active
 snapshot unsupported, but a completion record keeps its canonical completed date for calendar
 history.
+
+The platform-independent identity types, v10 recipe catalog, exact `4 Pairs Low` binding, and
+four-candidate FNV-1a seed schedule are implemented. Current device-local date capture and
+candidate generation remain outside this implemented boundary.
 
 ---
 


### PR DESCRIPTION
## Related Issue

Resolves #592

## Summary

- Add platform-independent Daily identity and canonical local-date representation.
- Configure the immutable v10 4 Pairs Low recipe and version resolver.
- Protect the exact four-candidate FNV-1a seed schedule with stable vectors.
- Update the Daily architecture and generation references with the implemented boundary.