### PR TITLE
[294] Share a non-spoiling Daily completion result

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/daily/share/DailyCompletionShareAndroidTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/daily/share/DailyCompletionShareAndroidTest.kt
@@ -1,0 +1,126 @@
+package org.cescfe.numpairs.feature.daily.share
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import androidx.core.os.BundleCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.time.LocalDate
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.feature.daily.DailyRecipes
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DailyCompletionShareAndroidTest {
+    @Test
+    fun payload_factory_uses_localized_v10_daily_completion_copy() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val identity = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(
+            LocalDate.of(2026, 7, 25)
+        )
+
+        val payload = AndroidDailyCompletionSharePayloadFactory(
+            resources = context.resources
+        ).create(completedIdentity = identity)
+
+        assertTrue(payload.text.value.startsWith(context.getString(R.string.daily_share_name)))
+        assertTrue(
+            payload.text.value.contains(
+                context.getString(
+                    R.string.generated_challenge_title,
+                    context.getString(R.string.four_pairs_screen_title),
+                    context.getString(R.string.generated_difficulty_low)
+                )
+            )
+        )
+        assertTrue(
+            payload.text.value.endsWith(
+                context.getString(R.string.daily_share_completed_status)
+            )
+        )
+        assertEquals(
+            context.getString(R.string.daily_share_chooser_title),
+            payload.chooserTitle
+        )
+    }
+
+    @Test
+    fun chooser_contains_one_exact_plain_text_send_intent_without_attachments() {
+        val payload = DailyCompletionSharePayload(
+            text = DailyCompletionShareText(
+                "NumPairs Daily · Jul 25, 2026\n4 Pairs · Low · Completed"
+            ),
+            chooserTitle = "Share Daily result"
+        )
+
+        val chooserIntent = DailyCompletionShareIntentFactory.create(payload)
+        val sendIntent = requireNotNull(
+            BundleCompat.getParcelable(
+                chooserIntent.extras ?: error("Chooser extras missing."),
+                Intent.EXTRA_INTENT,
+                Intent::class.java
+            )
+        )
+
+        assertEquals(Intent.ACTION_CHOOSER, chooserIntent.action)
+        assertEquals(payload.chooserTitle, chooserIntent.getStringExtra(Intent.EXTRA_TITLE))
+        assertEquals(Intent.ACTION_SEND, sendIntent.action)
+        assertEquals(DAILY_SHARE_MIME_TYPE, sendIntent.type)
+        assertEquals(payload.text.value, sendIntent.getStringExtra(Intent.EXTRA_TEXT))
+        assertFalse(sendIntent.hasExtra(Intent.EXTRA_STREAM))
+        assertEquals(null, sendIntent.clipData)
+        assertFalse(sendIntent.hasExtra(Intent.EXTRA_HTML_TEXT))
+    }
+
+    @Test
+    fun launcher_adds_new_task_for_non_activity_context_and_reports_success() {
+        val context = RecordingShareContext(
+            base = InstrumentationRegistry.getInstrumentation().targetContext
+        )
+        val payload = testPayload()
+
+        val result = AndroidDailyCompletionShareLauncher(context).launch(payload)
+
+        assertSame(DailyCompletionShareLaunchResult.Launched, result)
+        assertTrue(requireNotNull(context.startedIntent).flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+
+    @Test
+    fun unavailable_chooser_is_typed_and_does_not_crash() {
+        val context = RecordingShareContext(
+            base = InstrumentationRegistry.getInstrumentation().targetContext,
+            failure = ActivityNotFoundException("No chooser")
+        )
+
+        val result = AndroidDailyCompletionShareLauncher(context).launch(testPayload())
+
+        assertSame(DailyCompletionShareLaunchResult.Unavailable, result)
+    }
+}
+
+private class RecordingShareContext(base: Context, private val failure: ActivityNotFoundException? = null) :
+    ContextWrapper(base) {
+    var startedIntent: Intent? = null
+        private set
+
+    override fun startActivity(intent: Intent) {
+        failure?.let { throwable ->
+            throw throwable
+        }
+        startedIntent = intent
+    }
+}
+
+private fun testPayload(): DailyCompletionSharePayload = DailyCompletionSharePayload(
+    text = DailyCompletionShareText(
+        "NumPairs Daily · Jul 25, 2026\n4 Pairs · Low · Completed"
+    ),
+    chooserTitle = "Share Daily result"
+)

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/share/AndroidDailyCompletionShare.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/share/AndroidDailyCompletionShare.kt
@@ -1,0 +1,82 @@
+package org.cescfe.numpairs.feature.daily.share
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.content.res.Resources
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+
+data class DailyCompletionSharePayload(val text: DailyCompletionShareText, val chooserTitle: String) {
+    init {
+        require(chooserTitle.isNotBlank()) {
+            "Daily share chooser title must not be blank."
+        }
+    }
+}
+
+class AndroidDailyCompletionSharePayloadFactory(
+    private val resources: Resources,
+    private val formatter: DailyCompletionShareTextFormatter = DailyCompletionShareTextFormatter()
+) {
+    fun create(completedIdentity: DailyChallengeId): DailyCompletionSharePayload {
+        val locale = resources.configuration.locales[0]
+        val fourPairsName = resources.getString(R.string.four_pairs_screen_title)
+        val lowDifficultyName = resources.getString(R.string.generated_difficulty_low)
+        return DailyCompletionSharePayload(
+            text = formatter.format(
+                completedIdentity = completedIdentity,
+                copy = DailyCompletionShareCopy(
+                    dailyName = resources.getString(R.string.daily_share_name),
+                    challengeName = resources.getString(
+                        R.string.generated_challenge_title,
+                        fourPairsName,
+                        lowDifficultyName
+                    ),
+                    completedStatus = resources.getString(
+                        R.string.daily_share_completed_status
+                    )
+                ),
+                locale = locale
+            ),
+            chooserTitle = resources.getString(R.string.daily_share_chooser_title)
+        )
+    }
+}
+
+sealed interface DailyCompletionShareLaunchResult {
+    data object Launched : DailyCompletionShareLaunchResult
+
+    data object Unavailable : DailyCompletionShareLaunchResult
+}
+
+fun interface DailyCompletionShareLauncher {
+    fun launch(payload: DailyCompletionSharePayload): DailyCompletionShareLaunchResult
+}
+
+class AndroidDailyCompletionShareLauncher(private val context: Context) : DailyCompletionShareLauncher {
+    override fun launch(payload: DailyCompletionSharePayload): DailyCompletionShareLaunchResult = try {
+        val chooserIntent = DailyCompletionShareIntentFactory.create(payload).apply {
+            if (context !is Activity) {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        }
+        context.startActivity(chooserIntent)
+        DailyCompletionShareLaunchResult.Launched
+    } catch (_: ActivityNotFoundException) {
+        DailyCompletionShareLaunchResult.Unavailable
+    }
+}
+
+object DailyCompletionShareIntentFactory {
+    fun create(payload: DailyCompletionSharePayload): Intent {
+        val sendIntent = Intent(Intent.ACTION_SEND).apply {
+            type = DAILY_SHARE_MIME_TYPE
+            putExtra(Intent.EXTRA_TEXT, payload.text.value)
+        }
+        return Intent.createChooser(sendIntent, payload.chooserTitle)
+    }
+}
+
+internal const val DAILY_SHARE_MIME_TYPE = "text/plain"

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/share/DailyCompletionShareText.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/share/DailyCompletionShareText.kt
@@ -1,0 +1,48 @@
+package org.cescfe.numpairs.feature.daily.share
+
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.feature.daily.DailyRecipeCatalog
+import org.cescfe.numpairs.feature.daily.DailyRecipes
+
+data class DailyCompletionShareCopy(val dailyName: String, val challengeName: String, val completedStatus: String) {
+    init {
+        require(dailyName.isNotBlank()) {
+            "Daily share name must not be blank."
+        }
+        require(challengeName.isNotBlank()) {
+            "Daily share challenge name must not be blank."
+        }
+        require(completedStatus.isNotBlank()) {
+            "Daily share completed status must not be blank."
+        }
+    }
+}
+
+@JvmInline
+value class DailyCompletionShareText(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "Daily completion share text must not be blank."
+        }
+    }
+}
+
+class DailyCompletionShareTextFormatter(private val recipeCatalog: DailyRecipeCatalog = DailyRecipes.catalog) {
+    fun format(
+        completedIdentity: DailyChallengeId,
+        copy: DailyCompletionShareCopy,
+        locale: Locale
+    ): DailyCompletionShareText {
+        recipeCatalog.resolve(completedIdentity.recipeVersion)
+        val localizedDate = completedIdentity.localDate.format(
+            DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale)
+        )
+        return DailyCompletionShareText(
+            value = "${copy.dailyName} · $localizedDate\n" +
+                "${copy.challengeName} · ${copy.completedStatus}"
+        )
+    }
+}

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -71,6 +71,11 @@
     <string name="daily_calendar_future_completed_date_description">%1$s, Completat, Data futura</string>
     <string name="daily_calendar_future_date_description">%1$s, Data futura</string>
 
+    <!-- Compartir Daily -->
+    <string name="daily_share_name">NumPairs Daily</string>
+    <string name="daily_share_completed_status">Completat</string>
+    <string name="daily_share_chooser_title">Compartix el resultat Daily</string>
+
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Pas %1$d de %2$d</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -71,6 +71,11 @@
     <string name="daily_calendar_future_completed_date_description">%1$s, Completado, Fecha futura</string>
     <string name="daily_calendar_future_date_description">%1$s, Fecha futura</string>
 
+    <!-- Compartir Daily -->
+    <string name="daily_share_name">NumPairs Daily</string>
+    <string name="daily_share_completed_status">Completado</string>
+    <string name="daily_share_chooser_title">Compartir resultado Daily</string>
+
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Paso %1$d de %2$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,11 @@
     <string name="daily_calendar_future_completed_date_description">%1$s, Completed, Future date</string>
     <string name="daily_calendar_future_date_description">%1$s, Future date</string>
 
+    <!-- Daily sharing -->
+    <string name="daily_share_name">NumPairs Daily</string>
+    <string name="daily_share_completed_status">Completed</string>
+    <string name="daily_share_chooser_title">Share Daily result</string>
+
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Step %1$d of %2$d</string>

--- a/app/src/test/java/org/cescfe/numpairs/feature/daily/share/DailyCompletionShareTextFormatterTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/daily/share/DailyCompletionShareTextFormatterTest.kt
@@ -1,0 +1,113 @@
+package org.cescfe.numpairs.feature.daily.share
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DailyRecipeVersion
+import org.cescfe.numpairs.feature.daily.DailyRecipes
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class DailyCompletionShareTextFormatterTest {
+    @Test
+    fun formatted_result_contains_only_the_required_two_line_completion_copy() {
+        val identity = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(
+            LocalDate.of(2026, 7, 25)
+        )
+        val locale = Locale.US
+        val text = DailyCompletionShareTextFormatter().format(
+            completedIdentity = identity,
+            copy = DailyCompletionShareCopy(
+                dailyName = "NumPairs Daily",
+                challengeName = "4 Pairs · Low",
+                completedStatus = "Completed"
+            ),
+            locale = locale
+        )
+        val expectedDate = identity.localDate.format(
+            DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale)
+        )
+
+        assertEquals(
+            "NumPairs Daily · $expectedDate\n4 Pairs · Low · Completed",
+            text.value
+        )
+    }
+
+    @Test
+    fun formatter_localizes_display_date_without_changing_the_canonical_identity() {
+        val identity = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(
+            LocalDate.of(2028, 2, 29)
+        )
+        val canonicalDate = identity.canonicalLocalDate
+        val locale = Locale.forLanguageTag("es-ES")
+
+        val text = DailyCompletionShareTextFormatter().format(
+            completedIdentity = identity,
+            copy = DailyCompletionShareCopy(
+                dailyName = "NumPairs Daily",
+                challengeName = "4 pares · Baja",
+                completedStatus = "Completado"
+            ),
+            locale = locale
+        )
+        val expectedDate = identity.localDate.format(
+            DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale)
+        )
+
+        assertEquals(
+            "NumPairs Daily · $expectedDate\n4 pares · Baja · Completado",
+            text.value
+        )
+        assertEquals("2028-02-29", canonicalDate)
+        assertEquals(canonicalDate, identity.canonicalLocalDate)
+    }
+
+    @Test
+    fun unknown_recipe_identity_cannot_be_shared() {
+        val identity = DailyChallengeId(
+            localDate = LocalDate.of(2026, 7, 25),
+            recipeVersion = DailyRecipeVersion("unknown-daily-recipe")
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyCompletionShareTextFormatter().format(
+                completedIdentity = identity,
+                copy = DailyCompletionShareCopy(
+                    dailyName = "NumPairs Daily",
+                    challengeName = "4 Pairs · Low",
+                    completedStatus = "Completed"
+                ),
+                locale = Locale.US
+            )
+        }
+    }
+
+    @Test
+    fun localized_copy_requires_every_visible_field() {
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyCompletionShareCopy(
+                dailyName = " ",
+                challengeName = "4 Pairs · Low",
+                completedStatus = "Completed"
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyCompletionShareCopy(
+                dailyName = "NumPairs Daily",
+                challengeName = "",
+                completedStatus = "Completed"
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyCompletionShareCopy(
+                dailyName = "NumPairs Daily",
+                challengeName = "4 Pairs · Low",
+                completedStatus = ""
+            )
+        }
+    }
+}

--- a/docs/ui-behavior.md
+++ b/docs/ui-behavior.md
@@ -393,6 +393,9 @@ process recreation does not require restoring the displayed month or caller.
 
 ### Daily Textual Sharing
 
+Status: non-spoiling localized text formatting and the Android Sharesheet boundary implemented;
+Daily completion-surface integration planned.
+
 `Share result` opens the Android Sharesheet with localized `text/plain` content containing:
 
 - `NumPairs Daily`


### PR DESCRIPTION
## Related Issue

Resolves #609

## Summary

- Format a supported completed Daily identity as exactly two localized, non-spoiling text lines.
- Build localized payloads without accepting Puzzle, session, timing, score, action, or board data.
- Create an exact `ACTION_SEND` `text/plain` chooser with no attachment, ClipData, or HTML extras.
- Return typed launched/unavailable results and keep Sharesheet state entirely transient.
- Add English, Spanish, and Valencian copy plus formatter and Android boundary coverage.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew lintDebug`