### PR TITLE
[289] Persist the independent Daily session slot

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/data/daily/session/DailySessionRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/daily/session/DailySessionRepository.kt
@@ -1,0 +1,37 @@
+package org.cescfe.numpairs.data.daily.session
+
+import kotlinx.coroutines.flow.Flow
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+
+data class DailyState(val activeSession: DailySessionSnapshot?, val completedChallengeIds: List<DailyChallengeId>)
+
+sealed interface DailySessionReplacementResult {
+    data object Replaced : DailySessionReplacementResult
+
+    data class DateAlreadyCompleted(val completion: DailyChallengeId) : DailySessionReplacementResult
+}
+
+sealed interface DailySessionProgressUpdateResult {
+    data object Updated : DailySessionProgressUpdateResult
+
+    data object StaleSession : DailySessionProgressUpdateResult
+
+    data object InvalidPuzzle : DailySessionProgressUpdateResult
+}
+
+sealed interface DailySessionClearResult {
+    data object Cleared : DailySessionClearResult
+
+    data object StaleSession : DailySessionClearResult
+}
+
+interface DailySessionRepository {
+    val state: Flow<DailyState>
+
+    suspend fun replaceSession(snapshot: DailySessionSnapshot): DailySessionReplacementResult
+
+    suspend fun updateCurrentPuzzle(expectedSessionId: DailySessionId, puzzle: Puzzle): DailySessionProgressUpdateResult
+
+    suspend fun clearSession(expectedSessionId: DailySessionId): DailySessionClearResult
+}

--- a/app/src/main/java/org/cescfe/numpairs/data/daily/session/DailySessionRepositoryFactory.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/daily/session/DailySessionRepositoryFactory.kt
@@ -1,0 +1,21 @@
+package org.cescfe.numpairs.data.daily.session
+
+import android.content.Context
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStore
+
+fun createDailySessionRepository(context: Context): DailySessionRepository {
+    val applicationContext = context.applicationContext
+
+    return DataStoreDailySessionRepository(applicationContext.dailySessionDataStore)
+}
+
+private const val DAILY_SESSION_DATA_STORE_NAME = "daily_challenge"
+
+private val Context.dailySessionDataStore by preferencesDataStore(
+    name = DAILY_SESSION_DATA_STORE_NAME,
+    corruptionHandler = ReplaceFileCorruptionHandler {
+        emptyPreferences()
+    }
+)

--- a/app/src/main/java/org/cescfe/numpairs/data/daily/session/DataStoreDailySessionRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/daily/session/DataStoreDailySessionRepository.kt
@@ -1,0 +1,115 @@
+package org.cescfe.numpairs.data.daily.session
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.byteArrayPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import java.io.IOException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+
+class DataStoreDailySessionRepository(
+    private val dataStore: DataStore<Preferences>,
+    private val codec: DailyAggregateCodec = DailyAggregateCodec()
+) : DailySessionRepository {
+    override val state: Flow<DailyState> = dataStore.data
+        .catch { throwable ->
+            if (throwable is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw throwable
+            }
+        }.map { preferences ->
+            preferences.currentAggregate().toDailyState()
+        }
+
+    override suspend fun replaceSession(snapshot: DailySessionSnapshot): DailySessionReplacementResult {
+        var result: DailySessionReplacementResult? = null
+        dataStore.edit { preferences ->
+            val aggregate = preferences.currentAggregate()
+            val completion = aggregate.completedChallengeIds.singleOrNull { completedIdentity ->
+                completedIdentity.localDate == snapshot.dailyChallengeId.localDate
+            }
+            if (completion != null) {
+                result = DailySessionReplacementResult.DateAlreadyCompleted(completion)
+            } else {
+                preferences[PreferenceKeys.AGGREGATE] = codec.encode(
+                    aggregate.copy(activeSession = snapshot)
+                )
+                result = DailySessionReplacementResult.Replaced
+            }
+        }
+        return requireNotNull(result)
+    }
+
+    override suspend fun updateCurrentPuzzle(
+        expectedSessionId: DailySessionId,
+        puzzle: Puzzle
+    ): DailySessionProgressUpdateResult {
+        var result: DailySessionProgressUpdateResult? = null
+        dataStore.edit { preferences ->
+            val aggregate = preferences.currentAggregate()
+            val activeSession = aggregate.activeSession
+            if (activeSession?.sessionId != expectedSessionId) {
+                result = DailySessionProgressUpdateResult.StaleSession
+                return@edit
+            }
+
+            val updatedSession = try {
+                activeSession.copy(currentPuzzle = puzzle)
+            } catch (_: IllegalArgumentException) {
+                result = DailySessionProgressUpdateResult.InvalidPuzzle
+                return@edit
+            } catch (_: IllegalStateException) {
+                result = DailySessionProgressUpdateResult.InvalidPuzzle
+                return@edit
+            }
+            preferences[PreferenceKeys.AGGREGATE] = codec.encode(
+                aggregate.copy(activeSession = updatedSession)
+            )
+            result = DailySessionProgressUpdateResult.Updated
+        }
+        return requireNotNull(result)
+    }
+
+    override suspend fun clearSession(expectedSessionId: DailySessionId): DailySessionClearResult {
+        var result: DailySessionClearResult? = null
+        dataStore.edit { preferences ->
+            val aggregate = preferences.currentAggregate()
+            if (aggregate.activeSession?.sessionId != expectedSessionId) {
+                result = DailySessionClearResult.StaleSession
+            } else {
+                preferences[PreferenceKeys.AGGREGATE] = codec.encode(
+                    aggregate.copy(activeSession = null)
+                )
+                result = DailySessionClearResult.Cleared
+            }
+        }
+        return requireNotNull(result)
+    }
+
+    private fun Preferences.currentAggregate(): DailyAggregate = this[PreferenceKeys.AGGREGATE]
+        ?.let(codec::decode)
+        ?.decodedAggregateOrEmpty()
+        ?: DailyAggregate()
+
+    private object PreferenceKeys {
+        val AGGREGATE = byteArrayPreferencesKey(DAILY_AGGREGATE_PREFERENCE_KEY_NAME)
+    }
+}
+
+private fun DailyAggregate.toDailyState(): DailyState = DailyState(
+    activeSession = activeSession,
+    completedChallengeIds = completedChallengeIds
+)
+
+private fun DailyAggregateDecodingResult.decodedAggregateOrEmpty(): DailyAggregate = when (this) {
+    is DailyAggregateDecodingResult.Decoded -> aggregate
+    is DailyAggregateDecodingResult.UnsupportedVersion,
+    DailyAggregateDecodingResult.InvalidData -> DailyAggregate()
+}
+
+internal const val DAILY_AGGREGATE_PREFERENCE_KEY_NAME = "daily_aggregate"

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -12,6 +12,9 @@
     <exclude
         domain="file"
         path="datastore/generated_session.preferences_pb" />
+    <exclude
+        domain="file"
+        path="datastore/daily_challenge.preferences_pb" />
     <!--
    <include domain="sharedpref" path="."/>
    <exclude domain="sharedpref" path="device.xml"/>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -11,6 +11,9 @@
         <exclude
             domain="file"
             path="datastore/generated_session.preferences_pb" />
+        <exclude
+            domain="file"
+            path="datastore/daily_challenge.preferences_pb" />
         <!-- TODO: Use <include> and <exclude> to control what is backed up.
         <include .../>
         <exclude .../>
@@ -23,5 +26,8 @@
         <exclude
             domain="file"
             path="datastore/generated_session.preferences_pb" />
+        <exclude
+            domain="file"
+            path="datastore/daily_challenge.preferences_pb" />
     </device-transfer>
 </data-extraction-rules>

--- a/app/src/test/java/org/cescfe/numpairs/data/daily/session/DailyAggregateCodecTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/daily/session/DailyAggregateCodecTest.kt
@@ -6,17 +6,10 @@ import java.nio.ByteBuffer
 import java.time.LocalDate
 import org.cescfe.numpairs.domain.daily.DailyCandidateIndex
 import org.cescfe.numpairs.domain.daily.DailyChallengeId
-import org.cescfe.numpairs.domain.daily.DailyRecipeContracts
 import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
-import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
-import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerator
-import org.cescfe.numpairs.domain.generated.generation.GeneratedPuzzleGenerationRequest
-import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
 import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfiles
-import org.cescfe.numpairs.domain.generated.puzzle.GeneratedPairsPuzzle
 import org.cescfe.numpairs.domain.puzzle.model.Board
 import org.cescfe.numpairs.domain.puzzle.model.Expression
-import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.domain.puzzle.model.Strip
 import org.cescfe.numpairs.domain.puzzle.model.StripItem
 import org.junit.Assert.assertEquals
@@ -173,7 +166,7 @@ class DailyAggregateCodecTest {
     fun snapshot_rejects_recipe_seed_shape_and_progress_mismatches() {
         val fixture = generatedDailyFixture()
         val validSnapshot = fixture.snapshot()
-        val threePairsPuzzle = generatedPuzzle(
+        val threePairsPuzzle = generatedPuzzleFixture(
             profile = GeneratedPuzzleProfiles.THREE_PAIRS_LOW,
             seed = 42
         ).initialPuzzle
@@ -290,77 +283,6 @@ class DailyAggregateCodecTest {
         }
     }
 }
-
-private data class GeneratedDailyFixture(
-    val identity: DailyChallengeId,
-    val candidateIndex: DailyCandidateIndex,
-    val seed: Int,
-    val generatedPuzzle: GeneratedPairsPuzzle
-) {
-    fun snapshot(currentPuzzle: Puzzle = generatedPuzzle.initialPuzzle): DailySessionSnapshot = DailySessionSnapshot(
-        sessionId = DailySessionId("daily-session-${identity.canonicalLocalDate}"),
-        dailyChallengeId = identity,
-        candidateIndex = candidateIndex,
-        seed = seed,
-        initialPuzzle = generatedPuzzle.initialPuzzle,
-        currentPuzzle = currentPuzzle
-    )
-
-    fun progressPuzzle(): Puzzle {
-        val solvedValuesByEntryId = generatedPuzzle.solvedPuzzle.strip.entries.associate { entry ->
-            entry.id to (entry.item as StripItem.Known).value
-        }
-        return generatedPuzzle.initialPuzzle.copy(
-            board = Board(
-                tiles = generatedPuzzle.initialPuzzle.board.tiles.mapIndexed { index, tile ->
-                    if (index == 0) generatedPuzzle.solvedPuzzle.board.tiles[index] else tile
-                }
-            ),
-            strip = Strip.fromEntries(
-                generatedPuzzle.initialPuzzle.strip.entries.map { entry ->
-                    if (entry.item == StripItem.Hidden) {
-                        entry.copy(item = StripItem.PlayerEntered(solvedValuesByEntryId.getValue(entry.id)))
-                    } else {
-                        entry
-                    }
-                }
-            )
-        )
-    }
-}
-
-private fun generatedDailyFixture(
-    date: LocalDate = LocalDate.of(2027, 4, 18),
-    candidateIndex: DailyCandidateIndex = DailyCandidateIndex(0)
-): GeneratedDailyFixture {
-    val recipe = DailyRecipeContracts.FOUR_PAIRS_LOW_V1
-    val identity = recipe.identityFor(date)
-    val seed = recipe.seedFor(identity, candidateIndex)
-    return GeneratedDailyFixture(
-        identity = identity,
-        candidateIndex = candidateIndex,
-        seed = seed,
-        generatedPuzzle = generatedPuzzle(
-            profile = recipe.profile,
-            seed = seed
-        )
-    )
-}
-
-private fun generatedPuzzle(profile: GeneratedPuzzleProfile, seed: Int): GeneratedPairsPuzzle {
-    val outcome = GeneratedPairsPuzzleGenerator(profile).generate(
-        GeneratedPuzzleGenerationRequest(profile = profile, seed = seed)
-    )
-    return (outcome as GeneratedPairsPuzzleGenerationOutcome.Generated).puzzle
-}
-
-private fun dailyChallengeId(
-    date: LocalDate,
-    recipeVersion: DailyRecipeVersion = DailyRecipeContracts.FOUR_PAIRS_LOW_V1.version
-): DailyChallengeId = DailyChallengeId(
-    localDate = date,
-    recipeVersion = recipeVersion
-)
 
 private fun rawAggregateHeader(hasSession: Boolean, followingValue: Int): ByteArray =
     ByteArrayOutputStream().use { bytes ->

--- a/app/src/test/java/org/cescfe/numpairs/data/daily/session/DailySessionTestFixtures.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/daily/session/DailySessionTestFixtures.kt
@@ -1,0 +1,90 @@
+package org.cescfe.numpairs.data.daily.session
+
+import java.time.LocalDate
+import org.cescfe.numpairs.domain.daily.DailyCandidateIndex
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DailyRecipeContracts
+import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerator
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPuzzleGenerationRequest
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfile
+import org.cescfe.numpairs.domain.generated.puzzle.GeneratedPairsPuzzle
+import org.cescfe.numpairs.domain.puzzle.model.Board
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.domain.puzzle.model.Strip
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+
+internal data class GeneratedDailyFixture(
+    val identity: DailyChallengeId,
+    val candidateIndex: DailyCandidateIndex,
+    val seed: Int,
+    val generatedPuzzle: GeneratedPairsPuzzle
+) {
+    fun snapshot(
+        sessionId: String = "daily-session-${identity.canonicalLocalDate}",
+        currentPuzzle: Puzzle = generatedPuzzle.initialPuzzle
+    ): DailySessionSnapshot = DailySessionSnapshot(
+        sessionId = DailySessionId(sessionId),
+        dailyChallengeId = identity,
+        candidateIndex = candidateIndex,
+        seed = seed,
+        initialPuzzle = generatedPuzzle.initialPuzzle,
+        currentPuzzle = currentPuzzle
+    )
+
+    fun progressPuzzle(): Puzzle {
+        val solvedValuesByEntryId = generatedPuzzle.solvedPuzzle.strip.entries.associate { entry ->
+            entry.id to (entry.item as StripItem.Known).value
+        }
+        return generatedPuzzle.initialPuzzle.copy(
+            board = Board(
+                tiles = generatedPuzzle.initialPuzzle.board.tiles.mapIndexed { index, tile ->
+                    if (index == 0) generatedPuzzle.solvedPuzzle.board.tiles[index] else tile
+                }
+            ),
+            strip = Strip.fromEntries(
+                generatedPuzzle.initialPuzzle.strip.entries.map { entry ->
+                    if (entry.item == StripItem.Hidden) {
+                        entry.copy(item = StripItem.PlayerEntered(solvedValuesByEntryId.getValue(entry.id)))
+                    } else {
+                        entry
+                    }
+                }
+            )
+        )
+    }
+}
+
+internal fun generatedDailyFixture(
+    date: LocalDate = LocalDate.of(2027, 4, 18),
+    candidateIndex: DailyCandidateIndex = DailyCandidateIndex(0)
+): GeneratedDailyFixture {
+    val recipe = DailyRecipeContracts.FOUR_PAIRS_LOW_V1
+    val identity = recipe.identityFor(date)
+    val seed = recipe.seedFor(identity, candidateIndex)
+    return GeneratedDailyFixture(
+        identity = identity,
+        candidateIndex = candidateIndex,
+        seed = seed,
+        generatedPuzzle = generatedPuzzleFixture(
+            profile = recipe.profile,
+            seed = seed
+        )
+    )
+}
+
+internal fun dailyChallengeId(
+    date: LocalDate,
+    recipeVersion: DailyRecipeVersion = DailyRecipeContracts.FOUR_PAIRS_LOW_V1.version
+): DailyChallengeId = DailyChallengeId(
+    localDate = date,
+    recipeVersion = recipeVersion
+)
+
+internal fun generatedPuzzleFixture(profile: GeneratedPuzzleProfile, seed: Int): GeneratedPairsPuzzle {
+    val outcome = GeneratedPairsPuzzleGenerator(profile).generate(
+        GeneratedPuzzleGenerationRequest(profile = profile, seed = seed)
+    )
+    return (outcome as GeneratedPairsPuzzleGenerationOutcome.Generated).puzzle
+}

--- a/app/src/test/java/org/cescfe/numpairs/data/daily/session/DataStoreDailySessionRepositoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/daily/session/DataStoreDailySessionRepositoryTest.kt
@@ -1,0 +1,317 @@
+package org.cescfe.numpairs.data.daily.session
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.byteArrayPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import java.io.File
+import java.io.IOException
+import java.time.LocalDate
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.cescfe.numpairs.data.generated.session.DataStoreGeneratedSessionRepository
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionId
+import org.cescfe.numpairs.data.generated.session.GeneratedSessionSnapshot
+import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.domain.puzzle.model.Board
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DataStoreDailySessionRepositoryTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val dataStoreJobs = mutableListOf<Job>()
+
+    @After
+    fun tearDown() {
+        dataStoreJobs.forEach(Job::cancel)
+    }
+
+    @Test
+    fun empty_application_data_exposes_empty_daily_state() = runBlocking {
+        val fixture = createRepository()
+
+        assertEquals(
+            DailyState(activeSession = null, completedChallengeIds = emptyList()),
+            fixture.repository.state.first()
+        )
+    }
+
+    @Test
+    fun replacement_atomically_adopts_one_daily_session() = runBlocking {
+        val fixture = createRepository()
+        val first = generatedDailyFixture(date = LocalDate.of(2027, 4, 18)).snapshot(sessionId = "first")
+        val replacement = generatedDailyFixture(date = LocalDate.of(2027, 4, 19))
+            .snapshot(sessionId = "replacement")
+
+        assertEquals(
+            DailySessionReplacementResult.Replaced,
+            fixture.repository.replaceSession(first)
+        )
+        assertEquals(
+            DailySessionReplacementResult.Replaced,
+            fixture.repository.replaceSession(replacement)
+        )
+        assertEquals(replacement, fixture.repository.state.first().activeSession)
+    }
+
+    @Test
+    fun replacement_for_a_completed_date_is_rejected_without_changing_the_previous_session() = runBlocking {
+        val fixture = createRepository()
+        val previous = generatedDailyFixture(date = LocalDate.of(2027, 4, 17)).snapshot()
+        val completedIdentity = dailyChallengeId(LocalDate.of(2027, 4, 18))
+        fixture.storeAggregate(
+            DailyAggregate(
+                activeSession = previous,
+                completedChallengeIds = listOf(completedIdentity)
+            )
+        )
+        val rejected = generatedDailyFixture(date = completedIdentity.localDate).snapshot()
+
+        assertEquals(
+            DailySessionReplacementResult.DateAlreadyCompleted(completedIdentity),
+            fixture.repository.replaceSession(rejected)
+        )
+        assertEquals(previous, fixture.repository.state.first().activeSession)
+        assertEquals(listOf(completedIdentity), fixture.repository.state.first().completedChallengeIds)
+    }
+
+    @Test
+    fun incomplete_progress_updates_only_the_owning_daily_session() = runBlocking {
+        val fixture = createRepository()
+        val generatedFixture = generatedDailyFixture()
+        val snapshot = generatedFixture.snapshot()
+        fixture.repository.replaceSession(snapshot)
+
+        assertEquals(
+            DailySessionProgressUpdateResult.Updated,
+            fixture.repository.updateCurrentPuzzle(
+                expectedSessionId = snapshot.sessionId,
+                puzzle = generatedFixture.progressPuzzle()
+            )
+        )
+        assertEquals(
+            snapshot.copy(currentPuzzle = generatedFixture.progressPuzzle()),
+            fixture.repository.state.first().activeSession
+        )
+    }
+
+    @Test
+    fun stale_solved_and_inconsistent_progress_cannot_change_storage() = runBlocking {
+        val fixture = createRepository()
+        val generatedFixture = generatedDailyFixture()
+        val snapshot = generatedFixture.snapshot()
+        fixture.repository.replaceSession(snapshot)
+        val changedResultPuzzle = snapshot.currentPuzzle.copy(
+            board = Board(
+                tiles = snapshot.currentPuzzle.board.tiles.mapIndexed { index, tile ->
+                    if (index == 0) tile.copy(result = tile.result + 1) else tile
+                }
+            )
+        )
+
+        assertEquals(
+            DailySessionProgressUpdateResult.StaleSession,
+            fixture.repository.updateCurrentPuzzle(
+                expectedSessionId = DailySessionId("stale"),
+                puzzle = generatedFixture.progressPuzzle()
+            )
+        )
+        assertEquals(
+            DailySessionProgressUpdateResult.InvalidPuzzle,
+            fixture.repository.updateCurrentPuzzle(
+                expectedSessionId = snapshot.sessionId,
+                puzzle = changedResultPuzzle
+            )
+        )
+        assertEquals(
+            DailySessionProgressUpdateResult.InvalidPuzzle,
+            fixture.repository.updateCurrentPuzzle(
+                expectedSessionId = snapshot.sessionId,
+                puzzle = generatedFixture.generatedPuzzle.solvedPuzzle
+            )
+        )
+        assertEquals(snapshot, fixture.repository.state.first().activeSession)
+    }
+
+    @Test
+    fun clear_removes_only_the_owning_daily_session_and_preserves_completions() = runBlocking {
+        val fixture = createRepository()
+        val snapshot = generatedDailyFixture().snapshot()
+        val completion = dailyChallengeId(LocalDate.of(2027, 4, 17))
+        fixture.storeAggregate(
+            DailyAggregate(
+                activeSession = snapshot,
+                completedChallengeIds = listOf(completion)
+            )
+        )
+
+        assertEquals(
+            DailySessionClearResult.StaleSession,
+            fixture.repository.clearSession(DailySessionId("stale"))
+        )
+        assertEquals(snapshot, fixture.repository.state.first().activeSession)
+        assertEquals(
+            DailySessionClearResult.Cleared,
+            fixture.repository.clearSession(snapshot.sessionId)
+        )
+        assertNull(fixture.repository.state.first().activeSession)
+        assertEquals(listOf(completion), fixture.repository.state.first().completedChallengeIds)
+    }
+
+    @Test
+    fun exact_daily_state_survives_repository_and_data_store_recreation() = runBlocking {
+        val dataStoreFile = createDataStoreFile()
+        val snapshot = generatedDailyFixture().snapshot()
+        val completion = dailyChallengeId(LocalDate.of(2027, 4, 17))
+        val firstFixture = createRepository(dataStoreFile)
+        firstFixture.storeAggregate(
+            DailyAggregate(
+                activeSession = snapshot,
+                completedChallengeIds = listOf(completion)
+            )
+        )
+        firstFixture.close()
+
+        val secondFixture = createRepository(dataStoreFile)
+
+        assertEquals(
+            DailyState(
+                activeSession = snapshot,
+                completedChallengeIds = listOf(completion)
+            ),
+            secondFixture.repository.state.first()
+        )
+    }
+
+    @Test
+    fun invalid_or_unsupported_aggregate_recovers_as_empty_and_accepts_a_successor() = runBlocking {
+        val fixture = createRepository()
+        fixture.dataStore.edit { preferences ->
+            preferences[byteArrayPreferencesKey(DAILY_AGGREGATE_PREFERENCE_KEY_NAME)] =
+                byteArrayOf(1, 2, 3)
+        }
+
+        assertEquals(
+            DailyState(activeSession = null, completedChallengeIds = emptyList()),
+            fixture.repository.state.first()
+        )
+
+        val replacement = generatedDailyFixture().snapshot()
+        assertEquals(
+            DailySessionReplacementResult.Replaced,
+            fixture.repository.replaceSession(replacement)
+        )
+        assertEquals(replacement, fixture.repository.state.first().activeSession)
+    }
+
+    @Test
+    fun failed_replacement_write_leaves_the_previous_daily_state_intact() {
+        val previous = generatedDailyFixture(date = LocalDate.of(2027, 4, 17)).snapshot()
+        val aggregateKey = byteArrayPreferencesKey(DAILY_AGGREGATE_PREFERENCE_KEY_NAME)
+        val storedPreferences = mutablePreferencesOf(
+            aggregateKey to DailyAggregateCodec().encode(DailyAggregate(activeSession = previous))
+        )
+        val expectedFailure = IOException("Synthetic Daily write failure.")
+        val storedState = MutableStateFlow<Preferences>(storedPreferences)
+        val repository = DataStoreDailySessionRepository(
+            dataStore = object : DataStore<Preferences> {
+                override val data = storedState
+
+                override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+                    throw expectedFailure
+            }
+        )
+
+        val actualFailure = assertThrows(IOException::class.java) {
+            runBlocking {
+                repository.replaceSession(
+                    generatedDailyFixture(date = LocalDate.of(2027, 4, 18)).snapshot()
+                )
+            }
+        }
+
+        assertSame(expectedFailure, actualFailure)
+        assertEquals(previous, runBlocking { repository.state.first().activeSession })
+    }
+
+    @Test
+    fun daily_and_normal_generated_repositories_do_not_replace_each_other() = runBlocking {
+        val dailyFixture = createRepository()
+        val normalDataStoreFixture = createRepository()
+        val normalRepository = DataStoreGeneratedSessionRepository(normalDataStoreFixture.dataStore)
+        val normalSnapshot = GeneratedSessionSnapshot(
+            sessionId = GeneratedSessionId("normal-session"),
+            modeId = "four-pairs",
+            profileId = "4-pairs-low",
+            seed = 42,
+            initialPuzzle = samplePuzzle,
+            currentPuzzle = samplePuzzle
+        )
+        normalRepository.replace(normalSnapshot)
+        val dailySnapshot = generatedDailyFixture().snapshot()
+
+        dailyFixture.repository.replaceSession(dailySnapshot)
+
+        assertEquals(normalSnapshot, normalRepository.session.first())
+        assertEquals(dailySnapshot, dailyFixture.repository.state.first().activeSession)
+    }
+
+    private fun createRepository(dataStoreFile: File = createDataStoreFile()): RepositoryFixture {
+        val job = SupervisorJob()
+        dataStoreJobs += job
+        val dataStore = PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler {
+                emptyPreferences()
+            },
+            scope = CoroutineScope(job + Dispatchers.IO),
+            produceFile = { dataStoreFile }
+        )
+
+        return RepositoryFixture(
+            repository = DataStoreDailySessionRepository(dataStore),
+            dataStore = dataStore,
+            job = job
+        )
+    }
+
+    private fun createDataStoreFile(): File = File(
+        temporaryFolder.root,
+        "${UUID.randomUUID()}.preferences_pb"
+    )
+
+    private data class RepositoryFixture(
+        val repository: DataStoreDailySessionRepository,
+        val dataStore: DataStore<Preferences>,
+        private val job: Job
+    ) {
+        suspend fun storeAggregate(aggregate: DailyAggregate) {
+            dataStore.edit { preferences ->
+                preferences[byteArrayPreferencesKey(DAILY_AGGREGATE_PREFERENCE_KEY_NAME)] =
+                    DailyAggregateCodec().encode(aggregate)
+            }
+        }
+
+        suspend fun close() {
+            job.cancelAndJoin()
+        }
+    }
+}

--- a/docs/technical/daily-challenge-persistence.md
+++ b/docs/technical/daily-challenge-persistence.md
@@ -2,8 +2,8 @@
 
 ## Document Status
 
-- Status: Daily identity, deterministic generation, local-date boundary, and versioned aggregate
-  codec implemented; repository persistence and completion history planned
+- Status: Daily identity, deterministic generation, local-date boundary, versioned aggregate
+  codec, and independent session persistence implemented; atomic completion history planned
 - Product contract: `docs/product/prd/prd-v10.md`
 - Architecture decision:
   `docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md`
@@ -244,6 +244,11 @@ The file is excluded from:
 
 Reinstallation or application-data deletion resets both Daily progress and the completion
 calendar. Cache deletion does not.
+
+The dedicated Preferences DataStore, aggregate state flow, identity-guarded safe replacement,
+incomplete-progress update, explicit clear, corruption recovery, and all three backup and transfer
+exclusions are implemented. Atomic solved completion recording remains a separate delivery
+boundary.
 
 ---
 


### PR DESCRIPTION
## Related Issue

Resolves #599

## Summary

- Add the independent Daily state flow and dedicated daily_challenge Preferences DataStore.
- Guard safe replacement, incomplete progress updates, and explicit clear with stable Daily Session identity.
- Recover invalid aggregate data safely and preserve the prior slot when writes fail or a date is completed.
- Prove Daily and normal generated repositories coexist without replacing one another.
- Exclude Daily state from Auto Backup, cloud backup, and device-to-device transfer.