### PR TITLE
[293] Add the local Daily completion calendar

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarScreenTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarScreenTest.kt
@@ -1,0 +1,294 @@
+package org.cescfe.numpairs.feature.daily.calendar
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertHasNoClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.daily.session.DailySessionClearResult
+import org.cescfe.numpairs.data.daily.session.DailySessionCompletionResult
+import org.cescfe.numpairs.data.daily.session.DailySessionId
+import org.cescfe.numpairs.data.daily.session.DailySessionProgressUpdateResult
+import org.cescfe.numpairs.data.daily.session.DailySessionReplacementResult
+import org.cescfe.numpairs.data.daily.session.DailySessionRepository
+import org.cescfe.numpairs.data.daily.session.DailySessionSnapshot
+import org.cescfe.numpairs.data.daily.session.DailyState
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
+import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DailyCalendarScreenTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun date_cells_expose_non_interactive_today_completion_and_future_semantics() {
+        val currentDate = LocalDate.of(2026, 7, 25)
+        val pastCompletion = LocalDate.of(2026, 7, 3)
+        val futureDate = LocalDate.of(2026, 7, 27)
+        setScreen(
+            DailyCalendarMonth.create(
+                capturedCurrentDate = currentDate,
+                completedChallengeIds = listOf(
+                    identity(pastCompletion),
+                    identity(currentDate)
+                ),
+                locale = Locale.US
+            )
+        )
+
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.date(currentDate))
+            .assertIsDisplayed()
+            .assertHasNoClickAction()
+            .assertContentDescriptionEquals(
+                string(
+                    R.string.daily_calendar_today_completed_date_description,
+                    localizedDate(currentDate)
+                )
+            )
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.date(pastCompletion))
+            .assertHasNoClickAction()
+            .assertContentDescriptionEquals(
+                string(
+                    R.string.daily_calendar_completed_date_description,
+                    localizedDate(pastCompletion)
+                )
+            )
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.date(futureDate))
+            .assertHasNoClickAction()
+            .assertIsNotEnabled()
+            .assertContentDescriptionEquals(
+                string(
+                    R.string.daily_calendar_future_date_description,
+                    localizedDate(futureDate)
+                )
+            )
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.NEXT_MONTH_BUTTON)
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun month_and_back_actions_are_distinct_and_next_is_enabled_only_before_current_month() {
+        var previousCount = 0
+        var nextCount = 0
+        var backCount = 0
+        setScreen(
+            month = DailyCalendarMonth.create(
+                capturedCurrentDate = LocalDate.of(2026, 7, 25),
+                displayedMonth = YearMonth.of(2026, 6),
+                locale = Locale.US
+            ),
+            onPreviousMonth = { previousCount += 1 },
+            onNextMonth = { nextCount += 1 },
+            onNavigateBack = { backCount += 1 }
+        )
+
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.PREVIOUS_MONTH_BUTTON)
+            .assertHasClickAction()
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.NEXT_MONTH_BUTTON)
+            .assertIsEnabled()
+            .assertHasClickAction()
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.BACK_BUTTON)
+            .assertHasClickAction()
+            .performClick()
+
+        composeTestRule.runOnIdle {
+            assertEquals(1, previousCount)
+            assertEquals(1, nextCount)
+            assertEquals(1, backCount)
+        }
+    }
+
+    @Test
+    fun route_captures_date_once_reads_history_and_never_mutates_the_repository() {
+        val currentDate = LocalDate.of(2026, 7, 25)
+        val completion = identity(LocalDate.of(2026, 7, 3))
+        val repository = ReadOnlyRecordingDailyRepository(
+            DailyState(
+                activeSession = null,
+                completedChallengeIds = listOf(completion)
+            )
+        )
+        var dateReadCount = 0
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                DailyCalendarRoute(
+                    dailySessionRepository = repository,
+                    deviceLocalDateSource = DeviceLocalDateSource {
+                        dateReadCount += 1
+                        currentDate
+                    },
+                    onNavigateBack = {}
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.date(completion.localDate))
+            .assertContentDescriptionEquals(
+                string(
+                    R.string.daily_calendar_completed_date_description,
+                    localizedDate(completion.localDate)
+                )
+            )
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.PREVIOUS_MONTH_BUTTON)
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.NEXT_MONTH_BUTTON)
+            .performClick()
+
+        composeTestRule.runOnIdle {
+            assertEquals(1, dateReadCount)
+            assertEquals(0, repository.mutationCount)
+        }
+    }
+
+    @Test
+    fun compact_scaled_rtl_layout_keeps_late_month_dates_available_by_scrolling() {
+        val currentDate = LocalDate.of(2028, 2, 29)
+        composeTestRule.setContent {
+            val density = LocalDensity.current
+            CompositionLocalProvider(
+                LocalDensity provides Density(
+                    density = density.density,
+                    fontScale = 2f
+                ),
+                LocalLayoutDirection provides LayoutDirection.Rtl
+            ) {
+                NumPairsTheme {
+                    Box(modifier = Modifier.size(width = 320.dp, height = 420.dp)) {
+                        DailyCalendarScreen(
+                            calendarMonth = DailyCalendarMonth.create(
+                                capturedCurrentDate = currentDate,
+                                locale = Locale.forLanguageTag("ar")
+                            ),
+                            locale = Locale.forLanguageTag("ar"),
+                            onPreviousMonth = {},
+                            onNextMonth = {},
+                            onNavigateBack = {}
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.date(currentDate))
+            .performScrollTo()
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.MONTH_HEADING)
+            .assertTextEquals(
+                currentDate.format(
+                    DateTimeFormatter.ofPattern("LLLL yyyy", Locale.forLanguageTag("ar"))
+                )
+            )
+    }
+
+    private fun setScreen(
+        month: DailyCalendarMonth,
+        onPreviousMonth: () -> Unit = {},
+        onNextMonth: () -> Unit = {},
+        onNavigateBack: () -> Unit = {}
+    ) {
+        composeTestRule.setContent {
+            NumPairsTheme {
+                DailyCalendarScreen(
+                    calendarMonth = month,
+                    locale = Locale.US,
+                    onPreviousMonth = onPreviousMonth,
+                    onNextMonth = onNextMonth,
+                    onNavigateBack = onNavigateBack
+                )
+            }
+        }
+    }
+
+    private fun localizedDate(date: LocalDate): String = date.format(
+        DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).withLocale(Locale.US)
+    )
+
+    private fun string(stringResId: Int, vararg args: Any): String =
+        composeTestRule.activity.getString(stringResId, *args)
+}
+
+private class ReadOnlyRecordingDailyRepository(initialState: DailyState) : DailySessionRepository {
+    override val state = MutableStateFlow(initialState)
+
+    var mutationCount: Int = 0
+        private set
+
+    override suspend fun replaceSession(snapshot: DailySessionSnapshot): DailySessionReplacementResult {
+        mutationCount += 1
+        return DailySessionReplacementResult.Replaced
+    }
+
+    override suspend fun updateCurrentPuzzle(
+        expectedSessionId: DailySessionId,
+        puzzle: Puzzle
+    ): DailySessionProgressUpdateResult {
+        mutationCount += 1
+        return DailySessionProgressUpdateResult.StaleSession
+    }
+
+    override suspend fun clearSession(expectedSessionId: DailySessionId): DailySessionClearResult {
+        mutationCount += 1
+        return DailySessionClearResult.StaleSession
+    }
+
+    override suspend fun complete(
+        expectedSessionId: DailySessionId,
+        expectedDailyChallengeId: DailyChallengeId,
+        solvedPuzzle: Puzzle
+    ): DailySessionCompletionResult {
+        mutationCount += 1
+        return DailySessionCompletionResult.StaleSession
+    }
+}
+
+private fun identity(date: LocalDate): DailyChallengeId = DailyChallengeId(
+    localDate = date,
+    recipeVersion = DailyRecipeVersion("daily-calendar-test")
+)

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarMonth.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarMonth.kt
@@ -1,0 +1,120 @@
+package org.cescfe.numpairs.feature.daily.calendar
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.temporal.WeekFields
+import java.util.Locale
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+
+data class DailyCalendarDate(
+    val date: LocalDate,
+    val isToday: Boolean,
+    val isCompleted: Boolean,
+    val isFuture: Boolean
+) {
+    init {
+        require(!isToday || !isFuture) {
+            "Today cannot be a future Daily calendar date."
+        }
+    }
+}
+
+sealed interface DailyCalendarPosition {
+    data object OutsideMonth : DailyCalendarPosition
+
+    data class InMonth(val calendarDate: DailyCalendarDate) : DailyCalendarPosition
+}
+
+data class DailyCalendarMonth(
+    val capturedCurrentDate: LocalDate,
+    val displayedMonth: YearMonth,
+    val firstDayOfWeek: DayOfWeek,
+    val weekdayOrder: List<DayOfWeek>,
+    val positions: List<DailyCalendarPosition>
+) {
+    val currentMonth: YearMonth = YearMonth.from(capturedCurrentDate)
+
+    val canNavigateToNextMonth: Boolean
+        get() = displayedMonth < currentMonth
+
+    init {
+        require(displayedMonth <= currentMonth) {
+            "Daily calendar cannot display a future month."
+        }
+        require(weekdayOrder == orderedWeekdays(firstDayOfWeek)) {
+            "Daily calendar weekday order must start with its locale first day."
+        }
+        require(positions.size in 28..42 && positions.size % DAYS_PER_WEEK == 0) {
+            "Daily calendar positions must contain complete weeks."
+        }
+        require(
+            positions.filterIsInstance<DailyCalendarPosition.InMonth>()
+                .map { position -> position.calendarDate.date } ==
+                (1..displayedMonth.lengthOfMonth()).map(displayedMonth::atDay)
+        ) {
+            "Daily calendar must contain each in-month date exactly once and in order."
+        }
+    }
+
+    companion object {
+        fun create(
+            capturedCurrentDate: LocalDate,
+            displayedMonth: YearMonth = YearMonth.from(capturedCurrentDate),
+            completedChallengeIds: Collection<DailyChallengeId> = emptyList(),
+            locale: Locale = Locale.getDefault()
+        ): DailyCalendarMonth {
+            require(displayedMonth <= YearMonth.from(capturedCurrentDate)) {
+                "Daily calendar cannot display a future month."
+            }
+            require(
+                completedChallengeIds.map(DailyChallengeId::localDate).distinct().size ==
+                    completedChallengeIds.size
+            ) {
+                "Daily calendar history can contain at most one completion per local date."
+            }
+            val firstDayOfWeek = WeekFields.of(locale).firstDayOfWeek
+            val firstDate = displayedMonth.atDay(1)
+            val leadingPositionCount = (
+                firstDate.dayOfWeek.value -
+                    firstDayOfWeek.value +
+                    DAYS_PER_WEEK
+                ) % DAYS_PER_WEEK
+            val completedDates = completedChallengeIds.map(DailyChallengeId::localDate).toSet()
+            val inMonthPositions = (1..displayedMonth.lengthOfMonth()).map { day ->
+                val date = displayedMonth.atDay(day)
+                DailyCalendarPosition.InMonth(
+                    calendarDate = DailyCalendarDate(
+                        date = date,
+                        isToday = date == capturedCurrentDate,
+                        isCompleted = date in completedDates,
+                        isFuture = date > capturedCurrentDate
+                    )
+                )
+            }
+            val populatedPositionCount = leadingPositionCount + inMonthPositions.size
+            val trailingPositionCount = (
+                DAYS_PER_WEEK -
+                    populatedPositionCount % DAYS_PER_WEEK
+                ) % DAYS_PER_WEEK
+
+            return DailyCalendarMonth(
+                capturedCurrentDate = capturedCurrentDate,
+                displayedMonth = displayedMonth,
+                firstDayOfWeek = firstDayOfWeek,
+                weekdayOrder = orderedWeekdays(firstDayOfWeek),
+                positions = List(leadingPositionCount) {
+                    DailyCalendarPosition.OutsideMonth
+                } + inMonthPositions + List(trailingPositionCount) {
+                    DailyCalendarPosition.OutsideMonth
+                }
+            )
+        }
+    }
+}
+
+private fun orderedWeekdays(firstDayOfWeek: DayOfWeek): List<DayOfWeek> = List(DAYS_PER_WEEK) { offset ->
+    DayOfWeek.of((firstDayOfWeek.value - 1 + offset) % DAYS_PER_WEEK + 1)
+}
+
+private const val DAYS_PER_WEEK = 7

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarRoute.kt
@@ -1,0 +1,68 @@
+package org.cescfe.numpairs.feature.daily.calendar
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import java.time.YearMonth
+import java.util.Locale
+import org.cescfe.numpairs.data.daily.session.DailySessionRepository
+import org.cescfe.numpairs.data.daily.session.DailyState
+import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
+
+@Composable
+fun DailyCalendarRoute(
+    dailySessionRepository: DailySessionRepository,
+    deviceLocalDateSource: DeviceLocalDateSource,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val capturedCurrentDate = remember(deviceLocalDateSource) {
+        deviceLocalDateSource.currentDate()
+    }
+    var displayedMonth by remember(capturedCurrentDate) {
+        mutableStateOf(YearMonth.from(capturedCurrentDate))
+    }
+    val dailyState by dailySessionRepository.state.collectAsState(
+        initial = DailyState(
+            activeSession = null,
+            completedChallengeIds = emptyList()
+        )
+    )
+    val configuration = LocalConfiguration.current
+    val locale = remember(configuration) {
+        Locale.forLanguageTag(configuration.locales[0].toLanguageTag())
+    }
+    val calendarMonth = remember(
+        capturedCurrentDate,
+        displayedMonth,
+        dailyState.completedChallengeIds,
+        locale
+    ) {
+        DailyCalendarMonth.create(
+            capturedCurrentDate = capturedCurrentDate,
+            displayedMonth = displayedMonth,
+            completedChallengeIds = dailyState.completedChallengeIds,
+            locale = locale
+        )
+    }
+
+    DailyCalendarScreen(
+        calendarMonth = calendarMonth,
+        locale = locale,
+        onPreviousMonth = {
+            displayedMonth = displayedMonth.minusMonths(1)
+        },
+        onNextMonth = {
+            if (calendarMonth.canNavigateToNextMonth) {
+                displayedMonth = displayedMonth.plusMonths(1)
+            }
+        },
+        onNavigateBack = onNavigateBack,
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarScreen.kt
@@ -1,0 +1,327 @@
+package org.cescfe.numpairs.feature.daily.calendar
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import java.time.DayOfWeek
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.time.format.TextStyle
+import java.util.Locale
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.ui.theme.NumPairsComponents
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DailyCalendarScreen(
+    calendarMonth: DailyCalendarMonth,
+    locale: Locale,
+    onPreviousMonth: () -> Unit,
+    onNextMonth: () -> Unit,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        modifier = modifier
+            .fillMaxSize()
+            .testTag(DailyCalendarScreenTestTags.SCREEN),
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
+        topBar = {
+            TopAppBar(
+                colors = NumPairsComponents.topAppBarColors(),
+                navigationIcon = {
+                    IconButton(
+                        onClick = onNavigateBack,
+                        modifier = Modifier.testTag(DailyCalendarScreenTestTags.BACK_BUTTON)
+                    ) {
+                        LogicalChevronIcon(
+                            pointsToStart = true,
+                            contentDescription = stringResource(R.string.back_button_content_description)
+                        )
+                    }
+                },
+                title = {
+                    Text(text = stringResource(R.string.daily_calendar_screen_title))
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .widthIn(max = DAILY_CALENDAR_MAX_WIDTH),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                MonthNavigation(
+                    calendarMonth = calendarMonth,
+                    locale = locale,
+                    onPreviousMonth = onPreviousMonth,
+                    onNextMonth = onNextMonth
+                )
+                WeekdayHeadings(
+                    weekdays = calendarMonth.weekdayOrder,
+                    locale = locale
+                )
+                CalendarGrid(
+                    positions = calendarMonth.positions,
+                    locale = locale
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MonthNavigation(
+    calendarMonth: DailyCalendarMonth,
+    locale: Locale,
+    onPreviousMonth: () -> Unit,
+    onNextMonth: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        IconButton(
+            onClick = onPreviousMonth,
+            modifier = Modifier.testTag(DailyCalendarScreenTestTags.PREVIOUS_MONTH_BUTTON),
+            colors = NumPairsComponents.iconButtonColors()
+        ) {
+            LogicalChevronIcon(
+                pointsToStart = true,
+                contentDescription = stringResource(
+                    R.string.daily_calendar_previous_month_content_description
+                )
+            )
+        }
+        Text(
+            text = calendarMonth.displayedMonth.atDay(1).format(
+                DateTimeFormatter.ofPattern("LLLL yyyy", locale)
+            ),
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 8.dp)
+                .testTag(DailyCalendarScreenTestTags.MONTH_HEADING),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold
+        )
+        IconButton(
+            onClick = onNextMonth,
+            enabled = calendarMonth.canNavigateToNextMonth,
+            modifier = Modifier.testTag(DailyCalendarScreenTestTags.NEXT_MONTH_BUTTON),
+            colors = NumPairsComponents.iconButtonColors()
+        ) {
+            LogicalChevronIcon(
+                pointsToStart = false,
+                contentDescription = stringResource(
+                    R.string.daily_calendar_next_month_content_description
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun WeekdayHeadings(weekdays: List<DayOfWeek>, locale: Locale) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        weekdays.forEach { weekday ->
+            Text(
+                text = weekday.getDisplayName(TextStyle.SHORT_STANDALONE, locale),
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(vertical = 4.dp),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}
+
+@Composable
+private fun CalendarGrid(positions: List<DailyCalendarPosition>, locale: Locale) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        positions.chunked(DAYS_PER_WEEK).forEach { week ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                week.forEach { position ->
+                    Box(modifier = Modifier.weight(1f)) {
+                        when (position) {
+                            DailyCalendarPosition.OutsideMonth -> {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .aspectRatio(1f)
+                                )
+                            }
+
+                            is DailyCalendarPosition.InMonth -> {
+                                DailyCalendarDateCell(
+                                    calendarDate = position.calendarDate,
+                                    locale = locale
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DailyCalendarDateCell(calendarDate: DailyCalendarDate, locale: Locale) {
+    val description = calendarDate.localizedContentDescription(locale)
+    val border = when {
+        calendarDate.isToday -> NumPairsComponents.defaultBorder().copy(
+            width = NumPairsComponents.StrongBorderWidth
+        )
+
+        calendarDate.isCompleted -> NumPairsComponents.successBorder()
+        else -> BorderStroke(
+            width = NumPairsComponents.ThinBorderWidth,
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = NEUTRAL_CELL_BORDER_ALPHA)
+        )
+    }
+    val background = if (calendarDate.isCompleted) {
+        NumPairsComponents.successContainerColor()
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+    val contentColor = if (calendarDate.isCompleted) {
+        NumPairsComponents.successContentColor()
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(1f)
+            .alpha(if (calendarDate.isFuture) FUTURE_DATE_ALPHA else 1f)
+            .background(color = background, shape = CircleShape)
+            .border(border = border, shape = CircleShape)
+            .clearAndSetSemantics {
+                contentDescription = description
+                if (calendarDate.isFuture) {
+                    disabled()
+                }
+            }.testTag(DailyCalendarScreenTestTags.date(calendarDate.date)),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = calendarDate.date.dayOfMonth.toString(),
+                color = contentColor,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = if (calendarDate.isToday || calendarDate.isCompleted) {
+                    FontWeight.Bold
+                } else {
+                    FontWeight.Normal
+                }
+            )
+            if (calendarDate.isCompleted) {
+                Text(
+                    text = CHECK_MARK,
+                    color = contentColor,
+                    style = MaterialTheme.typography.labelSmall
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DailyCalendarDate.localizedContentDescription(locale: Locale): String {
+    val localizedDate = date.format(
+        DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).withLocale(locale)
+    )
+    return stringResource(
+        when {
+            isToday && isCompleted -> R.string.daily_calendar_today_completed_date_description
+            isToday -> R.string.daily_calendar_today_date_description
+            isCompleted && isFuture -> R.string.daily_calendar_future_completed_date_description
+            isCompleted -> R.string.daily_calendar_completed_date_description
+            isFuture -> R.string.daily_calendar_future_date_description
+            else -> R.string.daily_calendar_date_description
+        },
+        localizedDate
+    )
+}
+
+@Composable
+private fun LogicalChevronIcon(pointsToStart: Boolean, contentDescription: String) {
+    val layoutDirection = LocalLayoutDirection.current
+    val pointsLeft = pointsToStart == (layoutDirection == LayoutDirection.Ltr)
+    Icon(
+        painter = painterResource(R.drawable.ic_chevron_left),
+        contentDescription = contentDescription,
+        modifier = Modifier
+            .size(24.dp)
+            .graphicsLayer {
+                rotationZ = if (pointsLeft) 0f else 180f
+            }
+    )
+}
+
+private const val DAYS_PER_WEEK = 7
+private const val CHECK_MARK = "✓"
+private const val FUTURE_DATE_ALPHA = 0.5f
+private const val NEUTRAL_CELL_BORDER_ALPHA = 0.35f
+private val DAILY_CALENDAR_MAX_WIDTH = 480.dp

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarScreenTestTags.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarScreenTestTags.kt
@@ -1,0 +1,13 @@
+package org.cescfe.numpairs.feature.daily.calendar
+
+import java.time.LocalDate
+
+object DailyCalendarScreenTestTags {
+    const val SCREEN = "daily_calendar_screen"
+    const val BACK_BUTTON = "daily_calendar_back_button"
+    const val PREVIOUS_MONTH_BUTTON = "daily_calendar_previous_month_button"
+    const val NEXT_MONTH_BUTTON = "daily_calendar_next_month_button"
+    const val MONTH_HEADING = "daily_calendar_month_heading"
+
+    fun date(date: LocalDate): String = "daily_calendar_date_$date"
+}

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -60,6 +60,17 @@
     <string name="generated_puzzle_back_to_menu_button">Torna al menú</string>
     <string name="generated_session_resume_unavailable_message">Aquest puzle sense acabar ja no està disponible.</string>
 
+    <!-- Calendari Daily -->
+    <string name="daily_calendar_screen_title">Calendari Daily</string>
+    <string name="daily_calendar_previous_month_content_description">Mostra el mes anterior</string>
+    <string name="daily_calendar_next_month_content_description">Mostra el mes següent</string>
+    <string name="daily_calendar_date_description">%1$s</string>
+    <string name="daily_calendar_today_date_description">%1$s, Hui</string>
+    <string name="daily_calendar_completed_date_description">%1$s, Completat</string>
+    <string name="daily_calendar_today_completed_date_description">%1$s, Hui, Completat</string>
+    <string name="daily_calendar_future_completed_date_description">%1$s, Completat, Data futura</string>
+    <string name="daily_calendar_future_date_description">%1$s, Data futura</string>
+
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Pas %1$d de %2$d</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -60,6 +60,17 @@
     <string name="generated_puzzle_back_to_menu_button">Volver al menú</string>
     <string name="generated_session_resume_unavailable_message">Este puzle sin terminar ya no está disponible.</string>
 
+    <!-- Calendario Daily -->
+    <string name="daily_calendar_screen_title">Calendario Daily</string>
+    <string name="daily_calendar_previous_month_content_description">Mostrar mes anterior</string>
+    <string name="daily_calendar_next_month_content_description">Mostrar mes siguiente</string>
+    <string name="daily_calendar_date_description">%1$s</string>
+    <string name="daily_calendar_today_date_description">%1$s, Hoy</string>
+    <string name="daily_calendar_completed_date_description">%1$s, Completado</string>
+    <string name="daily_calendar_today_completed_date_description">%1$s, Hoy, Completado</string>
+    <string name="daily_calendar_future_completed_date_description">%1$s, Completado, Fecha futura</string>
+    <string name="daily_calendar_future_date_description">%1$s, Fecha futura</string>
+
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Paso %1$d de %2$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,17 @@
     <string name="generated_puzzle_back_to_menu_button">Back to menu</string>
     <string name="generated_session_resume_unavailable_message">This unfinished puzzle is no longer available.</string>
 
+    <!-- Daily calendar -->
+    <string name="daily_calendar_screen_title">Daily calendar</string>
+    <string name="daily_calendar_previous_month_content_description">Show previous month</string>
+    <string name="daily_calendar_next_month_content_description">Show next month</string>
+    <string name="daily_calendar_date_description">%1$s</string>
+    <string name="daily_calendar_today_date_description">%1$s, Today</string>
+    <string name="daily_calendar_completed_date_description">%1$s, Completed</string>
+    <string name="daily_calendar_today_completed_date_description">%1$s, Today, Completed</string>
+    <string name="daily_calendar_future_completed_date_description">%1$s, Completed, Future date</string>
+    <string name="daily_calendar_future_date_description">%1$s, Future date</string>
+
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Step %1$d of %2$d</string>

--- a/app/src/test/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarMonthTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarMonthTest.kt
@@ -1,0 +1,170 @@
+package org.cescfe.numpairs.feature.daily.calendar
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.YearMonth
+import java.util.Locale
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DailyCalendarMonthTest {
+    @Test
+    fun locale_first_day_controls_weekday_order_and_leading_positions() {
+        val currentDate = LocalDate.of(2026, 7, 25)
+
+        val sundayFirst = DailyCalendarMonth.create(
+            capturedCurrentDate = currentDate,
+            locale = Locale.US
+        )
+        val mondayFirst = DailyCalendarMonth.create(
+            capturedCurrentDate = currentDate,
+            locale = Locale.forLanguageTag("es-ES")
+        )
+
+        assertEquals(DayOfWeek.SUNDAY, sundayFirst.firstDayOfWeek)
+        assertEquals(
+            listOf(
+                DayOfWeek.SUNDAY,
+                DayOfWeek.MONDAY,
+                DayOfWeek.TUESDAY,
+                DayOfWeek.WEDNESDAY,
+                DayOfWeek.THURSDAY,
+                DayOfWeek.FRIDAY,
+                DayOfWeek.SATURDAY
+            ),
+            sundayFirst.weekdayOrder
+        )
+        assertEquals(3, sundayFirst.leadingOutsideMonthCount)
+        assertEquals(DayOfWeek.MONDAY, mondayFirst.firstDayOfWeek)
+        assertEquals(2, mondayFirst.leadingOutsideMonthCount)
+    }
+
+    @Test
+    fun leap_month_contains_every_date_once_in_complete_weeks() {
+        val month = DailyCalendarMonth.create(
+            capturedCurrentDate = LocalDate.of(2028, 2, 29),
+            locale = Locale.UK
+        )
+
+        val dates = month.inMonthDates
+
+        assertEquals(29, dates.size)
+        assertEquals(LocalDate.of(2028, 2, 1), dates.first().date)
+        assertEquals(LocalDate.of(2028, 2, 29), dates.last().date)
+        assertEquals(0, month.positions.size % 7)
+        assertEquals(dates.map(DailyCalendarDate::date).distinct(), dates.map(DailyCalendarDate::date))
+    }
+
+    @Test
+    fun date_flags_preserve_factual_completion_without_modelling_missed_days() {
+        val currentDate = LocalDate.of(2026, 7, 25)
+        val pastCompletion = identity(LocalDate.of(2026, 7, 3))
+        val todayCompletion = identity(currentDate)
+        val futureCompletionFromTrustedClock = identity(LocalDate.of(2026, 7, 27))
+        val month = DailyCalendarMonth.create(
+            capturedCurrentDate = currentDate,
+            completedChallengeIds = listOf(
+                pastCompletion,
+                todayCompletion,
+                futureCompletionFromTrustedClock
+            ),
+            locale = Locale.UK
+        )
+
+        assertEquals(
+            DailyCalendarDate(
+                date = pastCompletion.localDate,
+                isToday = false,
+                isCompleted = true,
+                isFuture = false
+            ),
+            month.date(pastCompletion.localDate)
+        )
+        assertEquals(
+            DailyCalendarDate(
+                date = currentDate,
+                isToday = true,
+                isCompleted = true,
+                isFuture = false
+            ),
+            month.date(currentDate)
+        )
+        assertEquals(
+            DailyCalendarDate(
+                date = futureCompletionFromTrustedClock.localDate,
+                isToday = false,
+                isCompleted = true,
+                isFuture = true
+            ),
+            month.date(futureCompletionFromTrustedClock.localDate)
+        )
+        assertEquals(
+            DailyCalendarDate(
+                date = LocalDate.of(2026, 7, 4),
+                isToday = false,
+                isCompleted = false,
+                isFuture = false
+            ),
+            month.date(LocalDate.of(2026, 7, 4))
+        )
+    }
+
+    @Test
+    fun previous_month_allows_forward_navigation_but_current_and_future_months_do_not() {
+        val currentDate = LocalDate.of(2026, 7, 25)
+        val previous = DailyCalendarMonth.create(
+            capturedCurrentDate = currentDate,
+            displayedMonth = YearMonth.of(2026, 6)
+        )
+        val current = DailyCalendarMonth.create(
+            capturedCurrentDate = currentDate
+        )
+
+        assertTrue(previous.canNavigateToNextMonth)
+        assertFalse(current.canNavigateToNextMonth)
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyCalendarMonth.create(
+                capturedCurrentDate = currentDate,
+                displayedMonth = YearMonth.of(2026, 8)
+            )
+        }
+    }
+
+    @Test
+    fun duplicate_recipe_completions_for_one_date_are_rejected() {
+        val completedDate = LocalDate.of(2026, 7, 3)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyCalendarMonth.create(
+                capturedCurrentDate = LocalDate.of(2026, 7, 25),
+                completedChallengeIds = listOf(
+                    identity(completedDate, recipe = "recipe-one"),
+                    identity(completedDate, recipe = "recipe-two")
+                )
+            )
+        }
+    }
+}
+
+private val DailyCalendarMonth.inMonthDates: List<DailyCalendarDate>
+    get() = positions.filterIsInstance<DailyCalendarPosition.InMonth>()
+        .map(DailyCalendarPosition.InMonth::calendarDate)
+
+private val DailyCalendarMonth.leadingOutsideMonthCount: Int
+    get() = positions.takeWhile { position ->
+        position == DailyCalendarPosition.OutsideMonth
+    }.size
+
+private fun DailyCalendarMonth.date(date: LocalDate): DailyCalendarDate = inMonthDates.single { calendarDate ->
+    calendarDate.date == date
+}
+
+private fun identity(date: LocalDate, recipe: String = "daily-test-recipe"): DailyChallengeId = DailyChallengeId(
+    localDate = date,
+    recipeVersion = DailyRecipeVersion(recipe)
+)

--- a/docs/ui-behavior.md
+++ b/docs/ui-behavior.md
@@ -345,6 +345,9 @@ returns to the normal menu.
 
 ### Daily Calendar
 
+Status: monthly calendar model and read-only Compose surface implemented; application navigation
+integration planned.
+
 The Daily calendar is a dedicated local-history destination with:
 
 - back navigation


### PR DESCRIPTION
## Related Issue

Resolves #608

## Summary

- Model locale-aware monthly Daily history as complete seven-day weeks over one captured local date.
- Render a read-only, scrollable calendar with factual today, completion, future, and combined states.
- Keep month navigation transient, prevent future-month browsing, and isolate the route from every repository mutation.
- Add English, Spanish, and Valencian copy plus deterministic model and focused Compose coverage.

## UI Consistency

- Shared components or tokens reused: `NumPairsComponents.topAppBarColors`, `iconButtonColors`, border widths, surface colors, and success semantic colors; the TopAppBar and IconButton structure follows Personalization.
- Intentional deviations from established visual roles: date cells use feature-local informational circles because they are non-interactive status cells, not buttons or selectable controls.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew lintDebug`