### PR TITLE
[287] Generate Daily candidates through deterministic fallback

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyPuzzleGenerationUseCase.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyPuzzleGenerationUseCase.kt
@@ -1,0 +1,176 @@
+package org.cescfe.numpairs.feature.daily
+
+import org.cescfe.numpairs.domain.daily.DailyCandidateIndex
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationFailureReason
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPuzzleGenerationRequest
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.feature.generated.GeneratedChallenge
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationResult
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
+
+data class DailyCandidateGenerationFailure(
+    val candidateIndex: DailyCandidateIndex,
+    val seed: Int,
+    val failure: GeneratedPairsPuzzleGenerationOutcome.Failed
+) {
+    init {
+        require(failure.request.seed == seed) {
+            "Daily candidate failure seed must match its generation request."
+        }
+    }
+}
+
+sealed interface DailyPuzzleGenerationResult {
+    val currentDailyChallenge: CurrentDailyChallenge
+
+    val identity: DailyChallengeId
+        get() = currentDailyChallenge.identity
+
+    val challenge: GeneratedChallenge
+        get() = currentDailyChallenge.recipe.challenge
+
+    data class Generated(
+        override val currentDailyChallenge: CurrentDailyChallenge,
+        val candidateIndex: DailyCandidateIndex,
+        val seed: Int,
+        val initialPuzzle: Puzzle
+    ) : DailyPuzzleGenerationResult {
+        init {
+            require(candidateIndex in currentDailyChallenge.recipe.candidateIndices) {
+                "Generated Daily candidate index must belong to its recipe."
+            }
+            require(
+                seed == currentDailyChallenge.recipe.seedFor(
+                    identity = currentDailyChallenge.identity,
+                    candidateIndex = candidateIndex
+                )
+            ) {
+                "Generated Daily seed must match its recipe candidate."
+            }
+        }
+    }
+
+    data class Exhausted(
+        override val currentDailyChallenge: CurrentDailyChallenge,
+        val attemptedFailures: List<DailyCandidateGenerationFailure>
+    ) : DailyPuzzleGenerationResult {
+        init {
+            require(attemptedFailures.isNotEmpty()) {
+                "Exhausted Daily generation requires at least one attempted failure."
+            }
+            require(
+                attemptedFailures.map(DailyCandidateGenerationFailure::candidateIndex) ==
+                    currentDailyChallenge.recipe.candidateIndices
+            ) {
+                "Exhausted Daily generation must preserve every configured candidate in order."
+            }
+            require(
+                attemptedFailures.none { attemptedFailure ->
+                    attemptedFailure.failure.reason == GeneratedPairsPuzzleGenerationFailureReason.Cancelled
+                }
+            ) {
+                "Cancelled Daily generation must not be reported as exhausted."
+            }
+            currentDailyChallenge.requireFailuresMatchRecipe(attemptedFailures)
+        }
+    }
+
+    data class Cancelled(
+        override val currentDailyChallenge: CurrentDailyChallenge,
+        val attemptedFailures: List<DailyCandidateGenerationFailure>
+    ) : DailyPuzzleGenerationResult {
+        init {
+            require(
+                attemptedFailures.lastOrNull()?.failure?.reason ==
+                    GeneratedPairsPuzzleGenerationFailureReason.Cancelled
+            ) {
+                "Cancelled Daily generation requires a terminal cancelled candidate."
+            }
+            require(
+                attemptedFailures.map(DailyCandidateGenerationFailure::candidateIndex) ==
+                    currentDailyChallenge.recipe.candidateIndices.take(attemptedFailures.size)
+            ) {
+                "Cancelled Daily generation must preserve the attempted candidate prefix in order."
+            }
+            currentDailyChallenge.requireFailuresMatchRecipe(attemptedFailures)
+        }
+    }
+}
+
+private fun CurrentDailyChallenge.requireFailuresMatchRecipe(attemptedFailures: List<DailyCandidateGenerationFailure>) {
+    attemptedFailures.forEach { attemptedFailure ->
+        require(
+            attemptedFailure.seed == recipe.seedFor(
+                identity = identity,
+                candidateIndex = attemptedFailure.candidateIndex
+            )
+        ) {
+            "Daily candidate failure seed must match its recipe candidate."
+        }
+        require(attemptedFailure.failure.request.profile == recipe.challenge.profile) {
+            "Daily candidate failure profile must match its recipe challenge."
+        }
+    }
+}
+
+class DailyPuzzleGenerationUseCase(
+    private val currentDailyChallengeResolver: CurrentDailyChallengeResolver,
+    private val generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory
+) {
+    suspend fun generate(): DailyPuzzleGenerationResult {
+        val currentDailyChallenge = currentDailyChallengeResolver.resolve()
+        val recipe = currentDailyChallenge.recipe
+        val challenge = recipe.challenge
+        val generationUseCase = generatedPuzzleGenerationUseCaseFactory.create(challenge)
+        val attemptedFailures = mutableListOf<DailyCandidateGenerationFailure>()
+
+        recipe.candidateIndices.forEach { candidateIndex ->
+            val seed = recipe.seedFor(
+                identity = currentDailyChallenge.identity,
+                candidateIndex = candidateIndex
+            )
+            val request = GeneratedPuzzleGenerationRequest(
+                profile = challenge.profile,
+                seed = seed
+            )
+
+            when (val result = generationUseCase.generate(request)) {
+                is GeneratedPuzzleGenerationResult.Generated -> {
+                    require(result.request == request) {
+                        "Generated Daily candidate must correspond to its requested seed and profile."
+                    }
+                    return DailyPuzzleGenerationResult.Generated(
+                        currentDailyChallenge = currentDailyChallenge,
+                        candidateIndex = candidateIndex,
+                        seed = seed,
+                        initialPuzzle = result.initialPuzzle
+                    )
+                }
+
+                is GeneratedPuzzleGenerationResult.Failed -> {
+                    require(result.request == request) {
+                        "Failed Daily candidate must correspond to its requested seed and profile."
+                    }
+                    attemptedFailures += DailyCandidateGenerationFailure(
+                        candidateIndex = candidateIndex,
+                        seed = seed,
+                        failure = result.failure
+                    )
+                    if (result.failure.reason == GeneratedPairsPuzzleGenerationFailureReason.Cancelled) {
+                        return DailyPuzzleGenerationResult.Cancelled(
+                            currentDailyChallenge = currentDailyChallenge,
+                            attemptedFailures = attemptedFailures
+                        )
+                    }
+                }
+            }
+        }
+
+        return DailyPuzzleGenerationResult.Exhausted(
+            currentDailyChallenge = currentDailyChallenge,
+            attemptedFailures = attemptedFailures
+        )
+    }
+}

--- a/app/src/test/java/org/cescfe/numpairs/feature/daily/DailyPuzzleGenerationUseCaseTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/daily/DailyPuzzleGenerationUseCaseTest.kt
@@ -1,0 +1,222 @@
+package org.cescfe.numpairs.feature.daily
+
+import java.time.LocalDate
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.domain.daily.DailyCandidateIndex
+import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationFailureReason
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPuzzleGenerationRequest
+import org.cescfe.numpairs.feature.generated.ConfiguredGeneratedPuzzleGenerationUseCaseFactory
+import org.cescfe.numpairs.feature.generated.GeneratedChallenge
+import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationResult
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCase
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DailyPuzzleGenerationUseCaseTest {
+    @Test
+    fun generation_captures_current_identity_once_and_returns_the_first_successful_candidate() = runBlocking {
+        val date = LocalDate.of(2026, 7, 25)
+        var dateReadCount = 0
+        val requests = mutableListOf<GeneratedPuzzleGenerationRequest>()
+        val createdChallenges = mutableListOf<GeneratedChallenge>()
+        val useCase = dailyGenerationUseCase(
+            dateSource = DeviceLocalDateSource {
+                dateReadCount += 1
+                date
+            },
+            generatedFactory = GeneratedPuzzleGenerationUseCaseFactory { challenge ->
+                createdChallenges += challenge
+                GeneratedPuzzleGenerationUseCase { request ->
+                    requests += request
+                    if (requests.size < 3) {
+                        failedResult(
+                            request = request,
+                            reason = GeneratedPairsPuzzleGenerationFailureReason.AttemptsExhausted
+                        )
+                    } else {
+                        GeneratedPuzzleGenerationResult.Generated(
+                            request = request,
+                            initialPuzzle = samplePuzzle
+                        )
+                    }
+                }
+            }
+        )
+
+        val result = useCase.generate() as DailyPuzzleGenerationResult.Generated
+        val expectedIdentity = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(date)
+        val expectedSeeds = (0..2).map { candidateIndex ->
+            DailyRecipes.FOUR_PAIRS_LOW_V1.seedFor(
+                identity = expectedIdentity,
+                candidateIndex = DailyCandidateIndex(candidateIndex)
+            )
+        }
+
+        assertEquals(1, dateReadCount)
+        assertEquals(expectedIdentity, result.identity)
+        assertSame(GeneratedModes.FOUR_PAIRS_LOW, result.challenge)
+        assertEquals(DailyCandidateIndex(2), result.candidateIndex)
+        assertEquals(expectedSeeds[2], result.seed)
+        assertSame(samplePuzzle, result.initialPuzzle)
+        assertEquals(expectedSeeds, requests.map(GeneratedPuzzleGenerationRequest::seed))
+        assertTrue(requests.all { request -> request.profile === GeneratedModes.FOUR_PAIRS_LOW.profile })
+        assertEquals(listOf(GeneratedModes.FOUR_PAIRS_LOW), createdChallenges)
+    }
+
+    @Test
+    fun non_cancellation_failures_are_preserved_in_order_when_every_candidate_is_exhausted() = runBlocking {
+        val reasons = listOf(
+            GeneratedPairsPuzzleGenerationFailureReason.AttemptsExhausted,
+            GeneratedPairsPuzzleGenerationFailureReason.SearchBudgetExhausted,
+            GeneratedPairsPuzzleGenerationFailureReason.DifficultyAssessmentWorkLimitReached,
+            GeneratedPairsPuzzleGenerationFailureReason.AttemptsExhausted
+        )
+        val useCase = dailyGenerationUseCase(
+            dateSource = DeviceLocalDateSource { LocalDate.of(2026, 12, 31) },
+            generatedFactory = generatedFactory { request, attempt ->
+                failedResult(request = request, reason = reasons[attempt])
+            }
+        )
+
+        val result = useCase.generate() as DailyPuzzleGenerationResult.Exhausted
+
+        assertEquals(listOf(0, 1, 2, 3), result.attemptedFailures.map { it.candidateIndex.value })
+        assertEquals(reasons, result.attemptedFailures.map { it.failure.reason })
+        assertEquals(
+            result.currentDailyChallenge.recipe.candidateIndices.map { candidateIndex ->
+                result.currentDailyChallenge.recipe.seedFor(result.identity, candidateIndex)
+            },
+            result.attemptedFailures.map(DailyCandidateGenerationFailure::seed)
+        )
+    }
+
+    @Test
+    fun typed_cancellation_is_terminal_and_does_not_attempt_later_candidates() = runBlocking {
+        val requests = mutableListOf<GeneratedPuzzleGenerationRequest>()
+        val useCase = dailyGenerationUseCase(
+            dateSource = DeviceLocalDateSource { LocalDate.of(2028, 2, 29) },
+            generatedFactory = generatedFactory { request, attempt ->
+                requests += request
+                failedResult(
+                    request = request,
+                    reason = if (attempt == 1) {
+                        GeneratedPairsPuzzleGenerationFailureReason.Cancelled
+                    } else {
+                        GeneratedPairsPuzzleGenerationFailureReason.AttemptsExhausted
+                    }
+                )
+            }
+        )
+
+        val result = useCase.generate() as DailyPuzzleGenerationResult.Cancelled
+
+        assertEquals(2, requests.size)
+        assertEquals(listOf(0, 1), result.attemptedFailures.map { it.candidateIndex.value })
+        assertEquals(
+            GeneratedPairsPuzzleGenerationFailureReason.Cancelled,
+            result.attemptedFailures.last().failure.reason
+        )
+    }
+
+    @Test
+    fun coroutine_cancellation_is_not_converted_into_exhaustion() {
+        val useCase = dailyGenerationUseCase(
+            dateSource = DeviceLocalDateSource { LocalDate.of(2026, 7, 25) },
+            generatedFactory = GeneratedPuzzleGenerationUseCaseFactory {
+                GeneratedPuzzleGenerationUseCase {
+                    throw CancellationException("cancel test")
+                }
+            }
+        )
+
+        assertThrows(CancellationException::class.java) {
+            runBlocking {
+                useCase.generate()
+            }
+        }
+    }
+
+    @Test
+    fun configured_generation_is_repeatable_for_the_same_daily_identity() = runBlocking {
+        val useCase = configuredDailyGenerationUseCase(LocalDate.of(2027, 4, 18))
+
+        val first = useCase.generate() as DailyPuzzleGenerationResult.Generated
+        val second = useCase.generate() as DailyPuzzleGenerationResult.Generated
+
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun every_date_in_2027_generates_within_the_configured_four_candidates() = runBlocking {
+        var currentDate = LocalDate.of(2027, 1, 1)
+        val useCase = configuredDailyGenerationUseCase(
+            dateSource = DeviceLocalDateSource { currentDate }
+        )
+        val successfulCandidateCounts = IntArray(4)
+
+        repeat(currentDate.lengthOfYear()) {
+            val result = useCase.generate() as DailyPuzzleGenerationResult.Generated
+            assertEquals(currentDate, result.identity.localDate)
+            successfulCandidateCounts[result.candidateIndex.value] += 1
+            currentDate = currentDate.plusDays(1)
+        }
+
+        assertEquals(
+            listOf(365, 0, 0, 0),
+            successfulCandidateCounts.toList()
+        )
+    }
+}
+
+private fun dailyGenerationUseCase(
+    dateSource: DeviceLocalDateSource,
+    generatedFactory: GeneratedPuzzleGenerationUseCaseFactory
+): DailyPuzzleGenerationUseCase = DailyPuzzleGenerationUseCase(
+    currentDailyChallengeResolver = CurrentDailyChallengeResolver(localDateSource = dateSource),
+    generatedPuzzleGenerationUseCaseFactory = generatedFactory
+)
+
+private fun configuredDailyGenerationUseCase(date: LocalDate): DailyPuzzleGenerationUseCase =
+    configuredDailyGenerationUseCase(
+        dateSource = DeviceLocalDateSource { date }
+    )
+
+private fun configuredDailyGenerationUseCase(dateSource: DeviceLocalDateSource): DailyPuzzleGenerationUseCase =
+    dailyGenerationUseCase(
+        dateSource = dateSource,
+        generatedFactory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
+            generationDispatcher = Dispatchers.Unconfined
+        )
+    )
+
+private fun generatedFactory(
+    resultForAttempt: (GeneratedPuzzleGenerationRequest, Int) -> GeneratedPuzzleGenerationResult
+): GeneratedPuzzleGenerationUseCaseFactory = GeneratedPuzzleGenerationUseCaseFactory {
+    var attempt = 0
+    GeneratedPuzzleGenerationUseCase { request ->
+        resultForAttempt(request, attempt++)
+    }
+}
+
+private fun failedResult(
+    request: GeneratedPuzzleGenerationRequest,
+    reason: GeneratedPairsPuzzleGenerationFailureReason
+): GeneratedPuzzleGenerationResult.Failed = GeneratedPuzzleGenerationResult.Failed(
+    failure = GeneratedPairsPuzzleGenerationOutcome.Failed(
+        request = request,
+        attemptsUsed = 1,
+        searchWorkConsumed = 1,
+        reason = reason,
+        candidateRejections = emptyList()
+    )
+)

--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -9,7 +9,8 @@
 - Implemented v10 generated presentation: Quick uses the shared Low learning route
 - Implemented v10 Menu exposure: direct Quick entry through the normal generated-session flow
 - Implemented v10 Daily foundation: versioned identity, `4 Pairs Low` recipe resolution,
-  deterministic four-candidate seed schedule, and device-local date capture
+  deterministic four-candidate seed schedule, device-local date capture, and ordered candidate
+  execution
 - v8 generated challenge matrix: implemented
 - Related references:
   - `docs/product/prd/prd-v5.md`
@@ -182,9 +183,9 @@ Committed puzzle changes update the current snapshot through the stable session 
 The v10 Daily Challenge reuses the existing generated-puzzle pipeline without making the generator
 aware of dates, calendars, completion history, Android clocks, or presentation state.
 
-Status: identity, immutable v10 recipe resolution, the FNV-1a candidate seed schedule, and
-device-local current-identity resolution are implemented. Candidate execution, persistence,
-gameplay, and presentation remain planned.
+Status: identity, immutable v10 recipe resolution, the FNV-1a candidate seed schedule,
+device-local current-identity resolution, and ordered candidate execution are implemented.
+Persistence, gameplay, and presentation remain planned.
 
 One immutable Daily Recipe version:
 
@@ -203,6 +204,10 @@ challenge.
 The recipe payload format, algorithm, challenge, candidate order, and limit are compatibility
 behavior and cannot change under the same recipe version. A deterministic future-date corpus must
 protect both the seed schedule and successful bounded generation before release.
+
+The implemented calendar-year 2027 corpus covers all 365 local dates. Every date generated and
+validated through candidate index `0`; indexes `1..3` were never required, and no date exhausted
+the four-candidate limit.
 
 The date is captured by an injected device-local date source outside the platform-independent
 generator. A local-date change never changes an already constructed generation request.

--- a/docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md
+++ b/docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md
@@ -87,6 +87,10 @@ The generator remains unaware of dates and Daily semantics. It receives ordinary
 generated-puzzle requests. Daily coordination never falls back to device randomness, current
 time-of-day entropy, or a different profile.
 
+Ordered candidate execution is implemented over the existing configured generation use case.
+Non-cancellation failures remain ordered and typed, exhaustion is explicit, and cancellation is
+terminal.
+
 ### Local-Date Boundary
 
 Application composition supplies the current device-local date through an explicit clock

--- a/docs/technical/daily-challenge-persistence.md
+++ b/docs/technical/daily-challenge-persistence.md
@@ -2,8 +2,8 @@
 
 ## Document Status
 
-- Status: Daily identity, recipe resolution, deterministic seed schedule, and device-local date
-  boundary implemented; session persistence and completion history planned
+- Status: Daily identity, recipe resolution, deterministic generation fallback, and device-local
+  date boundary implemented; session persistence and completion history planned
 - Product contract: `docs/product/prd/prd-v10.md`
 - Architecture decision:
   `docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md`
@@ -60,7 +60,8 @@ history.
 The platform-independent identity types, v10 recipe catalog, exact `4 Pairs Low` binding,
 four-candidate FNV-1a seed schedule, and injectable device-local date boundary are implemented.
 Current identity resolution captures one `LocalDate` before generation begins. Candidate
-generation remains outside this implemented boundary.
+generation attempts the recipe seeds in order, preserves typed failure and cancellation, and
+returns the first exact validated initial puzzle.
 
 ---
 


### PR DESCRIPTION
## Related Issue

Resolves #594

## Summary

- Generate Daily puzzles from one captured identity and the configured 4 Pairs Low context.
- Attempt the four recipe seeds in order and preserve typed failure, exhaustion, and cancellation outcomes.
- Return the exact first successful puzzle with its identity, challenge, candidate index, and seed.
- Characterize all 365 dates in 2027; every date succeeds at candidate index 0.
- Update Daily generation and architecture references with the implemented fallback boundary.