### PR TITLE
[290] Record Daily completion atomically and idempotently

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/data/daily/session/DailyAggregate.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/daily/session/DailyAggregate.kt
@@ -68,6 +68,15 @@ data class DailySessionSnapshot(
     }
 }
 
+internal fun DailySessionSnapshot.requireValidSolvedPuzzle(solvedPuzzle: Puzzle) {
+    requirePuzzleMatchesRecipe(solvedPuzzle, recipeContract)
+    require(solvedPuzzle.isSolved) {
+        "Daily completion puzzle must be solved."
+    }
+    requireConsistentProgress(initialPuzzle = initialPuzzle, currentPuzzle = solvedPuzzle)
+    requireValidCurrentAssignments(solvedPuzzle)
+}
+
 data class DailyAggregate(
     val schemaVersion: Int = DAILY_AGGREGATE_SCHEMA_VERSION,
     val activeSession: DailySessionSnapshot? = null,

--- a/app/src/main/java/org/cescfe/numpairs/data/daily/session/DailySessionRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/daily/session/DailySessionRepository.kt
@@ -26,6 +26,16 @@ sealed interface DailySessionClearResult {
     data object StaleSession : DailySessionClearResult
 }
 
+sealed interface DailySessionCompletionResult {
+    data object Completed : DailySessionCompletionResult
+
+    data class AlreadyCompleted(val completion: DailyChallengeId) : DailySessionCompletionResult
+
+    data object StaleSession : DailySessionCompletionResult
+
+    data object InvalidPuzzle : DailySessionCompletionResult
+}
+
 interface DailySessionRepository {
     val state: Flow<DailyState>
 
@@ -34,4 +44,10 @@ interface DailySessionRepository {
     suspend fun updateCurrentPuzzle(expectedSessionId: DailySessionId, puzzle: Puzzle): DailySessionProgressUpdateResult
 
     suspend fun clearSession(expectedSessionId: DailySessionId): DailySessionClearResult
+
+    suspend fun complete(
+        expectedSessionId: DailySessionId,
+        expectedDailyChallengeId: DailyChallengeId,
+        solvedPuzzle: Puzzle
+    ): DailySessionCompletionResult
 }

--- a/app/src/main/java/org/cescfe/numpairs/data/daily/session/DataStoreDailySessionRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/daily/session/DataStoreDailySessionRepository.kt
@@ -9,6 +9,7 @@ import java.io.IOException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 
 class DataStoreDailySessionRepository(
@@ -87,6 +88,53 @@ class DataStoreDailySessionRepository(
                 )
                 result = DailySessionClearResult.Cleared
             }
+        }
+        return requireNotNull(result)
+    }
+
+    override suspend fun complete(
+        expectedSessionId: DailySessionId,
+        expectedDailyChallengeId: DailyChallengeId,
+        solvedPuzzle: Puzzle
+    ): DailySessionCompletionResult {
+        var result: DailySessionCompletionResult? = null
+        dataStore.edit { preferences ->
+            val aggregate = preferences.currentAggregate()
+            val existingCompletion = aggregate.completedChallengeIds.singleOrNull { completedIdentity ->
+                completedIdentity.localDate == expectedDailyChallengeId.localDate
+            }
+            if (existingCompletion != null) {
+                result = DailySessionCompletionResult.AlreadyCompleted(existingCompletion)
+                return@edit
+            }
+
+            val activeSession = aggregate.activeSession
+            if (
+                activeSession?.sessionId != expectedSessionId ||
+                activeSession.dailyChallengeId != expectedDailyChallengeId
+            ) {
+                result = DailySessionCompletionResult.StaleSession
+                return@edit
+            }
+            try {
+                activeSession.requireValidSolvedPuzzle(solvedPuzzle)
+            } catch (_: IllegalArgumentException) {
+                result = DailySessionCompletionResult.InvalidPuzzle
+                return@edit
+            } catch (_: IllegalStateException) {
+                result = DailySessionCompletionResult.InvalidPuzzle
+                return@edit
+            }
+
+            val completedChallengeIds = (aggregate.completedChallengeIds + expectedDailyChallengeId)
+                .sortedWith(DAILY_CHALLENGE_ID_COMPARATOR)
+            preferences[PreferenceKeys.AGGREGATE] = codec.encode(
+                aggregate.copy(
+                    activeSession = null,
+                    completedChallengeIds = completedChallengeIds
+                )
+            )
+            result = DailySessionCompletionResult.Completed
         }
         return requireNotNull(result)
     }

--- a/app/src/test/java/org/cescfe/numpairs/data/daily/session/DailySessionTestFixtures.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/daily/session/DailySessionTestFixtures.kt
@@ -54,6 +54,24 @@ internal data class GeneratedDailyFixture(
             )
         )
     }
+
+    fun solvedProgressPuzzle(): Puzzle {
+        val solvedValuesByEntryId = generatedPuzzle.solvedPuzzle.strip.entries.associate { entry ->
+            entry.id to (entry.item as StripItem.Known).value
+        }
+        return Puzzle(
+            board = generatedPuzzle.solvedPuzzle.board,
+            strip = Strip.fromEntries(
+                generatedPuzzle.initialPuzzle.strip.entries.map { entry ->
+                    if (entry.item == StripItem.Hidden) {
+                        entry.copy(item = StripItem.PlayerEntered(solvedValuesByEntryId.getValue(entry.id)))
+                    } else {
+                        entry
+                    }
+                }
+            )
+        )
+    }
 }
 
 internal fun generatedDailyFixture(

--- a/app/src/test/java/org/cescfe/numpairs/data/daily/session/DataStoreDailySessionRepositoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/daily/session/DataStoreDailySessionRepositoryTest.kt
@@ -24,6 +24,8 @@ import org.cescfe.numpairs.data.generated.session.DataStoreGeneratedSessionRepos
 import org.cescfe.numpairs.data.generated.session.GeneratedSessionId
 import org.cescfe.numpairs.data.generated.session.GeneratedSessionSnapshot
 import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
 import org.cescfe.numpairs.domain.puzzle.model.Board
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -203,6 +205,173 @@ class DataStoreDailySessionRepositoryTest {
     }
 
     @Test
+    fun solved_completion_records_identity_and_removes_active_session_atomically() = runBlocking {
+        val fixture = createRepository()
+        val generatedFixture = generatedDailyFixture()
+        val snapshot = generatedFixture.snapshot()
+        fixture.repository.replaceSession(snapshot)
+
+        assertEquals(
+            DailySessionCompletionResult.Completed,
+            fixture.repository.complete(
+                expectedSessionId = snapshot.sessionId,
+                expectedDailyChallengeId = snapshot.dailyChallengeId,
+                solvedPuzzle = generatedFixture.solvedProgressPuzzle()
+            )
+        )
+        assertEquals(
+            DailyState(
+                activeSession = null,
+                completedChallengeIds = listOf(snapshot.dailyChallengeId)
+            ),
+            fixture.repository.state.first()
+        )
+    }
+
+    @Test
+    fun exact_repeated_completion_is_idempotent() = runBlocking {
+        val fixture = createRepository()
+        val generatedFixture = generatedDailyFixture()
+        val snapshot = generatedFixture.snapshot()
+        val solvedPuzzle = generatedFixture.solvedProgressPuzzle()
+        fixture.repository.replaceSession(snapshot)
+        fixture.repository.complete(
+            expectedSessionId = snapshot.sessionId,
+            expectedDailyChallengeId = snapshot.dailyChallengeId,
+            solvedPuzzle = solvedPuzzle
+        )
+
+        assertEquals(
+            DailySessionCompletionResult.AlreadyCompleted(snapshot.dailyChallengeId),
+            fixture.repository.complete(
+                expectedSessionId = snapshot.sessionId,
+                expectedDailyChallengeId = snapshot.dailyChallengeId,
+                solvedPuzzle = solvedPuzzle
+            )
+        )
+        assertEquals(
+            listOf(snapshot.dailyChallengeId),
+            fixture.repository.state.first().completedChallengeIds
+        )
+    }
+
+    @Test
+    fun another_recipe_cannot_add_a_second_completion_for_the_same_date() = runBlocking {
+        val fixture = createRepository()
+        val existingCompletion = dailyChallengeId(
+            date = LocalDate.of(2027, 4, 18),
+            recipeVersion = DailyRecipeVersion("retired-recipe")
+        )
+        fixture.storeAggregate(
+            DailyAggregate(completedChallengeIds = listOf(existingCompletion))
+        )
+        val currentFixture = generatedDailyFixture(date = existingCompletion.localDate)
+
+        assertEquals(
+            DailySessionCompletionResult.AlreadyCompleted(existingCompletion),
+            fixture.repository.complete(
+                expectedSessionId = DailySessionId("missing"),
+                expectedDailyChallengeId = currentFixture.identity,
+                solvedPuzzle = currentFixture.solvedProgressPuzzle()
+            )
+        )
+        assertEquals(
+            listOf(existingCompletion),
+            fixture.repository.state.first().completedChallengeIds
+        )
+    }
+
+    @Test
+    fun stale_session_or_challenge_identity_cannot_complete_a_successor() = runBlocking {
+        val fixture = createRepository()
+        val predecessorFixture = generatedDailyFixture(date = LocalDate.of(2027, 4, 18))
+        val predecessor = predecessorFixture.snapshot(sessionId = "predecessor")
+        fixture.repository.replaceSession(predecessor)
+        val successorFixture = generatedDailyFixture(date = LocalDate.of(2027, 4, 19))
+        val successor = successorFixture.snapshot(sessionId = "successor")
+        fixture.repository.replaceSession(successor)
+
+        assertEquals(
+            DailySessionCompletionResult.StaleSession,
+            fixture.repository.complete(
+                expectedSessionId = predecessor.sessionId,
+                expectedDailyChallengeId = predecessor.dailyChallengeId,
+                solvedPuzzle = predecessorFixture.solvedProgressPuzzle()
+            )
+        )
+        assertEquals(
+            DailySessionCompletionResult.StaleSession,
+            fixture.repository.complete(
+                expectedSessionId = successor.sessionId,
+                expectedDailyChallengeId = predecessor.dailyChallengeId,
+                solvedPuzzle = successorFixture.solvedProgressPuzzle()
+            )
+        )
+        assertEquals(successor, fixture.repository.state.first().activeSession)
+        assertEquals(emptyList<DailyChallengeId>(), fixture.repository.state.first().completedChallengeIds)
+    }
+
+    @Test
+    fun unsolved_or_inconsistent_puzzle_cannot_complete_daily() = runBlocking {
+        val fixture = createRepository()
+        val generatedFixture = generatedDailyFixture()
+        val snapshot = generatedFixture.snapshot()
+        fixture.repository.replaceSession(snapshot)
+        val solvedPuzzle = generatedFixture.solvedProgressPuzzle()
+        val inconsistentPuzzle = solvedPuzzle.copy(
+            board = Board(
+                tiles = solvedPuzzle.board.tiles.mapIndexed { index, tile ->
+                    if (index == 0) tile.copy(result = tile.result + 1) else tile
+                }
+            )
+        )
+
+        assertEquals(
+            DailySessionCompletionResult.InvalidPuzzle,
+            fixture.repository.complete(
+                expectedSessionId = snapshot.sessionId,
+                expectedDailyChallengeId = snapshot.dailyChallengeId,
+                solvedPuzzle = snapshot.currentPuzzle
+            )
+        )
+        assertEquals(
+            DailySessionCompletionResult.InvalidPuzzle,
+            fixture.repository.complete(
+                expectedSessionId = snapshot.sessionId,
+                expectedDailyChallengeId = snapshot.dailyChallengeId,
+                solvedPuzzle = inconsistentPuzzle
+            )
+        )
+        assertEquals(snapshot, fixture.repository.state.first().activeSession)
+        assertEquals(emptyList<DailyChallengeId>(), fixture.repository.state.first().completedChallengeIds)
+    }
+
+    @Test
+    fun completion_history_survives_repository_recreation() = runBlocking {
+        val dataStoreFile = createDataStoreFile()
+        val firstFixture = createRepository(dataStoreFile)
+        val generatedFixture = generatedDailyFixture()
+        val snapshot = generatedFixture.snapshot()
+        firstFixture.repository.replaceSession(snapshot)
+        firstFixture.repository.complete(
+            expectedSessionId = snapshot.sessionId,
+            expectedDailyChallengeId = snapshot.dailyChallengeId,
+            solvedPuzzle = generatedFixture.solvedProgressPuzzle()
+        )
+        firstFixture.close()
+
+        val secondFixture = createRepository(dataStoreFile)
+
+        assertEquals(
+            DailyState(
+                activeSession = null,
+                completedChallengeIds = listOf(snapshot.dailyChallengeId)
+            ),
+            secondFixture.repository.state.first()
+        )
+    }
+
+    @Test
     fun invalid_or_unsupported_aggregate_recovers_as_empty_and_accepts_a_successor() = runBlocking {
         val fixture = createRepository()
         fixture.dataStore.edit { preferences ->
@@ -216,6 +385,15 @@ class DataStoreDailySessionRepositoryTest {
         )
 
         val replacement = generatedDailyFixture().snapshot()
+        assertEquals(
+            DailySessionCompletionResult.StaleSession,
+            fixture.repository.complete(
+                expectedSessionId = replacement.sessionId,
+                expectedDailyChallengeId = replacement.dailyChallengeId,
+                solvedPuzzle = generatedDailyFixture().solvedProgressPuzzle()
+            )
+        )
+        assertEquals(emptyList<DailyChallengeId>(), fixture.repository.state.first().completedChallengeIds)
         assertEquals(
             DailySessionReplacementResult.Replaced,
             fixture.repository.replaceSession(replacement)
@@ -254,6 +432,42 @@ class DataStoreDailySessionRepositoryTest {
     }
 
     @Test
+    fun failed_completion_write_keeps_the_active_session_and_does_not_publish_history() {
+        val generatedFixture = generatedDailyFixture()
+        val activeSession = generatedFixture.snapshot()
+        val aggregateKey = byteArrayPreferencesKey(DAILY_AGGREGATE_PREFERENCE_KEY_NAME)
+        val storedPreferences = mutablePreferencesOf(
+            aggregateKey to DailyAggregateCodec().encode(DailyAggregate(activeSession = activeSession))
+        )
+        val expectedFailure = IOException("Synthetic Daily completion write failure.")
+        val storedState = MutableStateFlow<Preferences>(storedPreferences)
+        val repository = DataStoreDailySessionRepository(
+            dataStore = object : DataStore<Preferences> {
+                override val data = storedState
+
+                override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+                    throw expectedFailure
+            }
+        )
+
+        val actualFailure = assertThrows(IOException::class.java) {
+            runBlocking {
+                repository.complete(
+                    expectedSessionId = activeSession.sessionId,
+                    expectedDailyChallengeId = activeSession.dailyChallengeId,
+                    solvedPuzzle = generatedFixture.solvedProgressPuzzle()
+                )
+            }
+        }
+
+        assertSame(expectedFailure, actualFailure)
+        assertEquals(
+            DailyState(activeSession = activeSession, completedChallengeIds = emptyList()),
+            runBlocking { repository.state.first() }
+        )
+    }
+
+    @Test
     fun daily_and_normal_generated_repositories_do_not_replace_each_other() = runBlocking {
         val dailyFixture = createRepository()
         val normalDataStoreFixture = createRepository()
@@ -270,9 +484,17 @@ class DataStoreDailySessionRepositoryTest {
         val dailySnapshot = generatedDailyFixture().snapshot()
 
         dailyFixture.repository.replaceSession(dailySnapshot)
+        dailyFixture.repository.complete(
+            expectedSessionId = dailySnapshot.sessionId,
+            expectedDailyChallengeId = dailySnapshot.dailyChallengeId,
+            solvedPuzzle = generatedDailyFixture().solvedProgressPuzzle()
+        )
 
         assertEquals(normalSnapshot, normalRepository.session.first())
-        assertEquals(dailySnapshot, dailyFixture.repository.state.first().activeSession)
+        assertEquals(
+            listOf(dailySnapshot.dailyChallengeId),
+            dailyFixture.repository.state.first().completedChallengeIds
+        )
     }
 
     private fun createRepository(dataStoreFile: File = createDataStoreFile()): RepositoryFixture {

--- a/docs/technical/daily-challenge-persistence.md
+++ b/docs/technical/daily-challenge-persistence.md
@@ -2,8 +2,9 @@
 
 ## Document Status
 
-- Status: Daily identity, deterministic generation, local-date boundary, versioned aggregate
-  codec, and independent session persistence implemented; atomic completion history planned
+- Status: Daily identity, deterministic generation, local-date boundary, versioned aggregate,
+  independent session persistence, and atomic completion history implemented; feature lifecycle
+  coordination planned
 - Product contract: `docs/product/prd/prd-v10.md`
 - Architecture decision:
   `docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md`
@@ -144,6 +145,11 @@ stale screen cannot update or complete a successor.
 The operation is idempotent for already completed Daily identity and returns a typed outcome that
 distinguishes completed, already completed, stale session, and invalid puzzle. It never clears a
 session before the completion record is durable.
+
+The identity-guarded completion transition is implemented. It validates solved committed puzzle
+state, records one canonical identity, and removes the owning active session in the same
+Preferences DataStore edit. Exact repeats and same-date recipe collisions return the existing
+completion without adding history.
 
 Daily gameplay forwards only committed domain puzzle changes. Draft text, open selectors,
 dialogs, overlays, highlights, calendar month, scroll position, Sharesheet state, animations, and


### PR DESCRIPTION
## Related Issue

Resolves #600

## Summary

- Add typed completed, already-completed, stale-session, and invalid-puzzle outcomes.
- Validate solved gameplay progress against the owning Daily Session snapshot.
- Record completion identity and remove resumability in one DataStore edit.
- Reject same-date recipe duplicates and make exact repeated completion idempotent.
- Protect write failure, stale successor, recreation, corruption, and normal-session independence.