### PR TITLE
[288] Model and encode the versioned Daily aggregate

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/data/daily/session/DailyAggregate.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/daily/session/DailyAggregate.kt
@@ -1,0 +1,191 @@
+package org.cescfe.numpairs.data.daily.session
+
+import org.cescfe.numpairs.domain.daily.DailyCandidateIndex
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DailyRecipeContract
+import org.cescfe.numpairs.domain.daily.DailyRecipeContracts
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+
+const val DAILY_AGGREGATE_SCHEMA_VERSION: Int = 1
+internal const val MAX_DAILY_COMPLETION_COUNT: Int = 10_000
+
+@JvmInline
+value class DailySessionId(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "Daily Session id must not be blank."
+        }
+    }
+}
+
+data class DailySessionSnapshot(
+    val sessionId: DailySessionId,
+    val dailyChallengeId: DailyChallengeId,
+    val candidateIndex: DailyCandidateIndex,
+    val seed: Int,
+    val initialPuzzle: Puzzle,
+    val currentPuzzle: Puzzle
+) {
+    val recipeContract: DailyRecipeContract = requireNotNull(
+        DailyRecipeContracts.catalog.resolveOrNull(dailyChallengeId.recipeVersion)
+    ) {
+        "Daily Session recipe ${dailyChallengeId.recipeVersion.value} is unsupported."
+    }
+
+    init {
+        require(candidateIndex in recipeContract.candidateIndices) {
+            "Daily Session candidate index must belong to its recipe."
+        }
+        require(seed == recipeContract.seedFor(dailyChallengeId, candidateIndex)) {
+            "Daily Session seed must match its recipe candidate."
+        }
+        requirePuzzleMatchesRecipe(initialPuzzle, recipeContract)
+        requirePuzzleMatchesRecipe(currentPuzzle, recipeContract)
+        require(initialPuzzle.isIncomplete) {
+            "Initial Daily Session puzzle must be incomplete."
+        }
+        require(!currentPuzzle.isSolved) {
+            "An active Daily Session puzzle must be unsolved."
+        }
+        require(
+            initialPuzzle.board.tiles.all { tile ->
+                tile.expression.leftOperand == Expression.Operand.Hidden &&
+                    tile.expression.operator == Operator.Hidden &&
+                    tile.expression.rightOperand == Expression.Operand.Hidden
+            }
+        ) {
+            "Initial Daily Session tile expressions must be hidden."
+        }
+        require(initialPuzzle.strip.entries.none { entry -> entry.item is StripItem.PlayerEntered }) {
+            "Initial Daily Session strip entries cannot be player-entered."
+        }
+        requireInitialStripMatchesRecipe(initialPuzzle, recipeContract)
+        requireConsistentProgress(initialPuzzle = initialPuzzle, currentPuzzle = currentPuzzle)
+        requireValidCurrentAssignments(currentPuzzle)
+    }
+}
+
+data class DailyAggregate(
+    val schemaVersion: Int = DAILY_AGGREGATE_SCHEMA_VERSION,
+    val activeSession: DailySessionSnapshot? = null,
+    val completedChallengeIds: List<DailyChallengeId> = emptyList()
+) {
+    init {
+        require(schemaVersion == DAILY_AGGREGATE_SCHEMA_VERSION) {
+            "Daily aggregate schema version is unsupported."
+        }
+        require(completedChallengeIds.size <= MAX_DAILY_COMPLETION_COUNT) {
+            "Daily aggregate completion count exceeds the supported bound."
+        }
+        require(completedChallengeIds == completedChallengeIds.sortedWith(DAILY_CHALLENGE_ID_COMPARATOR)) {
+            "Daily aggregate completions must use canonical date and recipe order."
+        }
+        require(completedChallengeIds.distinct().size == completedChallengeIds.size) {
+            "Daily aggregate completion identities must be unique."
+        }
+        require(completedChallengeIds.map(DailyChallengeId::localDate).distinct().size == completedChallengeIds.size) {
+            "Daily aggregate can contain at most one completion per local date."
+        }
+        require(activeSession?.dailyChallengeId?.localDate !in completedChallengeIds.map(DailyChallengeId::localDate)) {
+            "Daily aggregate cannot keep an active session for a completed local date."
+        }
+    }
+}
+
+internal val DAILY_CHALLENGE_ID_COMPARATOR: Comparator<DailyChallengeId> =
+    compareBy(DailyChallengeId::localDate, { identity -> identity.recipeVersion.value })
+
+private fun requirePuzzleMatchesRecipe(puzzle: Puzzle, recipeContract: DailyRecipeContract) {
+    require(puzzle.board.tiles.size == recipeContract.profile.size.boardTileCount) {
+        "Daily Session board shape must match its recipe profile."
+    }
+    require(puzzle.strip.entries.size == recipeContract.profile.size.stripEntryCount) {
+        "Daily Session strip shape must match its recipe profile."
+    }
+    require(
+        puzzle.strip.entries.map { entry -> entry.id }.toSet() ==
+            (0 until recipeContract.profile.size.stripEntryCount).toSet()
+    ) {
+        "Daily Session strip identities must match its recipe shape."
+    }
+}
+
+private fun requireInitialStripMatchesRecipe(puzzle: Puzzle, recipeContract: DailyRecipeContract) {
+    val knownValues = puzzle.strip.entries.mapNotNull { entry ->
+        (entry.item as? StripItem.Known)?.value
+    }
+    require(knownValues.size in recipeContract.profile.initialStripMaskPolicy.knownEntryCountRange) {
+        "Initial Daily Session known-entry count must match its recipe profile."
+    }
+    require(knownValues.all { value -> value in recipeContract.profile.stripValuePolicy.valueRange }) {
+        "Initial Daily Session known values must match its recipe profile."
+    }
+    require(
+        knownValues.groupingBy { value -> value }
+            .eachCount()
+            .all { (_, count) -> count <= recipeContract.profile.stripValuePolicy.maxOccurrencesPerValue }
+    ) {
+        "Initial Daily Session known-value occurrences must match its recipe profile."
+    }
+}
+
+private fun requireConsistentProgress(initialPuzzle: Puzzle, currentPuzzle: Puzzle) {
+    require(
+        initialPuzzle.board.tiles.map { tile -> tile.result } ==
+            currentPuzzle.board.tiles.map { tile -> tile.result }
+    ) {
+        "Daily Session puzzle results must remain unchanged."
+    }
+    require(
+        initialPuzzle.strip.entries.map { entry -> entry.id }.toSet() ==
+            currentPuzzle.strip.entries.map { entry -> entry.id }.toSet()
+    ) {
+        "Daily Session strip entry identities must remain unchanged."
+    }
+
+    val currentItemsByEntryId = currentPuzzle.strip.entries.associate { entry ->
+        entry.id to entry.item
+    }
+    initialPuzzle.strip.entries.forEach { initialEntry ->
+        val currentItem = currentItemsByEntryId.getValue(initialEntry.id)
+        when (val initialItem = initialEntry.item) {
+            StripItem.Hidden -> require(currentItem !is StripItem.Known) {
+                "Hidden Daily Session strip entries cannot become known entries."
+            }
+
+            is StripItem.Known -> require(currentItem == initialItem) {
+                "Known Daily Session strip entries must remain unchanged."
+            }
+
+            is StripItem.PlayerEntered -> error(
+                "Initial Daily Session strip entries cannot be player-entered."
+            )
+        }
+    }
+}
+
+private fun requireValidCurrentAssignments(currentPuzzle: Puzzle) {
+    val visibleValuesByEntryId = currentPuzzle.strip.entries.associate { entry ->
+        entry.id to when (val item = entry.item) {
+            StripItem.Hidden -> null
+            is StripItem.Known -> item.value
+            is StripItem.PlayerEntered -> item.value
+        }
+    }
+    currentPuzzle.board.tiles.forEach { tile ->
+        listOf(tile.expression.leftOperand, tile.expression.rightOperand).forEach { operand ->
+            when (operand) {
+                Expression.Operand.Hidden -> Unit
+                is Expression.Operand.Known -> require(
+                    operand.stripEntryId != null &&
+                        visibleValuesByEntryId[operand.stripEntryId] == operand.value
+                ) {
+                    "Daily Session operands must reference matching visible strip entries."
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/daily/session/DailyAggregateCodec.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/daily/session/DailyAggregateCodec.kt
@@ -1,0 +1,148 @@
+package org.cescfe.numpairs.data.daily.session
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.IOException
+import java.time.DateTimeException
+import java.time.LocalDate
+import org.cescfe.numpairs.data.puzzle.readPuzzleSnapshot
+import org.cescfe.numpairs.data.puzzle.writePuzzleSnapshot
+import org.cescfe.numpairs.domain.daily.DailyCandidateIndex
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
+
+sealed interface DailyAggregateDecodingResult {
+    data class Decoded(val aggregate: DailyAggregate) : DailyAggregateDecodingResult
+
+    data class UnsupportedVersion(val schemaVersion: Int) : DailyAggregateDecodingResult
+
+    data object InvalidData : DailyAggregateDecodingResult
+}
+
+class DailyAggregateCodec {
+    fun encode(aggregate: DailyAggregate): ByteArray {
+        require(aggregate.schemaVersion == DAILY_AGGREGATE_SCHEMA_VERSION) {
+            "Only the current Daily aggregate schema can be encoded."
+        }
+
+        return ByteArrayOutputStream().use { bytes ->
+            DataOutputStream(bytes).use { output ->
+                output.writeInt(FILE_MAGIC)
+                output.writeInt(aggregate.schemaVersion)
+                output.writeBoolean(aggregate.activeSession != null)
+                aggregate.activeSession?.let { activeSession ->
+                    val encodedSession = encodeSession(activeSession)
+                    require(encodedSession.size <= MAX_SESSION_PAYLOAD_SIZE) {
+                        "Daily Session payload exceeds the supported bound."
+                    }
+                    output.writeInt(encodedSession.size)
+                    output.write(encodedSession)
+                }
+                output.writeInt(aggregate.completedChallengeIds.size)
+                aggregate.completedChallengeIds.forEach(output::writeDailyChallengeId)
+            }
+            bytes.toByteArray()
+        }
+    }
+
+    fun decode(bytes: ByteArray): DailyAggregateDecodingResult = try {
+        DataInputStream(ByteArrayInputStream(bytes)).use { input ->
+            if (input.readInt() != FILE_MAGIC) {
+                return DailyAggregateDecodingResult.InvalidData
+            }
+
+            val schemaVersion = input.readInt()
+            if (schemaVersion != DAILY_AGGREGATE_SCHEMA_VERSION) {
+                return DailyAggregateDecodingResult.UnsupportedVersion(schemaVersion)
+            }
+
+            val activeSession = if (input.readBoolean()) {
+                val sessionPayloadSize = input.readInt()
+                if (sessionPayloadSize !in 1..MAX_SESSION_PAYLOAD_SIZE) {
+                    return DailyAggregateDecodingResult.InvalidData
+                }
+                val sessionPayload = ByteArray(sessionPayloadSize)
+                input.readFully(sessionPayload)
+                decodeSessionOrNull(sessionPayload)
+            } else {
+                null
+            }
+            val completionCount = input.readInt()
+            if (completionCount !in 0..MAX_DAILY_COMPLETION_COUNT) {
+                return DailyAggregateDecodingResult.InvalidData
+            }
+            val completedChallengeIds = List(completionCount) {
+                input.readDailyChallengeId()
+            }
+
+            if (input.available() != 0) {
+                DailyAggregateDecodingResult.InvalidData
+            } else {
+                DailyAggregateDecodingResult.Decoded(
+                    DailyAggregate(
+                        schemaVersion = schemaVersion,
+                        activeSession = activeSession,
+                        completedChallengeIds = completedChallengeIds
+                    )
+                )
+            }
+        }
+    } catch (_: IOException) {
+        DailyAggregateDecodingResult.InvalidData
+    } catch (_: DateTimeException) {
+        DailyAggregateDecodingResult.InvalidData
+    } catch (_: IllegalArgumentException) {
+        DailyAggregateDecodingResult.InvalidData
+    } catch (_: IllegalStateException) {
+        DailyAggregateDecodingResult.InvalidData
+    }
+
+    private fun encodeSession(snapshot: DailySessionSnapshot): ByteArray = ByteArrayOutputStream().use { bytes ->
+        DataOutputStream(bytes).use { output ->
+            output.writeUTF(snapshot.sessionId.value)
+            output.writeDailyChallengeId(snapshot.dailyChallengeId)
+            output.writeInt(snapshot.candidateIndex.value)
+            output.writeInt(snapshot.seed)
+            output.writePuzzleSnapshot(snapshot.initialPuzzle)
+            output.writePuzzleSnapshot(snapshot.currentPuzzle)
+        }
+        bytes.toByteArray()
+    }
+
+    private fun decodeSessionOrNull(bytes: ByteArray): DailySessionSnapshot? = try {
+        DataInputStream(ByteArrayInputStream(bytes)).use { input ->
+            val snapshot = DailySessionSnapshot(
+                sessionId = DailySessionId(input.readUTF()),
+                dailyChallengeId = input.readDailyChallengeId(),
+                candidateIndex = DailyCandidateIndex(input.readInt()),
+                seed = input.readInt(),
+                initialPuzzle = input.readPuzzleSnapshot(),
+                currentPuzzle = input.readPuzzleSnapshot()
+            )
+            snapshot.takeIf { input.available() == 0 }
+        }
+    } catch (_: IOException) {
+        null
+    } catch (_: DateTimeException) {
+        null
+    } catch (_: IllegalArgumentException) {
+        null
+    } catch (_: IllegalStateException) {
+        null
+    }
+}
+
+private fun DataOutputStream.writeDailyChallengeId(identity: DailyChallengeId) {
+    writeUTF(identity.canonicalLocalDate)
+    writeUTF(identity.recipeVersion.value)
+}
+
+private fun DataInputStream.readDailyChallengeId(): DailyChallengeId = DailyChallengeId(
+    localDate = LocalDate.parse(readUTF()),
+    recipeVersion = DailyRecipeVersion(readUTF())
+)
+
+private const val FILE_MAGIC = 0x4E504441
+private const val MAX_SESSION_PAYLOAD_SIZE = 1_000_000

--- a/app/src/main/java/org/cescfe/numpairs/data/generated/session/GeneratedSessionSnapshotCodec.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/generated/session/GeneratedSessionSnapshotCodec.kt
@@ -5,14 +5,8 @@ import java.io.ByteArrayOutputStream
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import java.io.IOException
-import org.cescfe.numpairs.domain.puzzle.model.Board
-import org.cescfe.numpairs.domain.puzzle.model.Expression
-import org.cescfe.numpairs.domain.puzzle.model.Operator
-import org.cescfe.numpairs.domain.puzzle.model.Puzzle
-import org.cescfe.numpairs.domain.puzzle.model.Strip
-import org.cescfe.numpairs.domain.puzzle.model.StripEntry
-import org.cescfe.numpairs.domain.puzzle.model.StripItem
-import org.cescfe.numpairs.domain.puzzle.model.Tile
+import org.cescfe.numpairs.data.puzzle.readPuzzleSnapshot
+import org.cescfe.numpairs.data.puzzle.writePuzzleSnapshot
 
 sealed interface GeneratedSessionSnapshotDecodingResult {
     data class Decoded(val snapshot: GeneratedSessionSnapshot) : GeneratedSessionSnapshotDecodingResult
@@ -36,8 +30,8 @@ class GeneratedSessionSnapshotCodec {
                 output.writeUTF(snapshot.modeId)
                 output.writeUTF(snapshot.profileId)
                 output.writeInt(snapshot.seed)
-                output.writePuzzle(snapshot.initialPuzzle)
-                output.writePuzzle(snapshot.currentPuzzle)
+                output.writePuzzleSnapshot(snapshot.initialPuzzle)
+                output.writePuzzleSnapshot(snapshot.currentPuzzle)
             }
             bytes.toByteArray()
         }
@@ -60,8 +54,8 @@ class GeneratedSessionSnapshotCodec {
                 modeId = input.readUTF(),
                 profileId = input.readUTF(),
                 seed = input.readInt(),
-                initialPuzzle = input.readPuzzle(),
-                currentPuzzle = input.readPuzzle()
+                initialPuzzle = input.readPuzzleSnapshot(),
+                currentPuzzle = input.readPuzzleSnapshot()
             )
 
             if (input.available() != 0) {
@@ -79,142 +73,4 @@ class GeneratedSessionSnapshotCodec {
     }
 }
 
-private fun DataOutputStream.writePuzzle(puzzle: Puzzle) {
-    writeInt(puzzle.board.tiles.size)
-    puzzle.board.tiles.forEach(::writeTile)
-    writeInt(puzzle.strip.entries.size)
-    puzzle.strip.entries.forEach(::writeStripEntry)
-}
-
-private fun DataOutputStream.writeTile(tile: Tile) {
-    writeOperand(tile.expression.leftOperand)
-    writeOperator(tile.expression.operator)
-    writeOperand(tile.expression.rightOperand)
-    writeInt(tile.result)
-}
-
-private fun DataOutputStream.writeOperand(operand: Expression.Operand) {
-    when (operand) {
-        Expression.Operand.Hidden -> writeByte(OPERAND_HIDDEN)
-        is Expression.Operand.Known -> {
-            writeByte(OPERAND_KNOWN)
-            writeInt(operand.value)
-            writeBoolean(operand.stripEntryId != null)
-            operand.stripEntryId?.let(::writeInt)
-        }
-    }
-}
-
-private fun DataOutputStream.writeOperator(operator: Operator) {
-    val encodedOperator = when (operator) {
-        Operator.Hidden -> OPERATOR_HIDDEN
-        Operator.Addition -> OPERATOR_ADDITION
-        Operator.Multiplication -> OPERATOR_MULTIPLICATION
-    }
-    writeByte(encodedOperator)
-}
-
-private fun DataOutputStream.writeStripEntry(entry: StripEntry) {
-    writeInt(entry.id)
-    when (val item = entry.item) {
-        StripItem.Hidden -> writeByte(STRIP_ITEM_HIDDEN)
-        is StripItem.Known -> {
-            writeByte(STRIP_ITEM_KNOWN)
-            writeInt(item.value)
-        }
-
-        is StripItem.PlayerEntered -> {
-            writeByte(STRIP_ITEM_PLAYER_ENTERED)
-            writeInt(item.value)
-        }
-    }
-}
-
-private fun DataInputStream.readPuzzle(): Puzzle {
-    val tileCount = readPuzzleElementCount()
-    val board = Board(
-        tiles = List(tileCount) {
-            readTile()
-        }
-    )
-    val stripEntryCount = readPuzzleElementCount()
-    val strip = Strip.fromEntries(
-        entries = List(stripEntryCount) {
-            readStripEntry()
-        }
-    )
-
-    return Puzzle(
-        board = board,
-        strip = strip
-    )
-}
-
-private fun DataInputStream.readTile(): Tile = Tile(
-    expression = Expression(
-        leftOperand = readOperand(),
-        operator = readOperator(),
-        rightOperand = readOperand()
-    ),
-    result = readInt()
-)
-
-private fun DataInputStream.readOperand(): Expression.Operand = when (readUnsignedByte()) {
-    OPERAND_HIDDEN -> Expression.Operand.Hidden
-    OPERAND_KNOWN -> {
-        val value = readInt()
-        val stripEntryId = if (readBoolean()) {
-            readInt()
-        } else {
-            null
-        }
-        Expression.Operand.Known(
-            value = value,
-            stripEntryId = stripEntryId
-        )
-    }
-
-    else -> throw InvalidGeneratedSessionData()
-}
-
-private fun DataInputStream.readOperator(): Operator = when (readUnsignedByte()) {
-    OPERATOR_HIDDEN -> Operator.Hidden
-    OPERATOR_ADDITION -> Operator.ADDITION
-    OPERATOR_MULTIPLICATION -> Operator.MULTIPLICATION
-    else -> throw InvalidGeneratedSessionData()
-}
-
-private fun DataInputStream.readStripEntry(): StripEntry {
-    val id = readInt()
-    val item = when (readUnsignedByte()) {
-        STRIP_ITEM_HIDDEN -> StripItem.Hidden
-        STRIP_ITEM_KNOWN -> StripItem.Known(readInt())
-        STRIP_ITEM_PLAYER_ENTERED -> StripItem.PlayerEntered(readInt())
-        else -> throw InvalidGeneratedSessionData()
-    }
-
-    return StripEntry(
-        id = id,
-        item = item
-    )
-}
-
-private fun DataInputStream.readPuzzleElementCount(): Int = readInt().also { count ->
-    if (count !in MIN_PUZZLE_ELEMENT_COUNT..MAX_PUZZLE_ELEMENT_COUNT || count % 2 != 0) {
-        throw InvalidGeneratedSessionData()
-    }
-}
-
-private class InvalidGeneratedSessionData : IllegalArgumentException()
-
 private const val FILE_MAGIC = 0x4E505331
-private const val MIN_PUZZLE_ELEMENT_COUNT = 2
-private const val MAX_PUZZLE_ELEMENT_COUNT = 128
-private const val OPERAND_HIDDEN = 0
-private const val OPERAND_KNOWN = 1
-private const val OPERATOR_HIDDEN = 0
-private const val OPERATOR_ADDITION = 1
-private const val OPERATOR_MULTIPLICATION = 2
-private const val STRIP_ITEM_HIDDEN = 0
-private const val STRIP_ITEM_KNOWN = 1
-private const val STRIP_ITEM_PLAYER_ENTERED = 2

--- a/app/src/main/java/org/cescfe/numpairs/data/puzzle/PuzzleBinaryCodec.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/puzzle/PuzzleBinaryCodec.kt
@@ -1,0 +1,151 @@
+package org.cescfe.numpairs.data.puzzle
+
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import org.cescfe.numpairs.domain.puzzle.model.Board
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.Operator
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.Strip
+import org.cescfe.numpairs.domain.puzzle.model.StripEntry
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.cescfe.numpairs.domain.puzzle.model.Tile
+
+internal fun DataOutputStream.writePuzzleSnapshot(puzzle: Puzzle) {
+    writeInt(puzzle.board.tiles.size)
+    puzzle.board.tiles.forEach(::writeTile)
+    writeInt(puzzle.strip.entries.size)
+    puzzle.strip.entries.forEach(::writeStripEntry)
+}
+
+private fun DataOutputStream.writeTile(tile: Tile) {
+    writeOperand(tile.expression.leftOperand)
+    writeOperator(tile.expression.operator)
+    writeOperand(tile.expression.rightOperand)
+    writeInt(tile.result)
+}
+
+private fun DataOutputStream.writeOperand(operand: Expression.Operand) {
+    when (operand) {
+        Expression.Operand.Hidden -> writeByte(OPERAND_HIDDEN)
+        is Expression.Operand.Known -> {
+            writeByte(OPERAND_KNOWN)
+            writeInt(operand.value)
+            writeBoolean(operand.stripEntryId != null)
+            operand.stripEntryId?.let(::writeInt)
+        }
+    }
+}
+
+private fun DataOutputStream.writeOperator(operator: Operator) {
+    val encodedOperator = when (operator) {
+        Operator.Hidden -> OPERATOR_HIDDEN
+        Operator.Addition -> OPERATOR_ADDITION
+        Operator.Multiplication -> OPERATOR_MULTIPLICATION
+    }
+    writeByte(encodedOperator)
+}
+
+private fun DataOutputStream.writeStripEntry(entry: StripEntry) {
+    writeInt(entry.id)
+    when (val item = entry.item) {
+        StripItem.Hidden -> writeByte(STRIP_ITEM_HIDDEN)
+        is StripItem.Known -> {
+            writeByte(STRIP_ITEM_KNOWN)
+            writeInt(item.value)
+        }
+
+        is StripItem.PlayerEntered -> {
+            writeByte(STRIP_ITEM_PLAYER_ENTERED)
+            writeInt(item.value)
+        }
+    }
+}
+
+internal fun DataInputStream.readPuzzleSnapshot(): Puzzle {
+    val tileCount = readPuzzleElementCount()
+    val board = Board(
+        tiles = List(tileCount) {
+            readTile()
+        }
+    )
+    val stripEntryCount = readPuzzleElementCount()
+    val strip = Strip.fromEntries(
+        entries = List(stripEntryCount) {
+            readStripEntry()
+        }
+    )
+
+    return Puzzle(
+        board = board,
+        strip = strip
+    )
+}
+
+private fun DataInputStream.readTile(): Tile = Tile(
+    expression = Expression(
+        leftOperand = readOperand(),
+        operator = readOperator(),
+        rightOperand = readOperand()
+    ),
+    result = readInt()
+)
+
+private fun DataInputStream.readOperand(): Expression.Operand = when (readUnsignedByte()) {
+    OPERAND_HIDDEN -> Expression.Operand.Hidden
+    OPERAND_KNOWN -> {
+        val value = readInt()
+        val stripEntryId = if (readBoolean()) {
+            readInt()
+        } else {
+            null
+        }
+        Expression.Operand.Known(
+            value = value,
+            stripEntryId = stripEntryId
+        )
+    }
+
+    else -> throw InvalidPuzzleBinaryData()
+}
+
+private fun DataInputStream.readOperator(): Operator = when (readUnsignedByte()) {
+    OPERATOR_HIDDEN -> Operator.Hidden
+    OPERATOR_ADDITION -> Operator.ADDITION
+    OPERATOR_MULTIPLICATION -> Operator.MULTIPLICATION
+    else -> throw InvalidPuzzleBinaryData()
+}
+
+private fun DataInputStream.readStripEntry(): StripEntry {
+    val id = readInt()
+    val item = when (readUnsignedByte()) {
+        STRIP_ITEM_HIDDEN -> StripItem.Hidden
+        STRIP_ITEM_KNOWN -> StripItem.Known(readInt())
+        STRIP_ITEM_PLAYER_ENTERED -> StripItem.PlayerEntered(readInt())
+        else -> throw InvalidPuzzleBinaryData()
+    }
+
+    return StripEntry(
+        id = id,
+        item = item
+    )
+}
+
+private fun DataInputStream.readPuzzleElementCount(): Int = readInt().also { count ->
+    if (count !in MIN_PUZZLE_ELEMENT_COUNT..MAX_PUZZLE_ELEMENT_COUNT || count % 2 != 0) {
+        throw InvalidPuzzleBinaryData()
+    }
+}
+
+private class InvalidPuzzleBinaryData : IllegalArgumentException()
+
+private const val MIN_PUZZLE_ELEMENT_COUNT = 2
+private const val MAX_PUZZLE_ELEMENT_COUNT = 128
+private const val OPERAND_HIDDEN = 0
+private const val OPERAND_KNOWN = 1
+private const val OPERATOR_HIDDEN = 0
+private const val OPERATOR_ADDITION = 1
+private const val OPERATOR_MULTIPLICATION = 2
+private const val STRIP_ITEM_HIDDEN = 0
+private const val STRIP_ITEM_KNOWN = 1
+private const val STRIP_ITEM_PLAYER_ENTERED = 2

--- a/app/src/main/java/org/cescfe/numpairs/domain/daily/DailyRecipeContract.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/daily/DailyRecipeContract.kt
@@ -1,0 +1,69 @@
+package org.cescfe.numpairs.domain.daily
+
+import java.time.LocalDate
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfiles
+
+data class DailyRecipeContract(
+    val version: DailyRecipeVersion,
+    val profile: GeneratedPuzzleProfile,
+    val candidateIndices: List<DailyCandidateIndex>,
+    private val seedSchedule: DailyCandidateSeedSchedule
+) {
+    init {
+        require(candidateIndices.isNotEmpty()) {
+            "A Daily recipe contract must configure at least one candidate."
+        }
+        require(candidateIndices == List(candidateIndices.size, ::DailyCandidateIndex)) {
+            "Daily recipe candidate indexes must be contiguous and start at zero."
+        }
+    }
+
+    fun identityFor(localDate: LocalDate): DailyChallengeId = DailyChallengeId(
+        localDate = localDate,
+        recipeVersion = version
+    )
+
+    fun seedFor(identity: DailyChallengeId, candidateIndex: DailyCandidateIndex): Int {
+        require(identity.recipeVersion == version) {
+            "Daily Challenge identity must use recipe ${version.value}."
+        }
+        require(candidateIndex in candidateIndices) {
+            "Daily candidate index ${candidateIndex.value} is not configured by recipe ${version.value}."
+        }
+        return seedSchedule.seedFor(identity = identity, candidateIndex = candidateIndex)
+    }
+}
+
+class DailyRecipeContractCatalog(contracts: Collection<DailyRecipeContract>) {
+    val all: List<DailyRecipeContract> = contracts.toList()
+    private val contractsByVersion: Map<DailyRecipeVersion, DailyRecipeContract> =
+        all.associateBy(DailyRecipeContract::version)
+
+    init {
+        require(all.isNotEmpty()) {
+            "At least one Daily recipe contract must be configured."
+        }
+        require(contractsByVersion.size == all.size) {
+            "Daily recipe contract versions must be unique."
+        }
+    }
+
+    fun resolve(version: DailyRecipeVersion): DailyRecipeContract = requireNotNull(contractsByVersion[version]) {
+        "No Daily recipe contract is configured for version ${version.value}."
+    }
+
+    fun resolveOrNull(version: DailyRecipeVersion): DailyRecipeContract? = contractsByVersion[version]
+}
+
+object DailyRecipeContracts {
+    val FOUR_PAIRS_LOW_V1: DailyRecipeContract = DailyRecipeContract(
+        version = DailyRecipeVersion("daily-4-pairs-low-v1"),
+        profile = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW,
+        candidateIndices = List(4, ::DailyCandidateIndex),
+        seedSchedule = Fnv1a32DailyCandidateSeedSchedule
+    )
+    val catalog: DailyRecipeContractCatalog = DailyRecipeContractCatalog(
+        contracts = listOf(FOUR_PAIRS_LOW_V1)
+    )
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyRecipe.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyRecipe.kt
@@ -2,46 +2,39 @@ package org.cescfe.numpairs.feature.daily
 
 import java.time.LocalDate
 import org.cescfe.numpairs.domain.daily.DailyCandidateIndex
-import org.cescfe.numpairs.domain.daily.DailyCandidateSeedSchedule
 import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DailyRecipeContract
+import org.cescfe.numpairs.domain.daily.DailyRecipeContractCatalog
+import org.cescfe.numpairs.domain.daily.DailyRecipeContracts
 import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
-import org.cescfe.numpairs.domain.daily.Fnv1a32DailyCandidateSeedSchedule
 import org.cescfe.numpairs.feature.generated.GeneratedChallenge
 import org.cescfe.numpairs.feature.generated.GeneratedChallengeCatalog
 import org.cescfe.numpairs.feature.generated.GeneratedModes
 
-data class DailyRecipe(
-    val version: DailyRecipeVersion,
-    val challenge: GeneratedChallenge,
-    val candidateIndices: List<DailyCandidateIndex>,
-    private val seedSchedule: DailyCandidateSeedSchedule
-) {
+data class DailyRecipe(val contract: DailyRecipeContract, val challenge: GeneratedChallenge) {
+    val version: DailyRecipeVersion
+        get() = contract.version
+
+    val candidateIndices: List<DailyCandidateIndex>
+        get() = contract.candidateIndices
+
     init {
-        require(candidateIndices.isNotEmpty()) {
-            "A Daily recipe must configure at least one candidate."
-        }
-        require(candidateIndices == List(candidateIndices.size, ::DailyCandidateIndex)) {
-            "Daily recipe candidate indexes must be contiguous and start at zero."
+        require(challenge.profile == contract.profile) {
+            "Daily recipe challenge profile must match its platform-independent contract."
         }
     }
 
-    fun identityFor(localDate: LocalDate): DailyChallengeId = DailyChallengeId(
-        localDate = localDate,
-        recipeVersion = version
-    )
+    fun identityFor(localDate: LocalDate): DailyChallengeId = contract.identityFor(localDate)
 
-    fun seedFor(identity: DailyChallengeId, candidateIndex: DailyCandidateIndex): Int {
-        require(identity.recipeVersion == version) {
-            "Daily Challenge identity must use recipe ${version.value}."
-        }
-        require(candidateIndex in candidateIndices) {
-            "Daily candidate index ${candidateIndex.value} is not configured by recipe ${version.value}."
-        }
-        return seedSchedule.seedFor(identity = identity, candidateIndex = candidateIndex)
-    }
+    fun seedFor(identity: DailyChallengeId, candidateIndex: DailyCandidateIndex): Int =
+        contract.seedFor(identity = identity, candidateIndex = candidateIndex)
 }
 
-class DailyRecipeCatalog(recipes: Collection<DailyRecipe>, generatedChallengeCatalog: GeneratedChallengeCatalog) {
+class DailyRecipeCatalog(
+    recipes: Collection<DailyRecipe>,
+    generatedChallengeCatalog: GeneratedChallengeCatalog,
+    recipeContractCatalog: DailyRecipeContractCatalog = DailyRecipeContracts.catalog
+) {
     val all: List<DailyRecipe> = recipes.toList()
     private val recipesByVersion: Map<DailyRecipeVersion, DailyRecipe> = all.associateBy(DailyRecipe::version)
 
@@ -51,6 +44,9 @@ class DailyRecipeCatalog(recipes: Collection<DailyRecipe>, generatedChallengeCat
         }
         require(recipesByVersion.size == all.size) {
             "Daily recipe versions must be unique."
+        }
+        require(all.all { recipe -> recipeContractCatalog.resolve(recipe.version) == recipe.contract }) {
+            "Every Daily recipe must use its configured platform-independent contract."
         }
         require(
             all.all { recipe ->
@@ -70,10 +66,8 @@ class DailyRecipeCatalog(recipes: Collection<DailyRecipe>, generatedChallengeCat
 
 object DailyRecipes {
     val FOUR_PAIRS_LOW_V1: DailyRecipe = DailyRecipe(
-        version = DailyRecipeVersion("daily-4-pairs-low-v1"),
-        challenge = GeneratedModes.FOUR_PAIRS_LOW,
-        candidateIndices = List(4, ::DailyCandidateIndex),
-        seedSchedule = Fnv1a32DailyCandidateSeedSchedule
+        contract = DailyRecipeContracts.FOUR_PAIRS_LOW_V1,
+        challenge = GeneratedModes.FOUR_PAIRS_LOW
     )
     val catalog: DailyRecipeCatalog = DailyRecipeCatalog(
         recipes = listOf(FOUR_PAIRS_LOW_V1),

--- a/app/src/test/java/org/cescfe/numpairs/data/daily/session/DailyAggregateCodecTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/daily/session/DailyAggregateCodecTest.kt
@@ -1,0 +1,392 @@
+package org.cescfe.numpairs.data.daily.session
+
+import java.io.ByteArrayOutputStream
+import java.io.DataOutputStream
+import java.nio.ByteBuffer
+import java.time.LocalDate
+import org.cescfe.numpairs.domain.daily.DailyCandidateIndex
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DailyRecipeContracts
+import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerator
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPuzzleGenerationRequest
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfiles
+import org.cescfe.numpairs.domain.generated.puzzle.GeneratedPairsPuzzle
+import org.cescfe.numpairs.domain.puzzle.model.Board
+import org.cescfe.numpairs.domain.puzzle.model.Expression
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.Strip
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DailyAggregateCodecTest {
+    private val codec = DailyAggregateCodec()
+
+    @Test
+    fun aggregate_round_trip_preserves_exact_session_progress_and_completion_identity() {
+        val fixture = generatedDailyFixture()
+        val currentPuzzle = fixture.progressPuzzle()
+        val snapshot = fixture.snapshot(currentPuzzle = currentPuzzle)
+        val completions = listOf(
+            dailyChallengeId(date = LocalDate.of(2026, 12, 31)),
+            dailyChallengeId(
+                date = LocalDate.of(2027, 1, 1),
+                recipeVersion = DailyRecipeVersion("retired-daily-recipe")
+            )
+        )
+        val aggregate = DailyAggregate(
+            activeSession = snapshot,
+            completedChallengeIds = completions
+        )
+
+        val decoded = codec.decode(codec.encode(aggregate))
+
+        assertEquals(DailyAggregateDecodingResult.Decoded(aggregate), decoded)
+        val decodedSnapshot = (decoded as DailyAggregateDecodingResult.Decoded).aggregate.activeSession!!
+        assertEquals(currentPuzzle.board.tiles, decodedSnapshot.currentPuzzle.board.tiles)
+        assertEquals(currentPuzzle.strip.entries, decodedSnapshot.currentPuzzle.strip.entries)
+        assertEquals(snapshot.candidateIndex, decodedSnapshot.candidateIndex)
+        assertEquals(snapshot.seed, decodedSnapshot.seed)
+    }
+
+    @Test
+    fun encoding_is_deterministic() {
+        val aggregate = DailyAggregate(
+            activeSession = generatedDailyFixture().snapshot(),
+            completedChallengeIds = listOf(dailyChallengeId(LocalDate.of(2026, 12, 31)))
+        )
+
+        assertTrue(codec.encode(aggregate).contentEquals(codec.encode(aggregate)))
+    }
+
+    @Test
+    fun malformed_optional_session_is_discarded_while_valid_completions_are_preserved() {
+        val completion = dailyChallengeId(LocalDate.of(2026, 12, 31))
+        val encoded = codec.encode(
+            DailyAggregate(
+                activeSession = generatedDailyFixture().snapshot(),
+                completedChallengeIds = listOf(completion)
+            )
+        )
+        encoded[SESSION_PAYLOAD_OFFSET] = 0
+        encoded[SESSION_PAYLOAD_OFFSET + 1] = 0
+
+        val decoded = codec.decode(encoded) as DailyAggregateDecodingResult.Decoded
+
+        assertNull(decoded.aggregate.activeSession)
+        assertEquals(listOf(completion), decoded.aggregate.completedChallengeIds)
+    }
+
+    @Test
+    fun codec_reports_unsupported_schema_version() {
+        val encoded = codec.encode(DailyAggregate())
+        ByteBuffer.wrap(encoded).putInt(Int.SIZE_BYTES, DAILY_AGGREGATE_SCHEMA_VERSION + 1)
+
+        assertEquals(
+            DailyAggregateDecodingResult.UnsupportedVersion(DAILY_AGGREGATE_SCHEMA_VERSION + 1),
+            codec.decode(encoded)
+        )
+    }
+
+    @Test
+    fun codec_rejects_truncated_trailing_and_impossible_payloads() {
+        val encoded = codec.encode(
+            DailyAggregate(activeSession = generatedDailyFixture().snapshot())
+        )
+
+        assertEquals(
+            DailyAggregateDecodingResult.InvalidData,
+            codec.decode(byteArrayOf(1, 2, 3))
+        )
+        assertEquals(
+            DailyAggregateDecodingResult.InvalidData,
+            codec.decode(encoded.copyOf(encoded.size - 1))
+        )
+        assertEquals(
+            DailyAggregateDecodingResult.InvalidData,
+            codec.decode(encoded + 1)
+        )
+        assertEquals(
+            DailyAggregateDecodingResult.InvalidData,
+            codec.decode(rawAggregateHeader(hasSession = true, followingValue = 0))
+        )
+        assertEquals(
+            DailyAggregateDecodingResult.InvalidData,
+            codec.decode(rawAggregateHeader(hasSession = false, followingValue = MAX_DAILY_COMPLETION_COUNT + 1))
+        )
+    }
+
+    @Test
+    fun codec_rejects_duplicate_and_same_date_completion_records() {
+        val date = LocalDate.of(2027, 4, 18)
+
+        assertEquals(
+            DailyAggregateDecodingResult.InvalidData,
+            codec.decode(
+                rawCompletionAggregate(
+                    dailyChallengeId(date),
+                    dailyChallengeId(date)
+                )
+            )
+        )
+        assertEquals(
+            DailyAggregateDecodingResult.InvalidData,
+            codec.decode(
+                rawCompletionAggregate(
+                    dailyChallengeId(date),
+                    dailyChallengeId(
+                        date = date,
+                        recipeVersion = DailyRecipeVersion("another-recipe")
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun aggregate_rejects_duplicate_noncanonical_and_active_date_completion_state() {
+        val first = dailyChallengeId(LocalDate.of(2027, 4, 17))
+        val second = dailyChallengeId(LocalDate.of(2027, 4, 18))
+        val activeSession = generatedDailyFixture(date = second.localDate).snapshot()
+
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyAggregate(completedChallengeIds = listOf(first, first))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyAggregate(completedChallengeIds = listOf(second, first))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyAggregate(
+                activeSession = activeSession,
+                completedChallengeIds = listOf(second)
+            )
+        }
+    }
+
+    @Test
+    fun snapshot_rejects_recipe_seed_shape_and_progress_mismatches() {
+        val fixture = generatedDailyFixture()
+        val validSnapshot = fixture.snapshot()
+        val threePairsPuzzle = generatedPuzzle(
+            profile = GeneratedPuzzleProfiles.THREE_PAIRS_LOW,
+            seed = 42
+        ).initialPuzzle
+        val changedResultsPuzzle = validSnapshot.currentPuzzle.copy(
+            board = Board(
+                tiles = validSnapshot.currentPuzzle.board.tiles.mapIndexed { index, tile ->
+                    if (index == 0) tile.copy(result = tile.result + 1) else tile
+                }
+            )
+        )
+        val removedKnownEntryPuzzle = validSnapshot.currentPuzzle.copy(
+            strip = Strip.fromEntries(
+                validSnapshot.currentPuzzle.strip.entries.map { entry ->
+                    if (entry.item is StripItem.Known) {
+                        entry.copy(item = StripItem.Hidden)
+                    } else {
+                        entry
+                    }
+                }
+            )
+        )
+        val changedEntryIdentityPuzzle = validSnapshot.currentPuzzle.copy(
+            strip = Strip.fromEntries(
+                validSnapshot.currentPuzzle.strip.entries.mapIndexed { index, entry ->
+                    if (index == 0) {
+                        entry.copy(id = validSnapshot.currentPuzzle.strip.entries.size)
+                    } else {
+                        entry
+                    }
+                }
+            )
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            validSnapshot.copy(seed = validSnapshot.seed + 1)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            validSnapshot.copy(candidateIndex = DailyCandidateIndex(4))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            validSnapshot.copy(
+                dailyChallengeId = validSnapshot.dailyChallengeId.copy(
+                    recipeVersion = DailyRecipeVersion("unsupported-recipe")
+                )
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            validSnapshot.copy(
+                initialPuzzle = threePairsPuzzle,
+                currentPuzzle = threePairsPuzzle
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            validSnapshot.copy(currentPuzzle = changedResultsPuzzle)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            validSnapshot.copy(currentPuzzle = removedKnownEntryPuzzle)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            validSnapshot.copy(currentPuzzle = changedEntryIdentityPuzzle)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            validSnapshot.copy(currentPuzzle = fixture.generatedPuzzle.solvedPuzzle)
+        }
+    }
+
+    @Test
+    fun snapshot_rejects_player_entered_initial_state_and_invalid_current_assignments() {
+        val fixture = generatedDailyFixture()
+        val snapshot = fixture.snapshot()
+        val hiddenEntry = snapshot.initialPuzzle.strip.entries.first { entry ->
+            entry.item == StripItem.Hidden
+        }
+        val solvedValue = (
+            fixture.generatedPuzzle.solvedPuzzle.strip.entries
+                .single { entry -> entry.id == hiddenEntry.id }
+                .item as StripItem.Known
+            ).value
+        val playerEnteredInitial = snapshot.initialPuzzle.copy(
+            strip = Strip.fromEntries(
+                snapshot.initialPuzzle.strip.entries.map { entry ->
+                    if (entry.id == hiddenEntry.id) {
+                        entry.copy(item = StripItem.PlayerEntered(solvedValue))
+                    } else {
+                        entry
+                    }
+                }
+            )
+        )
+        val invalidAssignment = snapshot.currentPuzzle.copy(
+            board = Board(
+                tiles = snapshot.currentPuzzle.board.tiles.mapIndexed { index, tile ->
+                    if (index == 0) {
+                        tile.copy(
+                            expression = tile.expression.copy(
+                                leftOperand = Expression.Operand.Known(value = solvedValue)
+                            )
+                        )
+                    } else {
+                        tile
+                    }
+                }
+            )
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            snapshot.copy(
+                initialPuzzle = playerEnteredInitial,
+                currentPuzzle = playerEnteredInitial
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            snapshot.copy(currentPuzzle = invalidAssignment)
+        }
+    }
+}
+
+private data class GeneratedDailyFixture(
+    val identity: DailyChallengeId,
+    val candidateIndex: DailyCandidateIndex,
+    val seed: Int,
+    val generatedPuzzle: GeneratedPairsPuzzle
+) {
+    fun snapshot(currentPuzzle: Puzzle = generatedPuzzle.initialPuzzle): DailySessionSnapshot = DailySessionSnapshot(
+        sessionId = DailySessionId("daily-session-${identity.canonicalLocalDate}"),
+        dailyChallengeId = identity,
+        candidateIndex = candidateIndex,
+        seed = seed,
+        initialPuzzle = generatedPuzzle.initialPuzzle,
+        currentPuzzle = currentPuzzle
+    )
+
+    fun progressPuzzle(): Puzzle {
+        val solvedValuesByEntryId = generatedPuzzle.solvedPuzzle.strip.entries.associate { entry ->
+            entry.id to (entry.item as StripItem.Known).value
+        }
+        return generatedPuzzle.initialPuzzle.copy(
+            board = Board(
+                tiles = generatedPuzzle.initialPuzzle.board.tiles.mapIndexed { index, tile ->
+                    if (index == 0) generatedPuzzle.solvedPuzzle.board.tiles[index] else tile
+                }
+            ),
+            strip = Strip.fromEntries(
+                generatedPuzzle.initialPuzzle.strip.entries.map { entry ->
+                    if (entry.item == StripItem.Hidden) {
+                        entry.copy(item = StripItem.PlayerEntered(solvedValuesByEntryId.getValue(entry.id)))
+                    } else {
+                        entry
+                    }
+                }
+            )
+        )
+    }
+}
+
+private fun generatedDailyFixture(
+    date: LocalDate = LocalDate.of(2027, 4, 18),
+    candidateIndex: DailyCandidateIndex = DailyCandidateIndex(0)
+): GeneratedDailyFixture {
+    val recipe = DailyRecipeContracts.FOUR_PAIRS_LOW_V1
+    val identity = recipe.identityFor(date)
+    val seed = recipe.seedFor(identity, candidateIndex)
+    return GeneratedDailyFixture(
+        identity = identity,
+        candidateIndex = candidateIndex,
+        seed = seed,
+        generatedPuzzle = generatedPuzzle(
+            profile = recipe.profile,
+            seed = seed
+        )
+    )
+}
+
+private fun generatedPuzzle(profile: GeneratedPuzzleProfile, seed: Int): GeneratedPairsPuzzle {
+    val outcome = GeneratedPairsPuzzleGenerator(profile).generate(
+        GeneratedPuzzleGenerationRequest(profile = profile, seed = seed)
+    )
+    return (outcome as GeneratedPairsPuzzleGenerationOutcome.Generated).puzzle
+}
+
+private fun dailyChallengeId(
+    date: LocalDate,
+    recipeVersion: DailyRecipeVersion = DailyRecipeContracts.FOUR_PAIRS_LOW_V1.version
+): DailyChallengeId = DailyChallengeId(
+    localDate = date,
+    recipeVersion = recipeVersion
+)
+
+private fun rawAggregateHeader(hasSession: Boolean, followingValue: Int): ByteArray =
+    ByteArrayOutputStream().use { bytes ->
+        DataOutputStream(bytes).use { output ->
+            output.writeInt(DAILY_AGGREGATE_FILE_MAGIC)
+            output.writeInt(DAILY_AGGREGATE_SCHEMA_VERSION)
+            output.writeBoolean(hasSession)
+            output.writeInt(followingValue)
+        }
+        bytes.toByteArray()
+    }
+
+private fun rawCompletionAggregate(vararg completions: DailyChallengeId): ByteArray =
+    ByteArrayOutputStream().use { bytes ->
+        DataOutputStream(bytes).use { output ->
+            output.writeInt(DAILY_AGGREGATE_FILE_MAGIC)
+            output.writeInt(DAILY_AGGREGATE_SCHEMA_VERSION)
+            output.writeBoolean(false)
+            output.writeInt(completions.size)
+            completions.forEach { identity ->
+                output.writeUTF(identity.canonicalLocalDate)
+                output.writeUTF(identity.recipeVersion.value)
+            }
+        }
+        bytes.toByteArray()
+    }
+
+private const val DAILY_AGGREGATE_FILE_MAGIC = 0x4E504441
+private const val SESSION_PAYLOAD_OFFSET = 13

--- a/app/src/test/java/org/cescfe/numpairs/feature/daily/DailyRecipeTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/daily/DailyRecipeTest.kt
@@ -2,6 +2,8 @@ package org.cescfe.numpairs.feature.daily
 
 import java.time.LocalDate
 import org.cescfe.numpairs.domain.daily.DailyCandidateIndex
+import org.cescfe.numpairs.domain.daily.DailyRecipeContract
+import org.cescfe.numpairs.domain.daily.DailyRecipeContracts
 import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
 import org.cescfe.numpairs.domain.daily.Fnv1a32DailyCandidateSeedSchedule
 import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
@@ -19,6 +21,7 @@ class DailyRecipeTest {
         val recipe = DailyRecipes.catalog.resolve(DailyRecipeVersion("daily-4-pairs-low-v1"))
 
         assertSame(DailyRecipes.FOUR_PAIRS_LOW_V1, recipe)
+        assertSame(DailyRecipeContracts.FOUR_PAIRS_LOW_V1, recipe.contract)
         assertSame(GeneratedModes.FOUR_PAIRS_LOW, recipe.challenge)
         assertEquals(GeneratedModes.FOUR_PAIRS.id, recipe.challenge.modeId)
         assertEquals(DifficultyTier.LOW, recipe.challenge.difficulty)
@@ -58,18 +61,24 @@ class DailyRecipeTest {
     fun recipe_and_catalog_reject_invalid_candidate_and_challenge_configuration() {
         assertThrows(IllegalArgumentException::class.java) {
             DailyRecipe(
-                version = DailyRecipeVersion("daily-empty"),
-                challenge = GeneratedModes.FOUR_PAIRS_LOW,
-                candidateIndices = emptyList(),
-                seedSchedule = Fnv1a32DailyCandidateSeedSchedule
+                contract = DailyRecipeContract(
+                    version = DailyRecipeVersion("daily-empty"),
+                    profile = GeneratedModes.FOUR_PAIRS_LOW.profile,
+                    candidateIndices = emptyList(),
+                    seedSchedule = Fnv1a32DailyCandidateSeedSchedule
+                ),
+                challenge = GeneratedModes.FOUR_PAIRS_LOW
             )
         }
         assertThrows(IllegalArgumentException::class.java) {
             DailyRecipe(
-                version = DailyRecipeVersion("daily-non-contiguous"),
-                challenge = GeneratedModes.FOUR_PAIRS_LOW,
-                candidateIndices = listOf(DailyCandidateIndex(0), DailyCandidateIndex(2)),
-                seedSchedule = Fnv1a32DailyCandidateSeedSchedule
+                contract = DailyRecipeContract(
+                    version = DailyRecipeVersion("daily-non-contiguous"),
+                    profile = GeneratedModes.FOUR_PAIRS_LOW.profile,
+                    candidateIndices = listOf(DailyCandidateIndex(0), DailyCandidateIndex(2)),
+                    seedSchedule = Fnv1a32DailyCandidateSeedSchedule
+                ),
+                challenge = GeneratedModes.FOUR_PAIRS_LOW
             )
         }
         assertThrows(IllegalArgumentException::class.java) {

--- a/docs/technical/daily-challenge-persistence.md
+++ b/docs/technical/daily-challenge-persistence.md
@@ -2,8 +2,8 @@
 
 ## Document Status
 
-- Status: Daily identity, recipe resolution, deterministic generation fallback, and device-local
-  date boundary implemented; session persistence and completion history planned
+- Status: Daily identity, deterministic generation, local-date boundary, and versioned aggregate
+  codec implemented; repository persistence and completion history planned
 - Product contract: `docs/product/prd/prd-v10.md`
 - Architecture decision:
   `docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md`
@@ -109,6 +109,11 @@ Malformed active-session data must not fabricate a resumable puzzle or completio
 implementation should preserve independently valid completion records where the selected encoding
 can isolate a malformed optional session; otherwise aggregate corruption recovers to an empty
 local Daily state.
+
+The schema-1 aggregate, recipe-aware snapshot validation, canonical identity-only completion
+collection, and deterministic length-delimited codec are implemented. The optional session
+payload is isolated so invalid session bytes can be discarded without losing independently valid
+completion identities.
 
 ---
 


### PR DESCRIPTION
## Related Issue

Resolves #598

## Summary

- Add the schema-1 Daily aggregate, stable session identity, exact snapshot, and identity-only completion collection.
- Move the immutable recipe/profile/seed contract into the platform-independent domain boundary.
- Add deterministic length-delimited Daily encoding with typed unsupported and invalid outcomes.
- Preserve valid completion history when an isolated optional session payload is malformed.
- Share the unchanged Puzzle binary representation with normal generated-session encoding.