### PR TITLE
[295] Route Daily gameplay and completion surfaces

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/daily/DailyCompletionSurfaceTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/daily/DailyCompletionSurfaceTest.kt
@@ -1,0 +1,348 @@
+package org.cescfe.numpairs.feature.daily
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.time.LocalDate
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.cescfe.numpairs.data.daily.session.DailySessionClearResult
+import org.cescfe.numpairs.data.daily.session.DailySessionCompletionResult
+import org.cescfe.numpairs.data.daily.session.DailySessionId
+import org.cescfe.numpairs.data.daily.session.DailySessionProgressUpdateResult
+import org.cescfe.numpairs.data.daily.session.DailySessionReplacementResult
+import org.cescfe.numpairs.data.daily.session.DailySessionRepository
+import org.cescfe.numpairs.data.daily.session.DailySessionSnapshot
+import org.cescfe.numpairs.data.daily.session.DailyState
+import org.cescfe.numpairs.data.generated.selection.FakeGeneratedDifficultySelectionRepository
+import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
+import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
+import org.cescfe.numpairs.data.preferences.FakePersonalizationPreferencesRepository
+import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
+import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.feature.daily.calendar.DailyCalendarScreenTestTags
+import org.cescfe.numpairs.feature.daily.share.DailyCompletionShareLaunchResult
+import org.cescfe.numpairs.feature.daily.share.DailyCompletionShareLauncher
+import org.cescfe.numpairs.feature.game.GameRoute
+import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
+import org.cescfe.numpairs.feature.generated.ConfiguredGeneratedPuzzleGenerationUseCaseFactory
+import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.menu.ui.MenuScreenTestTags
+import org.cescfe.numpairs.ui.navigation.AppDestination
+import org.cescfe.numpairs.ui.navigation.AppNavigation
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DailyCompletionSurfaceTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun valid_completed_destination_shares_and_returns_from_calendar_without_mutation() {
+        val identity = identity()
+        val repository = RecordingDailyRepository(
+            DailyState(
+                activeSession = null,
+                completedChallengeIds = listOf(identity)
+            )
+        )
+        var sharedText: String? = null
+        val shareLauncher = DailyCompletionShareLauncher { payload ->
+            sharedText = payload.text.value
+            DailyCompletionShareLaunchResult.Launched
+        }
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                DailyCompletedTodayRoute(
+                    identity = identity,
+                    dailySessionRepository = repository,
+                    deviceLocalDateSource = DeviceLocalDateSource { identity.localDate },
+                    shareLauncher = shareLauncher,
+                    onNavigateBack = {}
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(DailyScreenTestTags.COMPLETION_SUMMARY)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(DailyScreenTestTags.SHARE_RESULT)
+            .performClick()
+        composeTestRule.runOnIdle {
+            assertNotNull(sharedText)
+            assertEquals(0, repository.mutationCount)
+        }
+
+        composeTestRule
+            .onNodeWithTag(DailyScreenTestTags.VIEW_CALENDAR)
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.BACK_BUTTON)
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(DailyScreenTestTags.COMPLETION_SUMMARY)
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(0, repository.mutationCount)
+        }
+    }
+
+    @Test
+    fun gameplay_route_prepares_the_captured_identity_and_publishes_the_game_surface() {
+        val identity = identity()
+        val repository = RecordingDailyRepository(
+            DailyState(
+                activeSession = null,
+                completedChallengeIds = emptyList()
+            )
+        )
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                DailyChallengeRoute(
+                    identity = identity,
+                    dailySessionRepository = repository,
+                    deviceLocalDateSource = DeviceLocalDateSource {
+                        identity.localDate.plusDays(1)
+                    },
+                    generatedPuzzleGenerationUseCaseFactory =
+                    ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
+                        challengeCatalog = GeneratedModes.catalog
+                    ),
+                    isGeneratedGameHapticsEnabled = false,
+                    onNavigateBack = {}
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 15_000) {
+            composeTestRule
+                .onAllNodesWithTag(GameScreenTestTags.SCREEN)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(1, repository.mutationCount)
+            assertEquals(identity, repository.lastReplacement?.dailyChallengeId)
+        }
+    }
+
+    @Test
+    fun typed_completed_destination_routes_system_back_to_menu_without_daily_mutation() {
+        val identity = identity()
+        val repository = RecordingDailyRepository(
+            DailyState(
+                activeSession = null,
+                completedChallengeIds = listOf(identity)
+            )
+        )
+        val generationFactory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
+            challengeCatalog = GeneratedModes.catalog
+        )
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                AppNavigation(
+                    onboardingRepository = FakeOnboardingRepository(),
+                    generatedSessionRepository = FakeGeneratedSessionRepository(),
+                    generatedDifficultySelectionRepository =
+                    FakeGeneratedDifficultySelectionRepository(),
+                    personalizationPreferencesRepository =
+                    FakePersonalizationPreferencesRepository(),
+                    topAppBarActionDiscoveryRepository =
+                    FakeTopAppBarActionDiscoveryRepository(),
+                    generatedChallengeCatalog = GeneratedModes.catalog,
+                    generatedPuzzleGenerationUseCaseFactory = generationFactory,
+                    dailyFeatureDependencies = DailyFeatureDependencies(
+                        dailySessionRepository = repository,
+                        deviceLocalDateSource = DeviceLocalDateSource { identity.localDate },
+                        generatedPuzzleGenerationUseCaseFactory = generationFactory
+                    ),
+                    startDestination = AppDestination.DailyCompletedToday(identity)
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(DailyScreenTestTags.COMPLETION_SUMMARY)
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            composeTestRule.activity.onBackPressedDispatcher.onBackPressed()
+        }
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(0, repository.mutationCount)
+        }
+    }
+
+    @Test
+    fun summary_keeps_all_three_actions_available_in_compact_scaled_rtl_content() {
+        var shareCount = 0
+        var calendarCount = 0
+        var backCount = 0
+
+        composeTestRule.setContent {
+            val density = LocalDensity.current
+            CompositionLocalProvider(
+                LocalDensity provides Density(
+                    density = density.density,
+                    fontScale = 2f
+                ),
+                LocalLayoutDirection provides LayoutDirection.Rtl
+            ) {
+                NumPairsTheme {
+                    Box(modifier = Modifier.size(width = 320.dp, height = 420.dp)) {
+                        DailyCompletionScreen(
+                            presentation = DailyChallengeTitle(
+                                visibleText = "Daily · 25 Jul 2026",
+                                accessibilityText = "Daily · 25 Jul 2026, 4 pairs · Low"
+                            ),
+                            onShareResult = { shareCount += 1 },
+                            onViewCalendar = { calendarCount += 1 },
+                            onNavigateBack = { backCount += 1 }
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(DailyScreenTestTags.SHARE_RESULT)
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(DailyScreenTestTags.VIEW_CALENDAR)
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(DailyScreenTestTags.BACK_TO_MENU)
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule.runOnIdle {
+            assertEquals(1, shareCount)
+            assertEquals(1, calendarCount)
+            assertEquals(1, backCount)
+        }
+    }
+
+    @Test
+    fun completion_identity_is_visible_without_reconstructing_a_game_board() {
+        val presentation = DailyChallengeTitle(
+            visibleText = "Daily · Jul 25, 2026",
+            accessibilityText = "Daily · Jul 25, 2026, 4 pairs · Low"
+        )
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                DailyCompletionScreen(
+                    presentation = presentation,
+                    onShareResult = {},
+                    onViewCalendar = {},
+                    onNavigateBack = {}
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(DailyScreenTestTags.COMPLETION_IDENTITY)
+            .assertIsDisplayed()
+            .assertTextEquals(presentation.visibleText)
+        composeTestRule
+            .onNodeWithTag("game_board")
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun game_title_keeps_concise_visible_copy_and_complete_accessibility_identity() {
+        val visibleTitle = "Daily · Jul 25, 2026"
+        val accessibilityTitle = "$visibleTitle, 4 pairs · Low"
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                GameRoute(
+                    title = visibleTitle,
+                    titleContentDescription = accessibilityTitle,
+                    initialPuzzle = samplePuzzle,
+                    gameSessionKey = "daily-title-accessibility"
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(accessibilityTitle)
+            .assertIsDisplayed()
+    }
+
+    private fun identity(): DailyChallengeId = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(
+        LocalDate.of(2026, 7, 25)
+    )
+}
+
+private class RecordingDailyRepository(initialState: DailyState) : DailySessionRepository {
+    override val state = MutableStateFlow(initialState)
+
+    var mutationCount: Int = 0
+    var lastReplacement: DailySessionSnapshot? = null
+
+    override suspend fun replaceSession(snapshot: DailySessionSnapshot): DailySessionReplacementResult {
+        mutationCount += 1
+        lastReplacement = snapshot
+        return DailySessionReplacementResult.Replaced
+    }
+
+    override suspend fun updateCurrentPuzzle(
+        expectedSessionId: DailySessionId,
+        puzzle: Puzzle
+    ): DailySessionProgressUpdateResult {
+        mutationCount += 1
+        return DailySessionProgressUpdateResult.Updated
+    }
+
+    override suspend fun clearSession(expectedSessionId: DailySessionId): DailySessionClearResult {
+        mutationCount += 1
+        return DailySessionClearResult.Cleared
+    }
+
+    override suspend fun complete(
+        expectedSessionId: DailySessionId,
+        expectedDailyChallengeId: DailyChallengeId,
+        solvedPuzzle: Puzzle
+    ): DailySessionCompletionResult {
+        mutationCount += 1
+        return DailySessionCompletionResult.Completed
+    }
+}

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/game/ui/screen/CustomCompletionActionsTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/game/ui/screen/CustomCompletionActionsTest.kt
@@ -1,0 +1,109 @@
+package org.cescfe.numpairs.feature.game.ui.screen
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.cescfe.numpairs.feature.game.GameSuccessOverlayContent
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CustomCompletionActionsTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun custom_completion_exposes_primary_secondary_and_tertiary_actions() {
+        var primaryCount = 0
+        var secondaryCount = 0
+        var tertiaryCount = 0
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                SuccessOverlay(
+                    onDismiss = {},
+                    content = GameSuccessOverlayContent(
+                        message = "Daily completed!",
+                        supportingText = "Today’s challenge is complete.",
+                        primaryActionLabel = "Share result",
+                        onPrimaryAction = { primaryCount += 1 },
+                        secondaryActionLabel = "View calendar",
+                        onSecondaryAction = { secondaryCount += 1 },
+                        tertiaryActionLabel = "Back to menu",
+                        onTertiaryAction = { tertiaryCount += 1 },
+                        onBackRequested = { tertiaryCount += 1 }
+                    )
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY_PRIMARY_ACTION)
+            .assertIsDisplayed()
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY_SECONDARY_ACTION)
+            .assertIsDisplayed()
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY_TERTIARY_ACTION)
+            .assertIsDisplayed()
+            .performClick()
+
+        composeTestRule.runOnIdle {
+            assertEquals(1, primaryCount)
+            assertEquals(1, secondaryCount)
+            assertEquals(1, tertiaryCount)
+        }
+    }
+
+    @Test
+    fun custom_completion_actions_remain_reachable_in_compact_scaled_content() {
+        composeTestRule.setContent {
+            val density = LocalDensity.current
+            CompositionLocalProvider(
+                LocalDensity provides Density(
+                    density = density.density,
+                    fontScale = 2f
+                )
+            ) {
+                NumPairsTheme {
+                    Box(modifier = Modifier.size(width = 320.dp, height = 420.dp)) {
+                        SuccessOverlay(
+                            onDismiss = {},
+                            content = GameSuccessOverlayContent(
+                                message = "Daily completed!",
+                                supportingText = "Today’s challenge is complete.",
+                                primaryActionLabel = "Share result",
+                                onPrimaryAction = {},
+                                secondaryActionLabel = "View calendar",
+                                onSecondaryAction = {},
+                                tertiaryActionLabel = "Back to menu",
+                                onTertiaryAction = {}
+                            )
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SUCCESS_OVERLAY_TERTIARY_ACTION)
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/MainActivity.kt
+++ b/app/src/main/java/org/cescfe/numpairs/MainActivity.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.graphics.luminance
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
+import org.cescfe.numpairs.data.daily.SystemDeviceLocalDateSource
+import org.cescfe.numpairs.data.daily.session.createDailySessionRepository
 import org.cescfe.numpairs.data.generated.selection.createGeneratedDifficultySelectionRepository
 import org.cescfe.numpairs.data.generated.session.createGeneratedSessionRepository
 import org.cescfe.numpairs.data.onboarding.createOnboardingRepository
@@ -20,6 +22,7 @@ import org.cescfe.numpairs.data.preferences.PersonalizationPreferences
 import org.cescfe.numpairs.data.preferences.PersonalizationPreferencesRepository
 import org.cescfe.numpairs.data.preferences.createPersonalizationPreferencesRepository
 import org.cescfe.numpairs.data.preferences.createTopAppBarActionDiscoveryRepository
+import org.cescfe.numpairs.feature.daily.DailyFeatureDependencies
 import org.cescfe.numpairs.feature.generated.ConfiguredGeneratedPuzzleGenerationUseCaseFactory
 import org.cescfe.numpairs.feature.generated.GeneratedModes
 import org.cescfe.numpairs.feature.onboarding.OnboardingStartupCoordinator
@@ -49,6 +52,11 @@ class MainActivity : ComponentActivity() {
         val generatedPuzzleGenerationUseCaseFactory = ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
             challengeCatalog = generatedChallengeCatalog
         )
+        val dailyFeatureDependencies = DailyFeatureDependencies(
+            dailySessionRepository = createDailySessionRepository(applicationContext),
+            deviceLocalDateSource = SystemDeviceLocalDateSource(),
+            generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory
+        )
         setContent {
             PersonalizationThemeProvider(personalizationPreferencesRepository) {
                 val onboardingStartupState by onboardingStartupCoordinator.state.collectAsState()
@@ -73,7 +81,8 @@ class MainActivity : ComponentActivity() {
                         personalizationPreferencesRepository = personalizationPreferencesRepository,
                         topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
                         generatedChallengeCatalog = generatedChallengeCatalog,
-                        generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory
+                        generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory,
+                        dailyFeatureDependencies = dailyFeatureDependencies
                     )
                 }
             }

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyChallengeRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyChallengeRoute.kt
@@ -1,0 +1,548 @@
+package org.cescfe.numpairs.feature.daily
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import java.util.Locale
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.daily.session.DailySessionRepository
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
+import org.cescfe.numpairs.feature.daily.calendar.DailyCalendarRoute
+import org.cescfe.numpairs.feature.daily.share.AndroidDailyCompletionShareLauncher
+import org.cescfe.numpairs.feature.daily.share.AndroidDailyCompletionSharePayloadFactory
+import org.cescfe.numpairs.feature.daily.share.DailyCompletionShareLauncher
+import org.cescfe.numpairs.feature.game.GameRoute
+import org.cescfe.numpairs.feature.game.GameSuccessOverlayContent
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
+import org.cescfe.numpairs.ui.theme.NumPairsComponents
+
+@Composable
+fun DailyChallengeRoute(
+    identity: DailyChallengeId,
+    dailySessionRepository: DailySessionRepository,
+    deviceLocalDateSource: DeviceLocalDateSource,
+    generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    isGeneratedGameHapticsEnabled: Boolean = true,
+    shareLauncher: DailyCompletionShareLauncher? = null
+) {
+    if (DailyRecipes.catalog.resolveOrNull(identity.recipeVersion) == null) {
+        DailyFailureScreen(
+            modifier = modifier,
+            message = stringResource(R.string.daily_completion_unavailable_message),
+            onRetry = null,
+            onNavigateBack = onNavigateBack
+        )
+        return
+    }
+    val viewModel = rememberDailyPuzzleViewModel(
+        identity = identity,
+        dailySessionRepository = dailySessionRepository,
+        generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory
+    )
+    val uiState by viewModel.uiState.collectAsState()
+    var isCalendarVisible by remember(identity) { mutableStateOf(false) }
+    val shareResult = rememberDailyShareResultAction(shareLauncher = shareLauncher)
+
+    DisposableEffect(viewModel) {
+        viewModel.onRouteEntered()
+        onDispose(viewModel::onRouteExited)
+    }
+
+    BackHandler(enabled = isCalendarVisible) {
+        isCalendarVisible = false
+    }
+
+    if (isCalendarVisible) {
+        DailyCalendarRoute(
+            dailySessionRepository = dailySessionRepository,
+            deviceLocalDateSource = deviceLocalDateSource,
+            onNavigateBack = {
+                isCalendarVisible = false
+            },
+            modifier = modifier
+        )
+        return
+    }
+
+    when (val state = uiState) {
+        DailyPuzzleUiState.Idle,
+        DailyPuzzleUiState.Resolving,
+        is DailyPuzzleUiState.Loading -> DailyLoadingScreen(
+            modifier = modifier,
+            onNavigateBack = onNavigateBack
+        )
+
+        is DailyPuzzleUiState.Failed -> DailyFailureScreen(
+            modifier = modifier,
+            message = stringResource(state.failure.messageResource()),
+            onRetry = viewModel::retry,
+            onNavigateBack = onNavigateBack
+        )
+
+        is DailyPuzzleUiState.Ready -> DailyGameContent(
+            state = state,
+            modifier = modifier,
+            isGeneratedGameHapticsEnabled = isGeneratedGameHapticsEnabled,
+            onPuzzleChanged = viewModel::onCommittedPuzzleChanged,
+            onRetryPersistence = viewModel::retryPersistence,
+            onNavigateBack = onNavigateBack
+        )
+
+        is DailyPuzzleUiState.Completed -> {
+            val completedIdentity = state.completedIdentity()
+            if (DailyRecipes.catalog.resolveOrNull(completedIdentity.recipeVersion) == null) {
+                DailyFailureScreen(
+                    modifier = modifier,
+                    message = stringResource(R.string.daily_completion_unavailable_message),
+                    onRetry = null,
+                    onNavigateBack = onNavigateBack
+                )
+            } else {
+                DailyGameContent(
+                    state = state,
+                    modifier = modifier,
+                    isGeneratedGameHapticsEnabled = isGeneratedGameHapticsEnabled,
+                    onPuzzleChanged = viewModel::onCommittedPuzzleChanged,
+                    onRetryPersistence = viewModel::retryPersistence,
+                    completionContent = dailyCompletionOverlayContent(
+                        onShareResult = {
+                            shareResult(completedIdentity)
+                        },
+                        onViewCalendar = {
+                            isCalendarVisible = true
+                        },
+                        onNavigateBack = onNavigateBack
+                    ),
+                    onNavigateBack = onNavigateBack
+                )
+            }
+        }
+
+        is DailyPuzzleUiState.CompletedToday -> {
+            if (DailyRecipes.catalog.resolveOrNull(state.completion.recipeVersion) == null) {
+                DailyFailureScreen(
+                    modifier = modifier,
+                    message = stringResource(R.string.daily_completion_unavailable_message),
+                    onRetry = null,
+                    onNavigateBack = onNavigateBack
+                )
+            } else {
+                val presentation = rememberDailyChallengeTitle(state.completion)
+                DailyCompletionScreen(
+                    presentation = presentation,
+                    onShareResult = {
+                        shareResult(state.completion)
+                    },
+                    onViewCalendar = {
+                        isCalendarVisible = true
+                    },
+                    onNavigateBack = onNavigateBack,
+                    modifier = modifier
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun DailyCompletedTodayRoute(
+    identity: DailyChallengeId,
+    dailySessionRepository: DailySessionRepository,
+    deviceLocalDateSource: DeviceLocalDateSource,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    shareLauncher: DailyCompletionShareLauncher? = null
+) {
+    val dailyState by dailySessionRepository.state.collectAsState(initial = null)
+    var isCalendarVisible by remember(identity) { mutableStateOf(false) }
+    val shareResult = rememberDailyShareResultAction(shareLauncher = shareLauncher)
+
+    BackHandler(enabled = isCalendarVisible) {
+        isCalendarVisible = false
+    }
+
+    if (isCalendarVisible) {
+        DailyCalendarRoute(
+            dailySessionRepository = dailySessionRepository,
+            deviceLocalDateSource = deviceLocalDateSource,
+            onNavigateBack = {
+                isCalendarVisible = false
+            },
+            modifier = modifier
+        )
+        return
+    }
+
+    when {
+        dailyState == null -> DailyLoadingScreen(
+            modifier = modifier,
+            onNavigateBack = onNavigateBack
+        )
+
+        identity in requireNotNull(dailyState).completedChallengeIds &&
+            DailyRecipes.catalog.resolveOrNull(identity.recipeVersion) != null -> {
+            val presentation = rememberDailyChallengeTitle(identity)
+            DailyCompletionScreen(
+                presentation = presentation,
+                onShareResult = {
+                    shareResult(identity)
+                },
+                onViewCalendar = {
+                    isCalendarVisible = true
+                },
+                onNavigateBack = onNavigateBack,
+                modifier = modifier
+            )
+        }
+
+        else -> DailyFailureScreen(
+            modifier = modifier,
+            message = stringResource(R.string.daily_completion_unavailable_message),
+            onRetry = null,
+            onNavigateBack = onNavigateBack
+        )
+    }
+}
+
+@Composable
+private fun DailyGameContent(
+    state: DailyPuzzleUiState,
+    modifier: Modifier,
+    isGeneratedGameHapticsEnabled: Boolean,
+    onPuzzleChanged: (
+        org.cescfe.numpairs.data.daily.session.DailySessionId,
+        org.cescfe.numpairs.domain.puzzle.model.Puzzle
+    ) -> Unit,
+    onRetryPersistence: () -> Unit,
+    completionContent: GameSuccessOverlayContent? = null,
+    onNavigateBack: () -> Unit
+) {
+    val session = when (state) {
+        is DailyPuzzleUiState.Ready -> state.session
+        is DailyPuzzleUiState.Completed -> state.session
+        else -> error("Daily game content requires a playable session.")
+    }
+    val title = rememberDailyChallengeTitle(session.currentDailyChallenge.identity)
+    val hapticFeedback = LocalHapticFeedback.current
+
+    Box(modifier = modifier.fillMaxSize()) {
+        GameRoute(
+            title = title.visibleText,
+            titleContentDescription = title.accessibilityText,
+            isNavigationIconVisible = state !is DailyPuzzleUiState.Completed,
+            initialPuzzle = session.currentPuzzle,
+            gameSessionKey = "DailyGame:${session.currentDailyChallenge.identity.canonicalKey()}",
+            puzzleResetKey = session.id,
+            isSuccessOverlayEnabled = state is DailyPuzzleUiState.Completed,
+            successOverlayContent = completionContent,
+            isCorrectTileMotionEnabled = true,
+            isCompletionCelebrationEnabled = true,
+            onPuzzleChanged = { puzzle ->
+                onPuzzleChanged(session.id, puzzle)
+            },
+            onTileAssignmentCommitted = {
+                if (isGeneratedGameHapticsEnabled) {
+                    hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                }
+            },
+            onNavigateBack = onNavigateBack
+        )
+        val persistenceFailure = (state as? DailyPuzzleUiState.Ready)?.persistenceFailure
+        if (persistenceFailure != null) {
+            DailyPersistenceFailureDialog(
+                failure = persistenceFailure,
+                onRetry = onRetryPersistence,
+                onNavigateBack = onNavigateBack
+            )
+        }
+    }
+}
+
+@Composable
+private fun dailyCompletionOverlayContent(
+    onShareResult: () -> Unit,
+    onViewCalendar: () -> Unit,
+    onNavigateBack: () -> Unit
+): GameSuccessOverlayContent = GameSuccessOverlayContent(
+    message = stringResource(R.string.daily_completion_message),
+    supportingText = stringResource(R.string.daily_completion_supporting_text),
+    primaryActionLabel = stringResource(R.string.daily_share_result_action),
+    onPrimaryAction = onShareResult,
+    secondaryActionLabel = stringResource(R.string.daily_view_calendar_action),
+    onSecondaryAction = onViewCalendar,
+    tertiaryActionLabel = stringResource(R.string.daily_back_to_menu_action),
+    onTertiaryAction = onNavigateBack,
+    onBackRequested = onNavigateBack
+)
+
+@Composable
+private fun rememberDailyChallengeTitle(identity: DailyChallengeId): DailyChallengeTitle {
+    val configuration = LocalConfiguration.current
+    val locale = remember(configuration) {
+        Locale.forLanguageTag(configuration.locales[0].toLanguageTag())
+    }
+    val dailyName = stringResource(R.string.daily_game_name)
+    val challengeName = stringResource(R.string.daily_completion_challenge_name)
+    return remember(identity, dailyName, challengeName, locale) {
+        DailyChallengeTitleFormatter().format(
+            identity = identity,
+            dailyName = dailyName,
+            challengeName = challengeName,
+            locale = locale
+        )
+    }
+}
+
+@Composable
+private fun rememberDailyShareResultAction(shareLauncher: DailyCompletionShareLauncher?): (DailyChallengeId) -> Unit {
+    val context = LocalContext.current
+    val defaultLauncher = remember(context) {
+        AndroidDailyCompletionShareLauncher(context)
+    }
+    val payloadFactory = remember(context.resources) {
+        AndroidDailyCompletionSharePayloadFactory(context.resources)
+    }
+    val activeLauncher = shareLauncher ?: defaultLauncher
+    return remember(activeLauncher, payloadFactory) {
+        { completedIdentity ->
+            activeLauncher.launch(payloadFactory.create(completedIdentity))
+        }
+    }
+}
+
+@Composable
+private fun DailyLoadingScreen(modifier: Modifier, onNavigateBack: () -> Unit) {
+    DailyStatusScreen(
+        modifier = modifier.testTag(DailyScreenTestTags.LOADING),
+        message = stringResource(R.string.daily_loading_message),
+        isLoading = true,
+        onRetry = null,
+        onNavigateBack = onNavigateBack
+    )
+}
+
+@Composable
+private fun DailyFailureScreen(
+    modifier: Modifier,
+    message: String,
+    onRetry: (() -> Unit)?,
+    onNavigateBack: () -> Unit
+) {
+    DailyStatusScreen(
+        modifier = modifier.testTag(DailyScreenTestTags.FAILURE),
+        message = message,
+        isLoading = false,
+        onRetry = onRetry,
+        onNavigateBack = onNavigateBack
+    )
+}
+
+@Composable
+private fun DailyStatusScreen(
+    modifier: Modifier,
+    message: String,
+    isLoading: Boolean,
+    onRetry: (() -> Unit)?,
+    onNavigateBack: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp, vertical = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        if (isLoading) {
+            CircularProgressIndicator()
+        }
+        Text(
+            text = message,
+            modifier = Modifier
+                .widthIn(max = DAILY_STATUS_MAX_WIDTH)
+                .padding(vertical = 16.dp),
+            color = MaterialTheme.colorScheme.onBackground,
+            style = MaterialTheme.typography.bodyLarge
+        )
+        onRetry?.let { retry ->
+            NumPairsComponents.PrimaryCtaButton(
+                onClick = retry,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .widthIn(max = DAILY_STATUS_MAX_WIDTH)
+                    .testTag(DailyScreenTestTags.RETRY)
+            ) {
+                Text(text = stringResource(R.string.daily_retry_action))
+            }
+        }
+        OutlinedButton(
+            onClick = onNavigateBack,
+            modifier = Modifier
+                .fillMaxWidth()
+                .widthIn(max = DAILY_STATUS_MAX_WIDTH)
+                .padding(top = 8.dp),
+            shape = NumPairsComponents.MediumShape,
+            colors = NumPairsComponents.secondaryButtonColors(),
+            border = NumPairsComponents.secondaryButtonBorder()
+        ) {
+            Text(text = stringResource(R.string.daily_back_to_menu_action))
+        }
+    }
+}
+
+@Composable
+private fun DailyPersistenceFailureDialog(
+    failure: DailyPuzzlePersistenceFailure,
+    onRetry: () -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onNavigateBack,
+        modifier = Modifier.testTag(DailyScreenTestTags.PERSISTENCE_FAILURE),
+        shape = NumPairsComponents.LargeShape,
+        containerColor = NumPairsComponents.raisedSurfaceColor(),
+        title = {
+            Text(text = stringResource(R.string.daily_progress_failure_title))
+        },
+        text = {
+            Text(text = stringResource(failure.messageResource()))
+        },
+        confirmButton = {
+            Button(onClick = onRetry) {
+                Text(text = stringResource(R.string.daily_retry_action))
+            }
+        },
+        dismissButton = {
+            Button(onClick = onNavigateBack) {
+                Text(text = stringResource(R.string.daily_back_to_menu_action))
+            }
+        }
+    )
+}
+
+private fun DailyPuzzlePreparationFailure.messageResource(): Int = when (this) {
+    is DailyPuzzlePreparationFailure.GenerationExhausted -> R.string.daily_generation_failure_message
+    is DailyPuzzlePreparationFailure.GenerationCancelled -> R.string.daily_generation_cancelled_message
+    DailyPuzzlePreparationFailure.InvalidGeneratedPuzzle -> R.string.daily_invalid_puzzle_message
+    DailyPuzzlePreparationFailure.Persistence -> R.string.daily_storage_failure_message
+}
+
+private fun DailyPuzzlePersistenceFailure.messageResource(): Int = when (this) {
+    DailyPuzzlePersistenceFailure.StaleSession -> R.string.daily_stale_session_message
+    DailyPuzzlePersistenceFailure.InvalidPuzzle -> R.string.daily_invalid_progress_message
+    DailyPuzzlePersistenceFailure.Persistence -> R.string.daily_storage_failure_message
+}
+
+private fun DailyPuzzleUiState.Completed.completedIdentity(): DailyChallengeId = when (val result = completion) {
+    DailyPuzzleCompletion.Completed -> session.currentDailyChallenge.identity
+    is DailyPuzzleCompletion.AlreadyCompleted -> result.completion
+}
+
+private fun DailyChallengeId.canonicalKey(): String = "$canonicalLocalDate:${recipeVersion.value}"
+
+private val DAILY_STATUS_MAX_WIDTH = 480.dp
+
+@Composable
+private fun rememberDailyPuzzleViewModel(
+    identity: DailyChallengeId,
+    dailySessionRepository: DailySessionRepository,
+    generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory
+): DailyPuzzleViewModel {
+    val activity = LocalContext.current.findComponentActivity()
+        ?: error("DailyChallengeRoute requires a ComponentActivity host.")
+    val currentDailyChallengeResolver = remember(identity) {
+        CurrentDailyChallengeResolver(
+            localDateSource = DeviceLocalDateSource { identity.localDate },
+            activeRecipeVersion = identity.recipeVersion
+        )
+    }
+    val factory = remember(
+        currentDailyChallengeResolver,
+        dailySessionRepository,
+        generatedPuzzleGenerationUseCaseFactory
+    ) {
+        DailyPuzzleViewModelFactory(
+            availabilityResolver = CurrentDailyAvailabilityResolver(
+                currentDailyChallengeResolver = currentDailyChallengeResolver,
+                dailySessionRepository = dailySessionRepository
+            ),
+            puzzleGenerator = DailyPuzzleGenerationUseCase(
+                currentDailyChallengeResolver = currentDailyChallengeResolver,
+                generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory
+            ),
+            dailySessionRepository = dailySessionRepository
+        )
+    }
+    return remember(activity, identity, factory) {
+        ViewModelProvider(activity, factory)[
+            "DailyPuzzle:${identity.canonicalKey()}",
+            DailyPuzzleViewModel::class.java
+        ]
+    }
+}
+
+private class DailyPuzzleViewModelFactory(
+    private val availabilityResolver: CurrentDailyAvailabilityResolver,
+    private val puzzleGenerator: DailyPuzzleGenerator,
+    private val dailySessionRepository: DailySessionRepository
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        require(modelClass.isAssignableFrom(DailyPuzzleViewModel::class.java)) {
+            "Unsupported ViewModel type ${modelClass.name}."
+        }
+        return requireNotNull(
+            modelClass.cast(
+                DailyPuzzleViewModel(
+                    availabilityResolver = availabilityResolver,
+                    puzzleGenerator = puzzleGenerator,
+                    dailySessionRepository = dailySessionRepository
+                )
+            )
+        )
+    }
+}
+
+private tailrec fun Context.findComponentActivity(): ComponentActivity? = when (this) {
+    is ComponentActivity -> this
+    is ContextWrapper -> baseContext.findComponentActivity()
+    else -> null
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyChallengeTitleFormatter.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyChallengeTitleFormatter.kt
@@ -1,0 +1,32 @@
+package org.cescfe.numpairs.feature.daily
+
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+
+data class DailyChallengeTitle(val visibleText: String, val accessibilityText: String)
+
+class DailyChallengeTitleFormatter {
+    fun format(
+        identity: DailyChallengeId,
+        dailyName: String,
+        challengeName: String,
+        locale: Locale
+    ): DailyChallengeTitle {
+        require(dailyName.isNotBlank()) {
+            "Daily name must not be blank."
+        }
+        require(challengeName.isNotBlank()) {
+            "Daily challenge name must not be blank."
+        }
+        val localizedDate = identity.localDate.format(
+            DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale)
+        )
+        val visibleText = "$dailyName · $localizedDate"
+        return DailyChallengeTitle(
+            visibleText = visibleText,
+            accessibilityText = "$visibleText, $challengeName"
+        )
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyCompletionScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyCompletionScreen.kt
@@ -1,0 +1,160 @@
+package org.cescfe.numpairs.feature.daily
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.preferences.PersonalizationTheme
+import org.cescfe.numpairs.ui.theme.NumPairsComponents
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.cescfe.numpairs.ui.theme.NumPairsThemePreviewParameterProvider
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DailyCompletionScreen(
+    presentation: DailyChallengeTitle,
+    onShareResult: () -> Unit,
+    onViewCalendar: () -> Unit,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        modifier = modifier
+            .fillMaxSize()
+            .testTag(DailyScreenTestTags.COMPLETION_SUMMARY),
+        containerColor = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
+        topBar = {
+            TopAppBar(
+                colors = NumPairsComponents.topAppBarColors(),
+                title = {
+                    Text(text = stringResource(R.string.daily_completion_screen_title))
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .widthIn(max = DAILY_COMPLETION_MAX_WIDTH),
+                shape = NumPairsComponents.LargeShape,
+                color = NumPairsComponents.successContainerColor(),
+                contentColor = NumPairsComponents.successContentColor(),
+                border = NumPairsComponents.successBorder()
+            ) {
+                Column(
+                    modifier = Modifier.padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.daily_completion_message),
+                        style = MaterialTheme.typography.headlineSmall,
+                        textAlign = TextAlign.Center
+                    )
+                    Text(
+                        text = presentation.visibleText,
+                        modifier = Modifier.testTag(DailyScreenTestTags.COMPLETION_IDENTITY),
+                        style = MaterialTheme.typography.titleMedium,
+                        textAlign = TextAlign.Center
+                    )
+                    Text(
+                        text = stringResource(R.string.daily_completion_challenge_name),
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center
+                    )
+                    NumPairsComponents.PrimaryCtaButton(
+                        onClick = onShareResult,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(DailyScreenTestTags.SHARE_RESULT)
+                    ) {
+                        Text(text = stringResource(R.string.daily_share_result_action))
+                    }
+                    OutlinedButton(
+                        onClick = onViewCalendar,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(DailyScreenTestTags.VIEW_CALENDAR),
+                        shape = NumPairsComponents.MediumShape,
+                        colors = NumPairsComponents.secondaryButtonColors(),
+                        border = NumPairsComponents.secondaryButtonBorder()
+                    ) {
+                        Text(text = stringResource(R.string.daily_view_calendar_action))
+                    }
+                    TextButton(
+                        onClick = onNavigateBack,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(DailyScreenTestTags.BACK_TO_MENU)
+                    ) {
+                        Text(text = stringResource(R.string.daily_back_to_menu_action))
+                    }
+                }
+            }
+        }
+    }
+}
+
+object DailyScreenTestTags {
+    const val LOADING = "daily_loading"
+    const val FAILURE = "daily_failure"
+    const val RETRY = "daily_retry"
+    const val COMPLETION_SUMMARY = "daily_completion_summary"
+    const val COMPLETION_IDENTITY = "daily_completion_identity"
+    const val SHARE_RESULT = "daily_share_result"
+    const val VIEW_CALENDAR = "daily_view_calendar"
+    const val BACK_TO_MENU = "daily_back_to_menu"
+    const val PERSISTENCE_FAILURE = "daily_persistence_failure"
+}
+
+private val DAILY_COMPLETION_MAX_WIDTH = 480.dp
+
+@Preview(showBackground = true)
+@Composable
+private fun DailyCompletionScreenPreview(
+    @PreviewParameter(NumPairsThemePreviewParameterProvider::class) theme: PersonalizationTheme
+) {
+    NumPairsTheme(theme = theme) {
+        DailyCompletionScreen(
+            presentation = DailyChallengeTitle(
+                visibleText = "Daily · Jul 25, 2026",
+                accessibilityText = "Daily · Jul 25, 2026, 4 pairs · Low"
+            ),
+            onShareResult = {},
+            onViewCalendar = {},
+            onNavigateBack = {}
+        )
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyFeatureDependencies.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/DailyFeatureDependencies.kt
@@ -1,0 +1,11 @@
+package org.cescfe.numpairs.feature.daily
+
+import org.cescfe.numpairs.data.daily.session.DailySessionRepository
+import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
+
+data class DailyFeatureDependencies(
+    val dailySessionRepository: DailySessionRepository,
+    val deviceLocalDateSource: DeviceLocalDateSource,
+    val generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory
+)

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/GameRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/GameRoute.kt
@@ -29,6 +29,8 @@ fun GameRoute(
     title: String,
     initialPuzzle: Puzzle,
     modifier: Modifier = Modifier,
+    titleContentDescription: String? = null,
+    isNavigationIconVisible: Boolean = true,
     gameSessionKey: String = defaultGameSessionKey(title = title, initialPuzzle = initialPuzzle),
     puzzleResetKey: Any = initialPuzzle,
     completionActions: GameCompletionActions? = null,
@@ -116,6 +118,8 @@ fun GameRoute(
 
     GameScreen(
         title = title,
+        titleContentDescription = titleContentDescription,
+        isNavigationIconVisible = isNavigationIconVisible,
         uiState = uiState,
         modifier = modifier,
         onNavigateBack = onNavigateBack,

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/GameSuccessOverlayContent.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/GameSuccessOverlayContent.kt
@@ -4,5 +4,19 @@ data class GameSuccessOverlayContent(
     val message: String,
     val supportingText: String,
     val primaryActionLabel: String,
-    val onPrimaryAction: () -> Unit
-)
+    val onPrimaryAction: () -> Unit,
+    val secondaryActionLabel: String? = null,
+    val onSecondaryAction: (() -> Unit)? = null,
+    val tertiaryActionLabel: String? = null,
+    val onTertiaryAction: (() -> Unit)? = null,
+    val onBackRequested: (() -> Unit)? = null
+) {
+    init {
+        require((secondaryActionLabel == null) == (onSecondaryAction == null)) {
+            "A custom secondary completion action requires both a label and callback."
+        }
+        require((tertiaryActionLabel == null) == (onTertiaryAction == null)) {
+            "A custom tertiary completion action requires both a label and callback."
+        }
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import org.cescfe.numpairs.R
@@ -55,6 +57,8 @@ fun GameScreen(
     title: String,
     uiState: GameUiState,
     modifier: Modifier = Modifier,
+    titleContentDescription: String? = null,
+    isNavigationIconVisible: Boolean = true,
     onNavigateBack: () -> Unit = {},
     onStripItemTapped: (Int) -> Unit = {},
     onStripItemEntryInputChanged: (String) -> Unit = {},
@@ -101,6 +105,8 @@ fun GameScreen(
             topBar = {
                 GameScreenTopBar(
                     title = title,
+                    titleContentDescription = titleContentDescription,
+                    isNavigationIconVisible = isNavigationIconVisible,
                     onNavigateBack = onNavigateBack,
                     onRulesHelperClick = {
                         onRulesHelperActionTapped()
@@ -257,6 +263,8 @@ private fun TileOperandOptionUiState.restrictedBy(
 @Composable
 private fun GameScreenTopBar(
     title: String,
+    titleContentDescription: String?,
+    isNavigationIconVisible: Boolean,
     onNavigateBack: () -> Unit,
     onRulesHelperClick: () -> Unit,
     isRulesHelperEnabled: Boolean,
@@ -269,18 +277,30 @@ private fun GameScreenTopBar(
         colors = NumPairsComponents.topAppBarColors(),
         expandedHeight = GAME_TOP_BAR_HEIGHT,
         navigationIcon = {
-            IconButton(
-                onClick = onNavigateBack,
-                modifier = Modifier.testTag(GameScreenTestTags.BACK_BUTTON)
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_chevron_left),
-                    contentDescription = backButtonContentDescription
-                )
+            if (isNavigationIconVisible) {
+                IconButton(
+                    onClick = onNavigateBack,
+                    modifier = Modifier.testTag(GameScreenTestTags.BACK_BUTTON)
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_chevron_left),
+                        contentDescription = backButtonContentDescription
+                    )
+                }
             }
         },
         title = {
-            Text(text = title)
+            val titleModifier = if (titleContentDescription == null) {
+                Modifier
+            } else {
+                Modifier.clearAndSetSemantics {
+                    contentDescription = titleContentDescription
+                }
+            }
+            Text(
+                text = title,
+                modifier = titleModifier
+            )
         },
         actions = {
             actions()

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenFeedback.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenFeedback.kt
@@ -16,12 +16,15 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -98,7 +101,12 @@ internal fun SuccessOverlay(
         )
     }
 
-    BackHandler(onBack = content?.onPrimaryAction ?: completionActions?.onReturnToMenuRequested ?: onDismiss)
+    BackHandler(
+        onBack = content?.onBackRequested
+            ?: content?.onPrimaryAction
+            ?: completionActions?.onReturnToMenuRequested
+            ?: onDismiss
+    )
 
     Box(
         modifier = dismissibleOverlayModifier,
@@ -124,6 +132,7 @@ internal fun SuccessOverlay(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
                     .padding(
                         horizontal = SUCCESS_OVERLAY_HORIZONTAL_PADDING,
                         vertical = SUCCESS_OVERLAY_VERTICAL_PADDING
@@ -170,6 +179,29 @@ internal fun SuccessOverlay(
                             .testTag(GameScreenTestTags.SUCCESS_OVERLAY_PRIMARY_ACTION)
                     ) {
                         Text(text = content.primaryActionLabel)
+                    }
+                    content.secondaryActionLabel?.let { label ->
+                        OutlinedButton(
+                            onClick = requireNotNull(content.onSecondaryAction),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag(GameScreenTestTags.SUCCESS_OVERLAY_SECONDARY_ACTION),
+                            shape = NumPairsComponents.MediumShape,
+                            colors = NumPairsComponents.secondaryButtonColors(),
+                            border = NumPairsComponents.secondaryButtonBorder()
+                        ) {
+                            Text(text = label)
+                        }
+                    }
+                    content.tertiaryActionLabel?.let { label ->
+                        TextButton(
+                            onClick = requireNotNull(content.onTertiaryAction),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag(GameScreenTestTags.SUCCESS_OVERLAY_TERTIARY_ACTION)
+                        ) {
+                            Text(text = label)
+                        }
                     }
                 } else {
                     completionActions?.let { actions ->

--- a/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenTestTags.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/game/ui/screen/GameScreenTestTags.kt
@@ -8,6 +8,8 @@ object GameScreenTestTags {
     const val SUCCESS_OVERLAY = "success_overlay"
     const val SUCCESS_OVERLAY_MESSAGE = "success_overlay_message"
     const val SUCCESS_OVERLAY_PRIMARY_ACTION = "success_overlay_primary_action"
+    const val SUCCESS_OVERLAY_SECONDARY_ACTION = "success_overlay_secondary_action"
+    const val SUCCESS_OVERLAY_TERTIARY_ACTION = "success_overlay_tertiary_action"
     const val SUCCESS_OVERLAY_NEW_PUZZLE = "success_overlay_new_puzzle"
     const val SUCCESS_OVERLAY_RETURN_TO_MENU = "success_overlay_return_to_menu"
     const val PUZZLE_OUTCOME = "puzzle_outcome"

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -14,6 +14,11 @@ import org.cescfe.numpairs.data.onboarding.OnboardingRepository
 import org.cescfe.numpairs.data.onboarding.OnboardingState
 import org.cescfe.numpairs.data.preferences.PersonalizationPreferencesRepository
 import org.cescfe.numpairs.data.preferences.TopAppBarActionDiscoveryRepository
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.feature.daily.DailyChallengeRoute
+import org.cescfe.numpairs.feature.daily.DailyCompletedTodayRoute
+import org.cescfe.numpairs.feature.daily.DailyFeatureDependencies
+import org.cescfe.numpairs.feature.daily.calendar.DailyCalendarRoute
 import org.cescfe.numpairs.feature.generated.GeneratedChallenge
 import org.cescfe.numpairs.feature.generated.GeneratedChallengeCatalog
 import org.cescfe.numpairs.feature.generated.GeneratedChallengeId
@@ -35,6 +40,9 @@ sealed interface AppDestination {
     data object Menu : AppDestination
     data object Tutorial : AppDestination
     data object Personalization : AppDestination
+    data class DailyChallenge(val identity: DailyChallengeId) : AppDestination
+    data class DailyCompletedToday(val identity: DailyChallengeId) : AppDestination
+    data object DailyCalendar : AppDestination
     data class GeneratedChallenge(
         val challengeId: GeneratedChallengeId,
         val launchIntent: GeneratedModeLaunchIntent = GeneratedModeLaunchIntent.newPuzzle()
@@ -50,6 +58,7 @@ fun AppNavigation(
     topAppBarActionDiscoveryRepository: TopAppBarActionDiscoveryRepository,
     generatedChallengeCatalog: GeneratedChallengeCatalog,
     generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory,
+    dailyFeatureDependencies: DailyFeatureDependencies? = null,
     modifier: Modifier = Modifier,
     startDestination: AppDestination = AppDestination.Menu
 ) {
@@ -68,6 +77,7 @@ fun AppNavigation(
             topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
             generatedChallengeCatalog = generatedChallengeCatalog,
             generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory,
+            dailyFeatureDependencies = dailyFeatureDependencies,
             modifier = modifier,
             startDestination = startDestination
         )
@@ -84,6 +94,7 @@ internal fun ReadyAppNavigation(
     topAppBarActionDiscoveryRepository: TopAppBarActionDiscoveryRepository,
     generatedChallengeCatalog: GeneratedChallengeCatalog,
     generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory,
+    dailyFeatureDependencies: DailyFeatureDependencies? = null,
     modifier: Modifier = Modifier,
     startDestination: AppDestination = AppDestination.Menu
 ) {
@@ -101,6 +112,7 @@ internal fun ReadyAppNavigation(
             topAppBarActionDiscoveryRepository = topAppBarActionDiscoveryRepository,
             generatedChallengeCatalog = generatedChallengeCatalog,
             generatedPuzzleGenerationUseCaseFactory = generatedPuzzleGenerationUseCaseFactory,
+            dailyFeatureDependencies = dailyFeatureDependencies,
             modifier = modifier,
             startDestination = startDestination
         )
@@ -115,6 +127,7 @@ private fun UnlockedAppNavigation(
     topAppBarActionDiscoveryRepository: TopAppBarActionDiscoveryRepository,
     generatedChallengeCatalog: GeneratedChallengeCatalog,
     generatedPuzzleGenerationUseCaseFactory: GeneratedPuzzleGenerationUseCaseFactory,
+    dailyFeatureDependencies: DailyFeatureDependencies?,
     modifier: Modifier,
     startDestination: AppDestination
 ) {
@@ -188,6 +201,45 @@ private fun UnlockedAppNavigation(
             onNavigateBack = navigateToMenu,
             modifier = modifier
         )
+        is AppDestination.DailyChallenge -> {
+            val dependencies = requireNotNull(dailyFeatureDependencies) {
+                "Daily feature dependencies are required for Daily gameplay."
+            }
+            DailyChallengeRoute(
+                identity = destination.identity,
+                dailySessionRepository = dependencies.dailySessionRepository,
+                deviceLocalDateSource = dependencies.deviceLocalDateSource,
+                generatedPuzzleGenerationUseCaseFactory =
+                dependencies.generatedPuzzleGenerationUseCaseFactory,
+                isGeneratedGameHapticsEnabled =
+                personalizationPreferences?.generatedGameHapticsEnabled == true,
+                onNavigateBack = navigateToMenu,
+                modifier = modifier
+            )
+        }
+        is AppDestination.DailyCompletedToday -> {
+            val dependencies = requireNotNull(dailyFeatureDependencies) {
+                "Daily feature dependencies are required for Daily completion."
+            }
+            DailyCompletedTodayRoute(
+                identity = destination.identity,
+                dailySessionRepository = dependencies.dailySessionRepository,
+                deviceLocalDateSource = dependencies.deviceLocalDateSource,
+                onNavigateBack = navigateToMenu,
+                modifier = modifier
+            )
+        }
+        AppDestination.DailyCalendar -> {
+            val dependencies = requireNotNull(dailyFeatureDependencies) {
+                "Daily feature dependencies are required for the Daily calendar."
+            }
+            DailyCalendarRoute(
+                dailySessionRepository = dependencies.dailySessionRepository,
+                deviceLocalDateSource = dependencies.deviceLocalDateSource,
+                onNavigateBack = navigateToMenu,
+                modifier = modifier
+            )
+        }
         is AppDestination.GeneratedChallenge -> {
             val challenge = generatedChallengeCatalog.resolveChallenge(id = destination.challengeId)
             val mode = generatedChallengeCatalog.modeFor(challenge)

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -76,6 +76,26 @@
     <string name="daily_share_completed_status">Completat</string>
     <string name="daily_share_chooser_title">Compartix el resultat Daily</string>
 
+    <!-- Joc i finalització Daily -->
+    <string name="daily_game_name">Daily</string>
+    <string name="daily_loading_message">Preparant el repte Daily de hui…</string>
+    <string name="daily_generation_failure_message">No s’ha pogut crear el repte Daily de hui. Torna-ho a provar amb el mateix repte.</string>
+    <string name="daily_generation_cancelled_message">La preparació de Daily s’ha interromput. Torna-ho a provar per a continuar amb el mateix repte.</string>
+    <string name="daily_invalid_puzzle_message">El repte Daily de hui no està disponible perquè el puzle no era vàlid.</string>
+    <string name="daily_storage_failure_message">No s’ha pogut guardar el progrés Daily. Torna-ho a provar abans de continuar.</string>
+    <string name="daily_stale_session_message">Esta sessió Daily ja no és l’actual. Torna al menú o reintenta el guardat segur.</string>
+    <string name="daily_invalid_progress_message">No s’ha pogut guardar este progrés Daily perquè ja no coincidix amb el puzle original.</string>
+    <string name="daily_progress_failure_title">Progrés Daily sense guardar</string>
+    <string name="daily_retry_action">Torna-ho a provar</string>
+    <string name="daily_completion_screen_title">Daily completat</string>
+    <string name="daily_completion_message">Daily completat!</string>
+    <string name="daily_completion_supporting_text">Has completat el repte de hui.</string>
+    <string name="daily_completion_challenge_name">4 parelles · Baixa</string>
+    <string name="daily_share_result_action">Compartix el resultat</string>
+    <string name="daily_view_calendar_action">Mostra el calendari</string>
+    <string name="daily_back_to_menu_action">Torna al menú</string>
+    <string name="daily_completion_unavailable_message">Esta finalització Daily ja no està disponible.</string>
+
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Pas %1$d de %2$d</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -76,6 +76,26 @@
     <string name="daily_share_completed_status">Completado</string>
     <string name="daily_share_chooser_title">Compartir resultado Daily</string>
 
+    <!-- Juego y finalización Daily -->
+    <string name="daily_game_name">Daily</string>
+    <string name="daily_loading_message">Preparando el reto Daily de hoy…</string>
+    <string name="daily_generation_failure_message">No se ha podido crear el reto Daily de hoy. Reinténtalo con el mismo reto.</string>
+    <string name="daily_generation_cancelled_message">La preparación de Daily se ha interrumpido. Reinténtalo para continuar con el mismo reto.</string>
+    <string name="daily_invalid_puzzle_message">El reto Daily de hoy no está disponible porque su puzle no era válido.</string>
+    <string name="daily_storage_failure_message">No se ha podido guardar el progreso Daily. Reinténtalo antes de continuar.</string>
+    <string name="daily_stale_session_message">Esta sesión Daily ya no es la actual. Vuelve al menú o reintenta el guardado seguro.</string>
+    <string name="daily_invalid_progress_message">No se ha podido guardar este progreso Daily porque ya no coincide con el puzle original.</string>
+    <string name="daily_progress_failure_title">Progreso Daily sin guardar</string>
+    <string name="daily_retry_action">Reintentar</string>
+    <string name="daily_completion_screen_title">Daily completado</string>
+    <string name="daily_completion_message">¡Daily completado!</string>
+    <string name="daily_completion_supporting_text">Has completado el reto de hoy.</string>
+    <string name="daily_completion_challenge_name">4 pares · Baja</string>
+    <string name="daily_share_result_action">Compartir resultado</string>
+    <string name="daily_view_calendar_action">Ver calendario</string>
+    <string name="daily_back_to_menu_action">Volver al menú</string>
+    <string name="daily_completion_unavailable_message">Esta finalización Daily ya no está disponible.</string>
+
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Paso %1$d de %2$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,26 @@
     <string name="daily_share_completed_status">Completed</string>
     <string name="daily_share_chooser_title">Share Daily result</string>
 
+    <!-- Daily gameplay and completion -->
+    <string name="daily_game_name">Daily</string>
+    <string name="daily_loading_message">Preparing today’s Daily challenge…</string>
+    <string name="daily_generation_failure_message">Today’s Daily challenge could not be created. Try again with the same challenge.</string>
+    <string name="daily_generation_cancelled_message">Daily preparation was interrupted. Try again to continue with the same challenge.</string>
+    <string name="daily_invalid_puzzle_message">Today’s Daily challenge is unavailable because its puzzle was invalid.</string>
+    <string name="daily_storage_failure_message">Daily progress could not be saved. Try again before continuing.</string>
+    <string name="daily_stale_session_message">This Daily session is no longer current. Return to the menu or try the safe save again.</string>
+    <string name="daily_invalid_progress_message">This Daily progress could not be saved because it no longer matches the original puzzle.</string>
+    <string name="daily_progress_failure_title">Daily progress not saved</string>
+    <string name="daily_retry_action">Retry</string>
+    <string name="daily_completion_screen_title">Daily completed</string>
+    <string name="daily_completion_message">Daily completed!</string>
+    <string name="daily_completion_supporting_text">Today’s challenge is complete.</string>
+    <string name="daily_completion_challenge_name">4 pairs · Low</string>
+    <string name="daily_share_result_action">Share result</string>
+    <string name="daily_view_calendar_action">View calendar</string>
+    <string name="daily_back_to_menu_action">Back to menu</string>
+    <string name="daily_completion_unavailable_message">This Daily completion is no longer available.</string>
+
     <!-- Tutorial screen -->
     <string name="tutorial_screen_title">Tutorial</string>
     <string name="tutorial_step_indicator">Step %1$d of %2$d</string>

--- a/app/src/test/java/org/cescfe/numpairs/feature/daily/DailyChallengeTitleFormatterTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/daily/DailyChallengeTitleFormatterTest.kt
@@ -1,0 +1,84 @@
+package org.cescfe.numpairs.feature.daily
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class DailyChallengeTitleFormatterTest {
+    @Test
+    fun title_uses_the_captured_identity_and_localizes_only_its_display_date() {
+        val identity = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(
+            LocalDate.of(2028, 2, 29)
+        )
+        val locale = Locale.forLanguageTag("es-ES")
+        val localizedDate = identity.localDate.format(
+            DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale)
+        )
+
+        val title = DailyChallengeTitleFormatter().format(
+            identity = identity,
+            dailyName = "Daily",
+            challengeName = "4 pares · Baja",
+            locale = locale
+        )
+
+        assertEquals("Daily · $localizedDate", title.visibleText)
+        assertEquals(
+            "Daily · $localizedDate, 4 pares · Baja",
+            title.accessibilityText
+        )
+        assertEquals("2028-02-29", identity.canonicalLocalDate)
+    }
+
+    @Test
+    fun changing_the_locale_does_not_change_the_captured_daily_identity() {
+        val identity = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(
+            LocalDate.of(2026, 7, 25)
+        )
+        val formatter = DailyChallengeTitleFormatter()
+
+        val english = formatter.format(
+            identity = identity,
+            dailyName = "Daily",
+            challengeName = "4 pairs · Low",
+            locale = Locale.US
+        )
+        val catalan = formatter.format(
+            identity = identity,
+            dailyName = "Daily",
+            challengeName = "4 parelles · Baixa",
+            locale = Locale.forLanguageTag("ca-ES")
+        )
+
+        assertEquals("2026-07-25", identity.canonicalLocalDate)
+        assertEquals(true, english.visibleText != catalan.visibleText)
+    }
+
+    @Test
+    fun title_requires_complete_localized_copy() {
+        val identity = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(
+            LocalDate.of(2026, 7, 25)
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyChallengeTitleFormatter().format(
+                identity = identity,
+                dailyName = " ",
+                challengeName = "4 pairs · Low",
+                locale = Locale.US
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DailyChallengeTitleFormatter().format(
+                identity = identity,
+                dailyName = "Daily",
+                challengeName = "",
+                locale = Locale.US
+            )
+        }
+    }
+}

--- a/app/src/test/java/org/cescfe/numpairs/feature/game/GameSuccessOverlayContentTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/game/GameSuccessOverlayContentTest.kt
@@ -1,0 +1,28 @@
+package org.cescfe.numpairs.feature.game
+
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class GameSuccessOverlayContentTest {
+    @Test
+    fun optional_completion_actions_require_a_label_and_callback_together() {
+        assertThrows(IllegalArgumentException::class.java) {
+            GameSuccessOverlayContent(
+                message = "Completed",
+                supportingText = "Supporting",
+                primaryActionLabel = "Share",
+                onPrimaryAction = {},
+                secondaryActionLabel = "Calendar"
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GameSuccessOverlayContent(
+                message = "Completed",
+                supportingText = "Supporting",
+                primaryActionLabel = "Share",
+                onPrimaryAction = {},
+                onTertiaryAction = {}
+            )
+        }
+    }
+}

--- a/docs/ui-behavior.md
+++ b/docs/ui-behavior.md
@@ -301,6 +301,10 @@ additional completion action.
 
 ## Daily Gameplay, Completion, And Rollover
 
+Status: application composition, gameplay, recoverable failure, immediate completion,
+completed-today summary, calendar return routing, and sharing integration implemented; the
+state-aware Menu entry remains planned.
+
 Daily gameplay reuses the generated Game screen and the `4 Pairs Low` challenge selected by its
 recipe. It does not expose a Daily difficulty selector or consult the remembered normal `4 Pairs`
 difficulty.
@@ -345,8 +349,8 @@ returns to the normal menu.
 
 ### Daily Calendar
 
-Status: monthly calendar model and read-only Compose surface implemented; application navigation
-integration planned.
+Status: monthly calendar model, read-only Compose surface, application destination, and
+completion-surface return routing implemented; the trailing Menu action remains planned.
 
 The Daily calendar is a dedicated local-history destination with:
 
@@ -394,7 +398,7 @@ process recreation does not require restoring the displayed month or caller.
 ### Daily Textual Sharing
 
 Status: non-spoiling localized text formatting and the Android Sharesheet boundary implemented;
-Daily completion-surface integration planned.
+integrated with valid immediate and reopened Daily completion surfaces.
 
 `Share result` opens the Android Sharesheet with localized `text/plain` content containing:
 


### PR DESCRIPTION
## Related Issue

Resolves #610

## Summary

- Compose one application-scoped Daily repository and date source with typed gameplay, completed-today, and calendar destinations.
- Route the captured Daily identity through deterministic preparation, exact-session gameplay, recoverable persistence, and midnight-safe completion.
- Add localized immediate and reopened completion surfaces with non-spoiling sharing, caller-aware calendar return, and exactly three Daily completion actions.
- Protect title accessibility, compact and RTL layouts, navigation, repository non-mutation, custom completion actions, and restored lifecycle behavior with focused tests.

## UI Consistency

- Shared components or tokens reused: `NumPairsComponents` primary CTA, secondary button, success container/border, top app bar colors, shapes, generated Game surface, feedback motion, and theme previews.
- Intentional deviations from established visual roles: completed Daily surfaces omit the duplicate top-bar navigation icon because `Back to menu` is already the explicit tertiary action; system back retains the same navigation behavior.
