### PR TITLE
[291] Resolve and prepare current Daily sessions

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/CurrentDailyAvailabilityResolver.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/CurrentDailyAvailabilityResolver.kt
@@ -1,0 +1,71 @@
+package org.cescfe.numpairs.feature.daily
+
+import kotlinx.coroutines.flow.first
+import org.cescfe.numpairs.data.daily.session.DailySessionRepository
+import org.cescfe.numpairs.data.daily.session.DailySessionSnapshot
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+
+sealed interface CurrentDailyAvailability {
+    val currentDailyChallenge: CurrentDailyChallenge
+
+    data class StartToday(override val currentDailyChallenge: CurrentDailyChallenge) : CurrentDailyAvailability
+
+    data class ContinueToday(
+        override val currentDailyChallenge: CurrentDailyChallenge,
+        val snapshot: DailySessionSnapshot
+    ) : CurrentDailyAvailability {
+        init {
+            require(snapshot.dailyChallengeId == currentDailyChallenge.identity) {
+                "A resumable Daily Session must match the captured current identity."
+            }
+            require(snapshot.recipeContract == currentDailyChallenge.recipe.contract) {
+                "A resumable Daily Session must match the captured current recipe."
+            }
+        }
+    }
+
+    data class CompletedToday(
+        override val currentDailyChallenge: CurrentDailyChallenge,
+        val completion: DailyChallengeId
+    ) : CurrentDailyAvailability {
+        init {
+            require(completion.localDate == currentDailyChallenge.identity.localDate) {
+                "A current Daily completion must own the captured local date."
+            }
+        }
+    }
+}
+
+class CurrentDailyAvailabilityResolver(
+    private val currentDailyChallengeResolver: CurrentDailyChallengeResolver,
+    private val dailySessionRepository: DailySessionRepository
+) {
+    suspend fun resolve(): CurrentDailyAvailability {
+        val currentDailyChallenge = currentDailyChallengeResolver.resolve()
+        val dailyState = dailySessionRepository.state.first()
+        val completion = dailyState.completedChallengeIds.singleOrNull { completedIdentity ->
+            completedIdentity.localDate == currentDailyChallenge.identity.localDate
+        }
+        if (completion != null) {
+            return CurrentDailyAvailability.CompletedToday(
+                currentDailyChallenge = currentDailyChallenge,
+                completion = completion
+            )
+        }
+
+        val activeSession = dailyState.activeSession
+        return if (
+            activeSession?.dailyChallengeId == currentDailyChallenge.identity &&
+            activeSession.recipeContract == currentDailyChallenge.recipe.contract
+        ) {
+            CurrentDailyAvailability.ContinueToday(
+                currentDailyChallenge = currentDailyChallenge,
+                snapshot = activeSession
+            )
+        } else {
+            CurrentDailyAvailability.StartToday(
+                currentDailyChallenge = currentDailyChallenge
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyPuzzleGenerationUseCase.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyPuzzleGenerationUseCase.kt
@@ -115,12 +115,19 @@ private fun CurrentDailyChallenge.requireFailuresMatchRecipe(attemptedFailures: 
     }
 }
 
+fun interface DailyPuzzleGenerator {
+    suspend fun generate(currentDailyChallenge: CurrentDailyChallenge): DailyPuzzleGenerationResult
+}
+
 class DailyPuzzleGenerationUseCase(
     private val currentDailyChallengeResolver: CurrentDailyChallengeResolver,
     private val generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory
-) {
-    suspend fun generate(): DailyPuzzleGenerationResult {
-        val currentDailyChallenge = currentDailyChallengeResolver.resolve()
+) : DailyPuzzleGenerator {
+    suspend fun generate(): DailyPuzzleGenerationResult = generate(
+        currentDailyChallenge = currentDailyChallengeResolver.resolve()
+    )
+
+    override suspend fun generate(currentDailyChallenge: CurrentDailyChallenge): DailyPuzzleGenerationResult {
         val recipe = currentDailyChallenge.recipe
         val challenge = recipe.challenge
         val generationUseCase = generatedPuzzleGenerationUseCaseFactory.create(challenge)

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyPuzzleViewModel.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyPuzzleViewModel.kt
@@ -1,0 +1,265 @@
+package org.cescfe.numpairs.feature.daily
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import java.io.IOException
+import java.util.UUID
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.cescfe.numpairs.data.daily.session.DailySessionId
+import org.cescfe.numpairs.data.daily.session.DailySessionReplacementResult
+import org.cescfe.numpairs.data.daily.session.DailySessionRepository
+import org.cescfe.numpairs.data.daily.session.DailySessionSnapshot
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+
+fun interface DailySessionIdSource {
+    fun nextId(): DailySessionId
+}
+
+internal object UuidDailySessionIdSource : DailySessionIdSource {
+    override fun nextId(): DailySessionId = DailySessionId(UUID.randomUUID().toString())
+}
+
+internal sealed interface DailyPuzzlePreparationFailure {
+    data class GenerationExhausted(val result: DailyPuzzleGenerationResult.Exhausted) : DailyPuzzlePreparationFailure
+
+    data class GenerationCancelled(val result: DailyPuzzleGenerationResult.Cancelled) : DailyPuzzlePreparationFailure
+
+    data object InvalidGeneratedPuzzle : DailyPuzzlePreparationFailure
+
+    data object Persistence : DailyPuzzlePreparationFailure
+}
+
+internal sealed interface DailyPuzzleUiState {
+    data object Idle : DailyPuzzleUiState
+
+    data object Resolving : DailyPuzzleUiState
+
+    data class Loading(val currentDailyChallenge: CurrentDailyChallenge) : DailyPuzzleUiState
+
+    data class Ready(val session: DailyGameSession) : DailyPuzzleUiState
+
+    data class CompletedToday(val currentDailyChallenge: CurrentDailyChallenge, val completion: DailyChallengeId) :
+        DailyPuzzleUiState {
+        init {
+            require(completion.localDate == currentDailyChallenge.identity.localDate) {
+                "A completed Daily UI state must own the captured local date."
+            }
+        }
+    }
+
+    data class Failed(val currentDailyChallenge: CurrentDailyChallenge, val failure: DailyPuzzlePreparationFailure) :
+        DailyPuzzleUiState
+}
+
+internal class DailyPuzzleViewModel(
+    private val availabilityResolver: CurrentDailyAvailabilityResolver,
+    private val puzzleGenerator: DailyPuzzleGenerator,
+    private val dailySessionRepository: DailySessionRepository,
+    private val sessionIdSource: DailySessionIdSource = UuidDailySessionIdSource
+) : ViewModel() {
+    private val _uiState = MutableStateFlow<DailyPuzzleUiState>(DailyPuzzleUiState.Idle)
+    val uiState: StateFlow<DailyPuzzleUiState> = _uiState.asStateFlow()
+
+    private var preparationJob: Job? = null
+    private var preparationToken: Int = 0
+    private var pendingSessionId: DailySessionId? = null
+
+    fun onRouteEntered() {
+        if (preparationJob != null || _uiState.value != DailyPuzzleUiState.Idle) {
+            return
+        }
+        resolveAndPrepare()
+    }
+
+    fun onRouteExited() {
+        preparationToken++
+        preparationJob?.cancel()
+        preparationJob = null
+        pendingSessionId = null
+        _uiState.value = DailyPuzzleUiState.Idle
+    }
+
+    fun retry() {
+        val failedState = _uiState.value as? DailyPuzzleUiState.Failed ?: return
+        startGeneration(currentDailyChallenge = failedState.currentDailyChallenge)
+    }
+
+    private fun resolveAndPrepare() {
+        val token = ++preparationToken
+        _uiState.value = DailyPuzzleUiState.Resolving
+        val job = viewModelScope.launch(start = CoroutineStart.LAZY) {
+            val availability = availabilityResolver.resolve()
+            if (token != preparationToken) {
+                return@launch
+            }
+
+            preparationJob = null
+            when (availability) {
+                is CurrentDailyAvailability.StartToday -> {
+                    startGeneration(
+                        currentDailyChallenge = availability.currentDailyChallenge
+                    )
+                }
+
+                is CurrentDailyAvailability.ContinueToday -> {
+                    _uiState.value = DailyPuzzleUiState.Ready(
+                        session = DailyGameSession(
+                            currentDailyChallenge = availability.currentDailyChallenge,
+                            snapshot = availability.snapshot
+                        )
+                    )
+                }
+
+                is CurrentDailyAvailability.CompletedToday -> {
+                    _uiState.value = DailyPuzzleUiState.CompletedToday(
+                        currentDailyChallenge = availability.currentDailyChallenge,
+                        completion = availability.completion
+                    )
+                }
+            }
+        }
+        preparationJob = job
+        job.start()
+    }
+
+    private fun startGeneration(currentDailyChallenge: CurrentDailyChallenge) {
+        if (preparationJob != null) {
+            return
+        }
+
+        val token = ++preparationToken
+        _uiState.value = DailyPuzzleUiState.Loading(
+            currentDailyChallenge = currentDailyChallenge
+        )
+        val job = viewModelScope.launch(start = CoroutineStart.LAZY) {
+            val outcome = puzzleGenerator.generate(currentDailyChallenge)
+            if (token != preparationToken) {
+                return@launch
+            }
+
+            val nextState = when (outcome) {
+                is DailyPuzzleGenerationResult.Generated -> {
+                    prepareGeneratedSession(
+                        expectedCurrentDailyChallenge = currentDailyChallenge,
+                        outcome = outcome
+                    )
+                }
+
+                is DailyPuzzleGenerationResult.Exhausted -> {
+                    require(outcome.currentDailyChallenge == currentDailyChallenge) {
+                        "Daily generation outcome must match the captured current identity."
+                    }
+                    DailyPuzzleUiState.Failed(
+                        currentDailyChallenge = currentDailyChallenge,
+                        failure = DailyPuzzlePreparationFailure.GenerationExhausted(outcome)
+                    )
+                }
+
+                is DailyPuzzleGenerationResult.Cancelled -> {
+                    require(outcome.currentDailyChallenge == currentDailyChallenge) {
+                        "Daily generation outcome must match the captured current identity."
+                    }
+                    DailyPuzzleUiState.Failed(
+                        currentDailyChallenge = currentDailyChallenge,
+                        failure = DailyPuzzlePreparationFailure.GenerationCancelled(outcome)
+                    )
+                }
+            }
+            if (token != preparationToken) {
+                return@launch
+            }
+
+            preparationJob = null
+            _uiState.value = nextState
+        }
+        preparationJob = job
+        job.start()
+    }
+
+    private suspend fun prepareGeneratedSession(
+        expectedCurrentDailyChallenge: CurrentDailyChallenge,
+        outcome: DailyPuzzleGenerationResult.Generated
+    ): DailyPuzzleUiState {
+        require(outcome.currentDailyChallenge == expectedCurrentDailyChallenge) {
+            "Daily generation outcome must match the captured current identity."
+        }
+        val snapshot = try {
+            DailySessionSnapshot(
+                sessionId = pendingSessionId ?: sessionIdSource.nextId().also { generatedId ->
+                    pendingSessionId = generatedId
+                },
+                dailyChallengeId = outcome.identity,
+                candidateIndex = outcome.candidateIndex,
+                seed = outcome.seed,
+                initialPuzzle = outcome.initialPuzzle,
+                currentPuzzle = outcome.initialPuzzle
+            )
+        } catch (_: IllegalArgumentException) {
+            return DailyPuzzleUiState.Failed(
+                currentDailyChallenge = expectedCurrentDailyChallenge,
+                failure = DailyPuzzlePreparationFailure.InvalidGeneratedPuzzle
+            )
+        } catch (_: IllegalStateException) {
+            return DailyPuzzleUiState.Failed(
+                currentDailyChallenge = expectedCurrentDailyChallenge,
+                failure = DailyPuzzlePreparationFailure.InvalidGeneratedPuzzle
+            )
+        }
+
+        return try {
+            when (val replacement = dailySessionRepository.replaceSession(snapshot)) {
+                DailySessionReplacementResult.Replaced -> {
+                    pendingSessionId = null
+                    DailyPuzzleUiState.Ready(
+                        session = DailyGameSession(
+                            currentDailyChallenge = expectedCurrentDailyChallenge,
+                            snapshot = snapshot
+                        )
+                    )
+                }
+
+                is DailySessionReplacementResult.DateAlreadyCompleted -> {
+                    pendingSessionId = null
+                    DailyPuzzleUiState.CompletedToday(
+                        currentDailyChallenge = expectedCurrentDailyChallenge,
+                        completion = replacement.completion
+                    )
+                }
+            }
+        } catch (_: IOException) {
+            DailyPuzzleUiState.Failed(
+                currentDailyChallenge = expectedCurrentDailyChallenge,
+                failure = DailyPuzzlePreparationFailure.Persistence
+            )
+        }
+    }
+}
+
+internal data class DailyGameSession(
+    val currentDailyChallenge: CurrentDailyChallenge,
+    val snapshot: DailySessionSnapshot
+) {
+    init {
+        require(snapshot.dailyChallengeId == currentDailyChallenge.identity) {
+            "Daily game session identity must match its captured current identity."
+        }
+        require(snapshot.recipeContract == currentDailyChallenge.recipe.contract) {
+            "Daily game session recipe must match its captured current recipe."
+        }
+    }
+
+    val id: DailySessionId
+        get() = snapshot.sessionId
+
+    val initialPuzzle: Puzzle
+        get() = snapshot.initialPuzzle
+
+    val currentPuzzle: Puzzle
+        get() = snapshot.currentPuzzle
+}

--- a/app/src/test/java/org/cescfe/numpairs/feature/daily/CurrentDailyAvailabilityResolverTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/daily/CurrentDailyAvailabilityResolverTest.kt
@@ -1,0 +1,162 @@
+package org.cescfe.numpairs.feature.daily
+
+import java.time.LocalDate
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import org.cescfe.numpairs.data.daily.session.DailySessionClearResult
+import org.cescfe.numpairs.data.daily.session.DailySessionCompletionResult
+import org.cescfe.numpairs.data.daily.session.DailySessionId
+import org.cescfe.numpairs.data.daily.session.DailySessionProgressUpdateResult
+import org.cescfe.numpairs.data.daily.session.DailySessionReplacementResult
+import org.cescfe.numpairs.data.daily.session.DailySessionRepository
+import org.cescfe.numpairs.data.daily.session.DailySessionSnapshot
+import org.cescfe.numpairs.data.daily.session.DailyState
+import org.cescfe.numpairs.data.daily.session.generatedDailyFixture
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
+import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CurrentDailyAvailabilityResolverTest {
+    @Test
+    fun same_date_completion_takes_precedence_over_an_exact_active_session() = runBlocking {
+        val date = LocalDate.of(2027, 4, 18)
+        val snapshot = generatedDailyFixture(date = date).snapshot()
+        val olderRecipeCompletion = DailyChallengeId(
+            localDate = date,
+            recipeVersion = DailyRecipeVersion("daily-older-supported-recipe")
+        )
+        val repository = FakeDailySessionRepository(
+            initialState = DailyState(
+                activeSession = snapshot,
+                completedChallengeIds = listOf(olderRecipeCompletion)
+            )
+        )
+
+        val availability = resolver(date = date, repository = repository).resolve()
+            as CurrentDailyAvailability.CompletedToday
+
+        assertEquals(olderRecipeCompletion, availability.completion)
+        assertEquals(date, availability.currentDailyChallenge.identity.localDate)
+        assertEquals(0, repository.mutationCount)
+    }
+
+    @Test
+    fun exact_current_snapshot_is_restored_without_generation_or_repository_mutation() = runBlocking {
+        val date = LocalDate.of(2027, 4, 18)
+        val fixture = generatedDailyFixture(date = date)
+        val snapshot = fixture.snapshot(currentPuzzle = fixture.progressPuzzle())
+        val repository = FakeDailySessionRepository(
+            initialState = DailyState(
+                activeSession = snapshot,
+                completedChallengeIds = emptyList()
+            )
+        )
+
+        val availability = resolver(date = date, repository = repository).resolve()
+            as CurrentDailyAvailability.ContinueToday
+
+        assertSame(snapshot, availability.snapshot)
+        assertEquals(0, repository.mutationCount)
+    }
+
+    @Test
+    fun stale_snapshot_is_unavailable_and_remains_untouched() = runBlocking {
+        val staleSnapshot = generatedDailyFixture(
+            date = LocalDate.of(2027, 4, 17)
+        ).snapshot()
+        val repository = FakeDailySessionRepository(
+            initialState = DailyState(
+                activeSession = staleSnapshot,
+                completedChallengeIds = emptyList()
+            )
+        )
+
+        val availability = resolver(
+            date = LocalDate.of(2027, 4, 18),
+            repository = repository
+        ).resolve()
+
+        assertTrue(availability is CurrentDailyAvailability.StartToday)
+        assertSame(staleSnapshot, repository.currentState.activeSession)
+        assertEquals(0, repository.mutationCount)
+    }
+
+    @Test
+    fun moving_the_trusted_clock_back_can_make_a_retained_exact_session_current_again() = runBlocking {
+        var currentDate = LocalDate.of(2027, 4, 19)
+        val retainedSnapshot = generatedDailyFixture(
+            date = LocalDate.of(2027, 4, 18)
+        ).snapshot()
+        val repository = FakeDailySessionRepository(
+            initialState = DailyState(
+                activeSession = retainedSnapshot,
+                completedChallengeIds = emptyList()
+            )
+        )
+        val resolver = CurrentDailyAvailabilityResolver(
+            currentDailyChallengeResolver = CurrentDailyChallengeResolver(
+                localDateSource = DeviceLocalDateSource { currentDate }
+            ),
+            dailySessionRepository = repository
+        )
+
+        assertTrue(resolver.resolve() is CurrentDailyAvailability.StartToday)
+        currentDate = LocalDate.of(2027, 4, 18)
+        val restored = resolver.resolve() as CurrentDailyAvailability.ContinueToday
+
+        assertSame(retainedSnapshot, restored.snapshot)
+        assertEquals(0, repository.mutationCount)
+    }
+}
+
+private fun resolver(date: LocalDate, repository: DailySessionRepository): CurrentDailyAvailabilityResolver =
+    CurrentDailyAvailabilityResolver(
+        currentDailyChallengeResolver = CurrentDailyChallengeResolver(
+            localDateSource = DeviceLocalDateSource { date }
+        ),
+        dailySessionRepository = repository
+    )
+
+private class FakeDailySessionRepository(initialState: DailyState) : DailySessionRepository {
+    private val mutableState = MutableStateFlow(initialState)
+    override val state = mutableState
+
+    val currentState: DailyState
+        get() = mutableState.value
+
+    var mutationCount: Int = 0
+        private set
+
+    override suspend fun replaceSession(snapshot: DailySessionSnapshot): DailySessionReplacementResult {
+        mutationCount += 1
+        mutableState.value = mutableState.value.copy(activeSession = snapshot)
+        return DailySessionReplacementResult.Replaced
+    }
+
+    override suspend fun updateCurrentPuzzle(
+        expectedSessionId: DailySessionId,
+        puzzle: Puzzle
+    ): DailySessionProgressUpdateResult {
+        mutationCount += 1
+        return DailySessionProgressUpdateResult.StaleSession
+    }
+
+    override suspend fun clearSession(expectedSessionId: DailySessionId): DailySessionClearResult {
+        mutationCount += 1
+        return DailySessionClearResult.StaleSession
+    }
+
+    override suspend fun complete(
+        expectedSessionId: DailySessionId,
+        expectedDailyChallengeId: DailyChallengeId,
+        solvedPuzzle: Puzzle
+    ): DailySessionCompletionResult {
+        mutationCount += 1
+        return DailySessionCompletionResult.StaleSession
+    }
+}

--- a/app/src/test/java/org/cescfe/numpairs/feature/daily/DailyPuzzleViewModelTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/daily/DailyPuzzleViewModelTest.kt
@@ -1,0 +1,457 @@
+package org.cescfe.numpairs.feature.daily
+
+import java.io.IOException
+import java.time.LocalDate
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.cescfe.numpairs.data.daily.session.DailySessionClearResult
+import org.cescfe.numpairs.data.daily.session.DailySessionCompletionResult
+import org.cescfe.numpairs.data.daily.session.DailySessionId
+import org.cescfe.numpairs.data.daily.session.DailySessionProgressUpdateResult
+import org.cescfe.numpairs.data.daily.session.DailySessionReplacementResult
+import org.cescfe.numpairs.data.daily.session.DailySessionRepository
+import org.cescfe.numpairs.data.daily.session.DailySessionSnapshot
+import org.cescfe.numpairs.data.daily.session.DailyState
+import org.cescfe.numpairs.data.daily.session.generatedDailyFixture
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationFailureReason
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPairsPuzzleGenerationOutcome
+import org.cescfe.numpairs.domain.generated.generation.GeneratedPuzzleGenerationRequest
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DailyPuzzleViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun exact_session_is_ready_without_generation_id_creation_or_writes() {
+        val fixture = generatedDailyFixture()
+        val snapshot = fixture.snapshot(currentPuzzle = fixture.progressPuzzle())
+        val repository = RecordingDailySessionRepository(
+            initialState = DailyState(snapshot, emptyList())
+        )
+        val generator = RecordingDailyPuzzleGenerator()
+        val idSource = QueueDailySessionIdSource("unexpected")
+        val viewModel = viewModel(
+            date = fixture.identity.localDate,
+            repository = repository,
+            generator = generator,
+            idSource = idSource
+        )
+
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val ready = viewModel.uiState.value as DailyPuzzleUiState.Ready
+        assertSame(snapshot, ready.session.snapshot)
+        assertEquals(0, generator.requestCount)
+        assertEquals(0, idSource.requestCount)
+        assertTrue(repository.replaceAttempts.isEmpty())
+    }
+
+    @Test
+    fun same_date_completion_is_published_without_generation_or_writes() {
+        val date = LocalDate.of(2027, 4, 18)
+        val completion = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(date)
+        val repository = RecordingDailySessionRepository(
+            initialState = DailyState(
+                activeSession = null,
+                completedChallengeIds = listOf(completion)
+            )
+        )
+        val generator = RecordingDailyPuzzleGenerator()
+        val viewModel = viewModel(
+            date = date,
+            repository = repository,
+            generator = generator
+        )
+
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val completed = viewModel.uiState.value as DailyPuzzleUiState.CompletedToday
+        assertEquals(completion, completed.completion)
+        assertEquals(0, generator.requestCount)
+        assertTrue(repository.replaceAttempts.isEmpty())
+    }
+
+    @Test
+    fun generated_successor_is_stored_with_identical_puzzles_before_readiness() {
+        val fixture = generatedDailyFixture()
+        val writeGate = CompletableDeferred<Unit>()
+        val repository = RecordingDailySessionRepository(
+            initialState = DailyState(activeSession = null, completedChallengeIds = emptyList()),
+            nextReplaceGate = writeGate
+        )
+        val generator = RecordingDailyPuzzleGenerator(
+            generatedResult(fixture.identity.localDate, fixture.generatedPuzzle.initialPuzzle)
+        )
+        val viewModel = viewModel(
+            date = fixture.identity.localDate,
+            repository = repository,
+            generator = generator,
+            idSource = QueueDailySessionIdSource("daily-stable")
+        )
+
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.runCurrent()
+
+        assertTrue(viewModel.uiState.value is DailyPuzzleUiState.Loading)
+        val attemptedSnapshot = repository.replaceAttempts.single()
+        assertEquals(DailySessionId("daily-stable"), attemptedSnapshot.sessionId)
+        assertEquals(attemptedSnapshot.initialPuzzle, attemptedSnapshot.currentPuzzle)
+        assertEquals(fixture.identity, attemptedSnapshot.dailyChallengeId)
+        assertSame(null, repository.currentState.activeSession)
+
+        writeGate.complete(Unit)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val ready = viewModel.uiState.value as DailyPuzzleUiState.Ready
+        assertEquals(attemptedSnapshot, repository.currentState.activeSession)
+        assertEquals(attemptedSnapshot, ready.session.snapshot)
+    }
+
+    @Test
+    fun stale_predecessor_remains_during_failure_then_is_replaced_after_retry_storage() {
+        val currentDate = LocalDate.of(2027, 4, 18)
+        val staleSnapshot = generatedDailyFixture(
+            date = currentDate.minusDays(1)
+        ).snapshot()
+        val repository = RecordingDailySessionRepository(
+            initialState = DailyState(staleSnapshot, emptyList()),
+            replaceFailures = ArrayDeque(listOf(IOException("storage unavailable")))
+        )
+        val generated = generatedResult(
+            date = currentDate,
+            initialPuzzle = generatedDailyFixture(date = currentDate).generatedPuzzle.initialPuzzle
+        )
+        val generator = RecordingDailyPuzzleGenerator(generated, generated)
+        val idSource = QueueDailySessionIdSource("stable-across-retry")
+        val viewModel = viewModel(
+            date = currentDate,
+            repository = repository,
+            generator = generator,
+            idSource = idSource
+        )
+
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val failed = viewModel.uiState.value as DailyPuzzleUiState.Failed
+        assertEquals(DailyPuzzlePreparationFailure.Persistence, failed.failure)
+        assertSame(staleSnapshot, repository.currentState.activeSession)
+
+        viewModel.retry()
+        viewModel.retry()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val ready = viewModel.uiState.value as DailyPuzzleUiState.Ready
+        assertEquals(DailySessionId("stable-across-retry"), ready.session.id)
+        assertEquals(1, idSource.requestCount)
+        assertEquals(2, generator.requestCount)
+        assertEquals(2, repository.replaceAttempts.size)
+        assertEquals(ready.session.snapshot, repository.currentState.activeSession)
+    }
+
+    @Test
+    fun duplicate_entry_does_not_duplicate_generation() {
+        val fixture = generatedDailyFixture()
+        val generationGate = CompletableDeferred<DailyPuzzleGenerationResult>()
+        val generator = RecordingDailyPuzzleGenerator(generationGate)
+        val repository = RecordingDailySessionRepository(
+            initialState = DailyState(null, emptyList())
+        )
+        val viewModel = viewModel(
+            date = fixture.identity.localDate,
+            repository = repository,
+            generator = generator
+        )
+
+        viewModel.onRouteEntered()
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.runCurrent()
+
+        assertEquals(1, generator.requestCount)
+
+        generationGate.complete(
+            generatedResult(
+                date = fixture.identity.localDate,
+                initialPuzzle = fixture.generatedPuzzle.initialPuzzle
+            )
+        )
+        dispatcher.scheduler.advanceUntilIdle()
+        assertTrue(viewModel.uiState.value is DailyPuzzleUiState.Ready)
+    }
+
+    @Test
+    fun exhaustion_and_typed_cancellation_keep_the_previous_slot() {
+        val date = LocalDate.of(2027, 4, 18)
+        val staleSnapshot = generatedDailyFixture(date = date.minusDays(1)).snapshot()
+        val repository = RecordingDailySessionRepository(
+            initialState = DailyState(staleSnapshot, emptyList())
+        )
+        val current = currentDailyChallenge(date)
+        val generator = RecordingDailyPuzzleGenerator(
+            exhaustedResult(current),
+            cancelledResult(current)
+        )
+        val viewModel = viewModel(
+            date = date,
+            repository = repository,
+            generator = generator
+        )
+
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val exhausted = viewModel.uiState.value as DailyPuzzleUiState.Failed
+        assertTrue(exhausted.failure is DailyPuzzlePreparationFailure.GenerationExhausted)
+        assertSame(staleSnapshot, repository.currentState.activeSession)
+        assertTrue(repository.replaceAttempts.isEmpty())
+
+        viewModel.retry()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val cancelled = viewModel.uiState.value as DailyPuzzleUiState.Failed
+        assertTrue(cancelled.failure is DailyPuzzlePreparationFailure.GenerationCancelled)
+        assertSame(staleSnapshot, repository.currentState.activeSession)
+        assertTrue(repository.replaceAttempts.isEmpty())
+    }
+
+    @Test
+    fun route_exit_ignores_a_late_generation_result_and_reentry_captures_the_new_date() {
+        var date = LocalDate.of(2027, 4, 18)
+        val firstGate = CompletableDeferred<DailyPuzzleGenerationResult>()
+        val secondFixture = generatedDailyFixture(date = date.plusDays(1))
+        val generator = RecordingDailyPuzzleGenerator(
+            firstGate,
+            generatedResult(
+                date = secondFixture.identity.localDate,
+                initialPuzzle = secondFixture.generatedPuzzle.initialPuzzle
+            )
+        )
+        val repository = RecordingDailySessionRepository(
+            initialState = DailyState(null, emptyList())
+        )
+        val viewModel = viewModel(
+            dateSource = DeviceLocalDateSource { date },
+            repository = repository,
+            generator = generator
+        )
+
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.runCurrent()
+        viewModel.onRouteExited()
+        date = date.plusDays(1)
+        firstGate.complete(
+            generatedResult(
+                date = date.minusDays(1),
+                initialPuzzle = generatedDailyFixture(date = date.minusDays(1)).generatedPuzzle.initialPuzzle
+            )
+        )
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value is DailyPuzzleUiState.Idle)
+        assertTrue(repository.replaceAttempts.isEmpty())
+
+        viewModel.onRouteEntered()
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val ready = viewModel.uiState.value as DailyPuzzleUiState.Ready
+        assertEquals(date, ready.session.currentDailyChallenge.identity.localDate)
+        assertEquals(2, generator.requestCount)
+    }
+}
+
+private fun viewModel(
+    date: LocalDate,
+    repository: DailySessionRepository,
+    generator: DailyPuzzleGenerator,
+    idSource: DailySessionIdSource = QueueDailySessionIdSource("daily-session")
+): DailyPuzzleViewModel = viewModel(
+    dateSource = DeviceLocalDateSource { date },
+    repository = repository,
+    generator = generator,
+    idSource = idSource
+)
+
+private fun viewModel(
+    dateSource: DeviceLocalDateSource,
+    repository: DailySessionRepository,
+    generator: DailyPuzzleGenerator,
+    idSource: DailySessionIdSource = QueueDailySessionIdSource("daily-session")
+): DailyPuzzleViewModel = DailyPuzzleViewModel(
+    availabilityResolver = CurrentDailyAvailabilityResolver(
+        currentDailyChallengeResolver = CurrentDailyChallengeResolver(
+            localDateSource = dateSource
+        ),
+        dailySessionRepository = repository
+    ),
+    puzzleGenerator = generator,
+    dailySessionRepository = repository,
+    sessionIdSource = idSource
+)
+
+private fun currentDailyChallenge(date: LocalDate): CurrentDailyChallenge = CurrentDailyChallenge(
+    identity = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(date),
+    recipe = DailyRecipes.FOUR_PAIRS_LOW_V1
+)
+
+private fun generatedResult(date: LocalDate, initialPuzzle: Puzzle): DailyPuzzleGenerationResult.Generated {
+    val current = currentDailyChallenge(date)
+    val candidateIndex = current.recipe.candidateIndices.first()
+    return DailyPuzzleGenerationResult.Generated(
+        currentDailyChallenge = current,
+        candidateIndex = candidateIndex,
+        seed = current.recipe.seedFor(current.identity, candidateIndex),
+        initialPuzzle = initialPuzzle
+    )
+}
+
+private fun exhaustedResult(current: CurrentDailyChallenge): DailyPuzzleGenerationResult.Exhausted =
+    DailyPuzzleGenerationResult.Exhausted(
+        currentDailyChallenge = current,
+        attemptedFailures = current.recipe.candidateIndices.map { candidateIndex ->
+            candidateFailure(
+                current = current,
+                candidateIndex = candidateIndex,
+                reason = GeneratedPairsPuzzleGenerationFailureReason.AttemptsExhausted
+            )
+        }
+    )
+
+private fun cancelledResult(current: CurrentDailyChallenge): DailyPuzzleGenerationResult.Cancelled =
+    DailyPuzzleGenerationResult.Cancelled(
+        currentDailyChallenge = current,
+        attemptedFailures = listOf(
+            candidateFailure(
+                current = current,
+                candidateIndex = current.recipe.candidateIndices.first(),
+                reason = GeneratedPairsPuzzleGenerationFailureReason.Cancelled
+            )
+        )
+    )
+
+private fun candidateFailure(
+    current: CurrentDailyChallenge,
+    candidateIndex: org.cescfe.numpairs.domain.daily.DailyCandidateIndex,
+    reason: GeneratedPairsPuzzleGenerationFailureReason
+): DailyCandidateGenerationFailure {
+    val seed = current.recipe.seedFor(current.identity, candidateIndex)
+    val request = GeneratedPuzzleGenerationRequest(
+        profile = current.recipe.challenge.profile,
+        seed = seed
+    )
+    return DailyCandidateGenerationFailure(
+        candidateIndex = candidateIndex,
+        seed = seed,
+        failure = GeneratedPairsPuzzleGenerationOutcome.Failed(
+            request = request,
+            attemptsUsed = 1,
+            searchWorkConsumed = 1,
+            reason = reason,
+            candidateRejections = emptyList()
+        )
+    )
+}
+
+private class QueueDailySessionIdSource(vararg ids: String) : DailySessionIdSource {
+    private val remainingIds = ArrayDeque(ids.toList())
+
+    var requestCount: Int = 0
+        private set
+
+    override fun nextId(): DailySessionId {
+        requestCount += 1
+        return DailySessionId(remainingIds.removeFirst())
+    }
+}
+
+private class RecordingDailyPuzzleGenerator(vararg outcomes: Any) : DailyPuzzleGenerator {
+    private val remainingOutcomes = ArrayDeque(outcomes.toList())
+
+    var requestCount: Int = 0
+        private set
+
+    override suspend fun generate(currentDailyChallenge: CurrentDailyChallenge): DailyPuzzleGenerationResult {
+        requestCount += 1
+        return when (val outcome = remainingOutcomes.removeFirst()) {
+            is DailyPuzzleGenerationResult -> outcome
+            is CompletableDeferred<*> -> {
+                @Suppress("UNCHECKED_CAST")
+                (outcome as CompletableDeferred<DailyPuzzleGenerationResult>).await()
+            }
+
+            else -> error("Unsupported Daily generation test outcome.")
+        }
+    }
+}
+
+private class RecordingDailySessionRepository(
+    initialState: DailyState,
+    var nextReplaceGate: CompletableDeferred<Unit>? = null,
+    private val replaceFailures: ArrayDeque<IOException> = ArrayDeque()
+) : DailySessionRepository {
+    private val mutableState = MutableStateFlow(initialState)
+    override val state = mutableState
+
+    val currentState: DailyState
+        get() = mutableState.value
+
+    val replaceAttempts = mutableListOf<DailySessionSnapshot>()
+
+    override suspend fun replaceSession(snapshot: DailySessionSnapshot): DailySessionReplacementResult {
+        replaceAttempts += snapshot
+        nextReplaceGate?.also { gate ->
+            nextReplaceGate = null
+            gate.await()
+        }
+        if (replaceFailures.isNotEmpty()) {
+            throw replaceFailures.removeFirst()
+        }
+        val completion = mutableState.value.completedChallengeIds.singleOrNull { completedIdentity ->
+            completedIdentity.localDate == snapshot.dailyChallengeId.localDate
+        }
+        if (completion != null) {
+            return DailySessionReplacementResult.DateAlreadyCompleted(completion)
+        }
+        mutableState.value = mutableState.value.copy(activeSession = snapshot)
+        return DailySessionReplacementResult.Replaced
+    }
+
+    override suspend fun updateCurrentPuzzle(
+        expectedSessionId: DailySessionId,
+        puzzle: Puzzle
+    ): DailySessionProgressUpdateResult = DailySessionProgressUpdateResult.StaleSession
+
+    override suspend fun clearSession(expectedSessionId: DailySessionId): DailySessionClearResult =
+        DailySessionClearResult.StaleSession
+
+    override suspend fun complete(
+        expectedSessionId: DailySessionId,
+        expectedDailyChallengeId: DailyChallengeId,
+        solvedPuzzle: Puzzle
+    ): DailySessionCompletionResult = DailySessionCompletionResult.StaleSession
+}

--- a/docs/technical/daily-challenge-persistence.md
+++ b/docs/technical/daily-challenge-persistence.md
@@ -3,8 +3,8 @@
 ## Document Status
 
 - Status: Daily identity, deterministic generation, local-date boundary, versioned aggregate,
-  independent session persistence, and atomic completion history implemented; feature lifecycle
-  coordination planned
+  independent session persistence, atomic completion history, and current-session lifecycle
+  coordination implemented; committed gameplay persistence coordination planned
 - Product contract: `docs/product/prd/prd-v10.md`
 - Architecture decision:
   `docs/technical/adr/adr-006-model-daily-challenge-as-versioned-local-cadence.md`
@@ -170,6 +170,10 @@ For the captured local date:
 
 A prior-date session is retained safely but is not exposed as resumable.
 
+Current-state resolution is implemented as a read-only operation over one captured local identity
+and one Daily aggregate emission. Same-date completion takes precedence over continuation,
+including a completion recorded under another recipe version.
+
 ### Create And Replace
 
 1. Capture local date and resolve the Daily Challenge identity.
@@ -185,6 +189,11 @@ cancellation, or exhaustion leaves it intact. A successful stored successor repl
 prior-date session before the new puzzle is shown.
 
 Normal generated-session state is not consulted or mutated.
+
+Safe creation and replacement are implemented in platform-independent feature state. Duplicate
+entry is deduplicated, retry retains the captured Daily identity and deterministic recipe
+sequence, and a stable injectable session id identifies a generated snapshot. Readiness is
+published only after successful repository adoption.
 
 ### Restore
 
@@ -203,6 +212,10 @@ difficulty lookup, or repository writes.
 
 Missing, stale, prior-date, solved, mismatched, corrupt, completed, or unsupported snapshots are
 not resumable. Prior-date content is not offered through the calendar.
+
+Exact restoration is implemented without generation, randomness, remembered difficulty lookup,
+or repository mutation. Generation exhaustion, cancellation, invalid output, and persistence
+failure produce recoverable typed feature states while leaving the stored predecessor unchanged.
 
 ### Progress And Completion
 
@@ -253,8 +266,8 @@ calendar. Cache deletion does not.
 
 The dedicated Preferences DataStore, aggregate state flow, identity-guarded safe replacement,
 incomplete-progress update, explicit clear, corruption recovery, and all three backup and transfer
-exclusions are implemented. Atomic solved completion recording remains a separate delivery
-boundary.
+exclusions are implemented. Atomic solved completion recording is implemented in the same
+aggregate repository.
 
 ---
 


### PR DESCRIPTION
## Related Issue

Resolves #601

## Summary

- Resolve one captured Daily identity to typed start, continue, or completed availability with same-date completion precedence.
- Restore exact persisted progress without generation or writes, and safely generate and store deterministic successors before readiness.
- Keep stale slots intact across pending work and failures while deduplicating entry, retry, and stale asynchronous results.
- Document the implemented current-session lifecycle and cover restoration, rollover, persistence ordering, retry, cancellation, and clock-back behavior.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew lintDebug`