### PR TITLE
[286] Add the device-local Daily date boundary

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/data/daily/SystemDeviceLocalDateSource.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/daily/SystemDeviceLocalDateSource.kt
@@ -1,0 +1,15 @@
+package org.cescfe.numpairs.data.daily
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
+
+class SystemDeviceLocalDateSource(
+    private val instantSource: () -> Instant = Instant::now,
+    private val zoneIdSource: () -> ZoneId = ZoneId::systemDefault
+) : DeviceLocalDateSource {
+    override fun currentDate(): LocalDate = instantSource()
+        .atZone(zoneIdSource())
+        .toLocalDate()
+}

--- a/app/src/main/java/org/cescfe/numpairs/domain/daily/DeviceLocalDateSource.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/daily/DeviceLocalDateSource.kt
@@ -1,0 +1,7 @@
+package org.cescfe.numpairs.domain.daily
+
+import java.time.LocalDate
+
+fun interface DeviceLocalDateSource {
+    fun currentDate(): LocalDate
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/CurrentDailyChallengeResolver.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/CurrentDailyChallengeResolver.kt
@@ -1,0 +1,28 @@
+package org.cescfe.numpairs.feature.daily
+
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
+import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
+
+data class CurrentDailyChallenge(val identity: DailyChallengeId, val recipe: DailyRecipe) {
+    init {
+        require(identity.recipeVersion == recipe.version) {
+            "Current Daily Challenge identity and recipe version must match."
+        }
+    }
+}
+
+class CurrentDailyChallengeResolver(
+    private val localDateSource: DeviceLocalDateSource,
+    private val recipeCatalog: DailyRecipeCatalog = DailyRecipes.catalog,
+    private val activeRecipeVersion: DailyRecipeVersion = DailyRecipes.FOUR_PAIRS_LOW_V1.version
+) {
+    fun resolve(): CurrentDailyChallenge {
+        val localDate = localDateSource.currentDate()
+        val recipe = recipeCatalog.resolve(activeRecipeVersion)
+        return CurrentDailyChallenge(
+            identity = recipe.identityFor(localDate),
+            recipe = recipe
+        )
+    }
+}

--- a/app/src/test/java/org/cescfe/numpairs/data/daily/SystemDeviceLocalDateSourceTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/daily/SystemDeviceLocalDateSourceTest.kt
@@ -1,0 +1,40 @@
+package org.cescfe.numpairs.data.daily
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SystemDeviceLocalDateSourceTest {
+    @Test
+    fun current_date_changes_at_midnight_in_the_supplied_device_timezone() {
+        var currentInstant = Instant.parse("2026-07-25T21:59:59Z")
+        val source = SystemDeviceLocalDateSource(
+            instantSource = { currentInstant },
+            zoneIdSource = { ZoneId.of("Europe/Madrid") }
+        )
+
+        assertEquals(LocalDate.of(2026, 7, 25), source.currentDate())
+
+        currentInstant = Instant.parse("2026-07-25T22:00:00Z")
+
+        assertEquals(LocalDate.of(2026, 7, 26), source.currentDate())
+    }
+
+    @Test
+    fun current_date_uses_the_current_supplied_device_timezone() {
+        val currentInstant = Instant.parse("2026-07-25T23:30:00Z")
+        var currentZone = ZoneId.of("America/New_York")
+        val source = SystemDeviceLocalDateSource(
+            instantSource = { currentInstant },
+            zoneIdSource = { currentZone }
+        )
+
+        assertEquals(LocalDate.of(2026, 7, 25), source.currentDate())
+
+        currentZone = ZoneId.of("Europe/Madrid")
+
+        assertEquals(LocalDate.of(2026, 7, 26), source.currentDate())
+    }
+}

--- a/app/src/test/java/org/cescfe/numpairs/feature/daily/CurrentDailyChallengeResolverTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/daily/CurrentDailyChallengeResolverTest.kt
@@ -1,0 +1,59 @@
+package org.cescfe.numpairs.feature.daily
+
+import java.time.LocalDate
+import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
+import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
+import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class CurrentDailyChallengeResolverTest {
+    @Test
+    fun resolver_reads_the_local_date_once_and_combines_it_with_the_active_recipe() {
+        var dateReadCount = 0
+        val resolver = CurrentDailyChallengeResolver(
+            localDateSource = DeviceLocalDateSource {
+                dateReadCount += 1
+                LocalDate.of(2026, 7, 25)
+            }
+        )
+
+        val currentDailyChallenge = resolver.resolve()
+
+        assertEquals(1, dateReadCount)
+        assertEquals(LocalDate.of(2026, 7, 25), currentDailyChallenge.identity.localDate)
+        assertEquals(DailyRecipes.FOUR_PAIRS_LOW_V1.version, currentDailyChallenge.identity.recipeVersion)
+        assertSame(DailyRecipes.FOUR_PAIRS_LOW_V1, currentDailyChallenge.recipe)
+        assertSame(GeneratedModes.FOUR_PAIRS_LOW, currentDailyChallenge.recipe.challenge)
+    }
+
+    @Test
+    fun resolved_identity_does_not_change_when_the_local_date_source_changes() {
+        var currentDate = LocalDate.of(2026, 12, 31)
+        val resolver = CurrentDailyChallengeResolver(
+            localDateSource = DeviceLocalDateSource { currentDate }
+        )
+
+        val firstResolution = resolver.resolve()
+        currentDate = LocalDate.of(2027, 1, 1)
+
+        assertEquals(LocalDate.of(2026, 12, 31), firstResolution.identity.localDate)
+        assertEquals(LocalDate.of(2027, 1, 1), resolver.resolve().identity.localDate)
+    }
+
+    @Test
+    fun current_daily_challenge_rejects_an_identity_from_another_recipe() {
+        val configuredRecipe = DailyRecipes.FOUR_PAIRS_LOW_V1
+
+        assertThrows(IllegalArgumentException::class.java) {
+            CurrentDailyChallenge(
+                identity = configuredRecipe.identityFor(LocalDate.of(2026, 7, 25)).copy(
+                    recipeVersion = DailyRecipeVersion("other-recipe")
+                ),
+                recipe = configuredRecipe
+            )
+        }
+    }
+}

--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -8,8 +8,8 @@
 - Implemented v10 challenge registration: generated `3 Pairs Low` is the only Quick challenge
 - Implemented v10 generated presentation: Quick uses the shared Low learning route
 - Implemented v10 Menu exposure: direct Quick entry through the normal generated-session flow
-- Implemented v10 Daily foundation: versioned identity, `4 Pairs Low` recipe resolution, and
-  deterministic four-candidate seed schedule
+- Implemented v10 Daily foundation: versioned identity, `4 Pairs Low` recipe resolution,
+  deterministic four-candidate seed schedule, and device-local date capture
 - v8 generated challenge matrix: implemented
 - Related references:
   - `docs/product/prd/prd-v5.md`
@@ -182,9 +182,9 @@ Committed puzzle changes update the current snapshot through the stable session 
 The v10 Daily Challenge reuses the existing generated-puzzle pipeline without making the generator
 aware of dates, calendars, completion history, Android clocks, or presentation state.
 
-Status: identity, immutable v10 recipe resolution, and the FNV-1a candidate seed schedule are
-implemented. Device-local date capture, candidate execution, persistence, gameplay, and
-presentation remain planned.
+Status: identity, immutable v10 recipe resolution, the FNV-1a candidate seed schedule, and
+device-local current-identity resolution are implemented. Candidate execution, persistence,
+gameplay, and presentation remain planned.
 
 One immutable Daily Recipe version:
 

--- a/docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md
+++ b/docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md
@@ -99,6 +99,10 @@ Daily identity and does not expose an unfinished prior-date session for backfill
 The clock and time zone are trusted local inputs. Manual changes may make a matching stored
 session or completion visible again; v10 does not add anti-cheat state.
 
+The injectable device-local date source and current-Daily resolver are implemented. The source
+reads the current instant in the current default device time zone, and each resolution captures
+one `LocalDate` before constructing immutable Daily identity.
+
 ### Daily Aggregate
 
 NumPairs owns one application-private Daily aggregate containing:

--- a/docs/technical/daily-challenge-persistence.md
+++ b/docs/technical/daily-challenge-persistence.md
@@ -2,8 +2,8 @@
 
 ## Document Status
 
-- Status: Daily identity, recipe resolution, and deterministic seed schedule implemented; local
-  date access, session persistence, and completion history planned
+- Status: Daily identity, recipe resolution, deterministic seed schedule, and device-local date
+  boundary implemented; session persistence and completion history planned
 - Product contract: `docs/product/prd/prd-v10.md`
 - Architecture decision:
   `docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md`
@@ -57,9 +57,10 @@ The recipe resolver accepts only configured recipe versions. An unknown recipe m
 snapshot unsupported, but a completion record keeps its canonical completed date for calendar
 history.
 
-The platform-independent identity types, v10 recipe catalog, exact `4 Pairs Low` binding, and
-four-candidate FNV-1a seed schedule are implemented. Current device-local date capture and
-candidate generation remain outside this implemented boundary.
+The platform-independent identity types, v10 recipe catalog, exact `4 Pairs Low` binding,
+four-candidate FNV-1a seed schedule, and injectable device-local date boundary are implemented.
+Current identity resolution captures one `LocalDate` before generation begins. Candidate
+generation remains outside this implemented boundary.
 
 ---
 


### PR DESCRIPTION
## Related Issue

Resolves #593

## Summary

- Add an injectable Daily local-date boundary backed by the current instant and device timezone.
- Resolve one immutable current Daily identity from one captured LocalDate and the active recipe.
- Cover local-midnight, timezone-change, and post-resolution source mutation behavior.
- Update Daily architecture and generation references with the implemented date boundary.