### PR TITLE
[296] Add the state-aware Daily action to Menu

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTest.kt
@@ -5,6 +5,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
@@ -39,7 +42,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.test.espresso.Espresso.pressBackUnconditionally
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.time.LocalDate
 import org.cescfe.numpairs.R
+import org.cescfe.numpairs.feature.daily.DailyRecipes
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
 import org.junit.Assert.assertEquals
@@ -52,6 +57,135 @@ import org.junit.runner.RunWith
 class MenuScreenTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun daily_primary_state_updates_label_action_and_non_color_semantics() {
+        val identity = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(
+            LocalDate.of(2026, 7, 25)
+        )
+        var dailyState by mutableStateOf<DailyMenuUiState>(
+            DailyMenuUiState.StartToday(identity)
+        )
+
+        composeTestRule.setContent {
+            NumPairsTheme {
+                MenuScreen(
+                    dailyChallenge = dailyState,
+                    fourPairsMode = fourPairsState,
+                    eightPairsMode = eightPairsState
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_BUTTON)
+            .assertTextEquals(string(R.string.menu_daily_start_button))
+            .assertContentDescriptionEquals(
+                string(R.string.menu_daily_start_content_description)
+            ).assert(
+                SemanticsMatcher.expectValue(
+                    SemanticsProperties.StateDescription,
+                    string(R.string.menu_daily_not_started_state)
+                )
+            ).assertIsNotSelected()
+
+        composeTestRule.runOnIdle {
+            dailyState = DailyMenuUiState.ContinueToday(identity)
+        }
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_BUTTON)
+            .assertTextEquals(string(R.string.menu_daily_continue_button))
+            .assertContentDescriptionEquals(
+                string(R.string.menu_daily_continue_content_description)
+            ).assert(
+                SemanticsMatcher.expectValue(
+                    SemanticsProperties.StateDescription,
+                    string(R.string.menu_daily_in_progress_state)
+                )
+            ).assertIsNotSelected()
+
+        composeTestRule.runOnIdle {
+            dailyState = DailyMenuUiState.CompletedToday(identity)
+        }
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_BUTTON)
+            .assertTextEquals(string(R.string.menu_daily_completed_button))
+            .assertContentDescriptionEquals(
+                string(R.string.menu_daily_completed_content_description)
+            ).assert(
+                SemanticsMatcher.expectValue(
+                    SemanticsProperties.StateDescription,
+                    string(R.string.menu_daily_completed_state)
+                )
+            ).assertIsSelected()
+    }
+
+    @Test
+    fun daily_split_action_is_first_full_width_and_emits_primary_and_calendar_separately() {
+        val identity = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(
+            LocalDate.of(2026, 7, 25)
+        )
+        var primaryCount = 0
+        var calendarCount = 0
+
+        setContent(
+            dailyChallenge = DailyMenuUiState.StartToday(identity),
+            resumeChallengeName = "4 pairs · Low",
+            onDailySelected = { primaryCount += 1 },
+            onDailyCalendarSelected = { calendarCount += 1 }
+        )
+
+        val dailyContainer = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_SPLIT_CTA)
+            .assertIsDisplayed()
+            .assertHasNoClickAction()
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val dailyPrimary = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_BUTTON)
+            .assertHasClickAction()
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val dailyCalendar = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_CALENDAR_BUTTON)
+            .assertHasClickAction()
+            .assertContentDescriptionEquals(
+                string(R.string.menu_daily_calendar_content_description)
+            ).fetchSemanticsNode()
+            .boundsInRoot
+        val resumeTop = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.RESUME_BUTTON)
+            .fetchSemanticsNode()
+            .boundsInRoot
+            .top
+        val quickBounds = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.QUICK_BUTTON)
+            .fetchSemanticsNode()
+            .boundsInRoot
+
+        assertTrue(dailyContainer.top < resumeTop)
+        assertTrue(resumeTop < quickBounds.top)
+        assertEquals(quickBounds.left, dailyContainer.left, 0.5f)
+        assertEquals(quickBounds.right, dailyContainer.right, 0.5f)
+        assertEquals(dailyContainer.left, dailyPrimary.left, 0.5f)
+        assertEquals(dailyContainer.right, dailyCalendar.right, 0.5f)
+        assertTrue(
+            dailyCalendar.width >= with(composeTestRule.density) {
+                48.dp.toPx()
+            }
+        )
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_CALENDAR_BUTTON)
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_BUTTON)
+            .performClick()
+        composeTestRule.runOnIdle {
+            assertEquals(1, primaryCount)
+            assertEquals(1, calendarCount)
+        }
+    }
 
     @Test
     fun settings_action_replaces_personalization_button_and_emits_action() {
@@ -416,9 +550,19 @@ class MenuScreenTest {
             width = 320.dp,
             height = 360.dp,
             fontScale = 2f,
-            layoutDirection = LayoutDirection.Rtl
+            layoutDirection = LayoutDirection.Rtl,
+            dailyChallenge = DailyMenuUiState.StartToday(
+                DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(
+                    LocalDate.of(2026, 7, 25)
+                )
+            )
         )
 
+        val dailyBounds = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_SPLIT_CTA)
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+            .boundsInRoot
         val quickBounds = composeTestRule
             .onNodeWithTag(MenuScreenTestTags.QUICK_BUTTON)
             .performScrollTo()
@@ -435,6 +579,8 @@ class MenuScreenTest {
         assertEquals(fourPairsBounds.left, quickBounds.left, 0.5f)
         assertEquals(fourPairsBounds.right, quickBounds.right, 0.5f)
         assertEquals(fourPairsBounds.height, quickBounds.height, 0.5f)
+        assertEquals(quickBounds.left, dailyBounds.left, 0.5f)
+        assertEquals(quickBounds.right, dailyBounds.right, 0.5f)
     }
 
     private fun assertSelectorEndAlignment(layoutDirection: LayoutDirection) {
@@ -469,6 +615,10 @@ class MenuScreenTest {
         height: Dp? = null,
         fontScale: Float = 1f,
         layoutDirection: LayoutDirection = LayoutDirection.Ltr,
+        dailyChallenge: DailyMenuUiState? = null,
+        resumeChallengeName: String? = null,
+        onDailySelected: () -> Unit = {},
+        onDailyCalendarSelected: () -> Unit = {},
         onPersonalizationSelected: () -> Unit = {},
         onQuickSelected: () -> Unit = {},
         onFourPairsSelected: () -> Unit = {},
@@ -487,6 +637,10 @@ class MenuScreenTest {
                     if (width != null && height != null) {
                         Box(modifier = Modifier.size(width = width, height = height)) {
                             MenuContent(
+                                dailyChallenge = dailyChallenge,
+                                resumeChallengeName = resumeChallengeName,
+                                onDailySelected = onDailySelected,
+                                onDailyCalendarSelected = onDailyCalendarSelected,
                                 onPersonalizationSelected = onPersonalizationSelected,
                                 onQuickSelected = onQuickSelected,
                                 onFourPairsSelected = onFourPairsSelected,
@@ -495,6 +649,10 @@ class MenuScreenTest {
                         }
                     } else {
                         MenuContent(
+                            dailyChallenge = dailyChallenge,
+                            resumeChallengeName = resumeChallengeName,
+                            onDailySelected = onDailySelected,
+                            onDailyCalendarSelected = onDailyCalendarSelected,
                             onPersonalizationSelected = onPersonalizationSelected,
                             onQuickSelected = onQuickSelected,
                             onFourPairsSelected = onFourPairsSelected,
@@ -508,14 +666,22 @@ class MenuScreenTest {
 
     @Composable
     private fun MenuContent(
+        dailyChallenge: DailyMenuUiState?,
+        resumeChallengeName: String?,
+        onDailySelected: () -> Unit,
+        onDailyCalendarSelected: () -> Unit,
         onPersonalizationSelected: () -> Unit,
         onQuickSelected: () -> Unit,
         onFourPairsSelected: () -> Unit,
         onFourPairsDifficultySelected: (GeneratedDifficultyMenuOptionId) -> Unit
     ) {
         MenuScreen(
+            dailyChallenge = dailyChallenge,
+            resumeChallengeName = resumeChallengeName,
             fourPairsMode = fourPairsState,
             eightPairsMode = eightPairsState,
+            onDailySelected = onDailySelected,
+            onDailyCalendarSelected = onDailyCalendarSelected,
             onPersonalizationSelected = onPersonalizationSelected,
             onQuickSelected = onQuickSelected,
             onFourPairsSelected = onFourPairsSelected,

--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/DailyMenuNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/DailyMenuNavigationTest.kt
@@ -1,0 +1,295 @@
+package org.cescfe.numpairs.ui.navigation
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.time.LocalDate
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import org.cescfe.numpairs.R
+import org.cescfe.numpairs.data.daily.session.DailySessionClearResult
+import org.cescfe.numpairs.data.daily.session.DailySessionCompletionResult
+import org.cescfe.numpairs.data.daily.session.DailySessionId
+import org.cescfe.numpairs.data.daily.session.DailySessionProgressUpdateResult
+import org.cescfe.numpairs.data.daily.session.DailySessionReplacementResult
+import org.cescfe.numpairs.data.daily.session.DailySessionRepository
+import org.cescfe.numpairs.data.daily.session.DailySessionSnapshot
+import org.cescfe.numpairs.data.daily.session.DailyState
+import org.cescfe.numpairs.data.generated.selection.FakeGeneratedDifficultySelectionRepository
+import org.cescfe.numpairs.data.generated.session.FakeGeneratedSessionRepository
+import org.cescfe.numpairs.data.onboarding.FakeOnboardingRepository
+import org.cescfe.numpairs.data.preferences.FakePersonalizationPreferencesRepository
+import org.cescfe.numpairs.data.preferences.FakeTopAppBarActionDiscoveryRepository
+import org.cescfe.numpairs.data.puzzle.seed.samplePuzzle
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
+import org.cescfe.numpairs.domain.puzzle.model.Puzzle
+import org.cescfe.numpairs.feature.daily.CurrentDailyChallengeResolver
+import org.cescfe.numpairs.feature.daily.DailyFeatureDependencies
+import org.cescfe.numpairs.feature.daily.DailyPuzzleGenerationResult
+import org.cescfe.numpairs.feature.daily.DailyPuzzleGenerationUseCase
+import org.cescfe.numpairs.feature.daily.DailyRecipes
+import org.cescfe.numpairs.feature.daily.DailyScreenTestTags
+import org.cescfe.numpairs.feature.daily.calendar.DailyCalendarScreenTestTags
+import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
+import org.cescfe.numpairs.feature.generated.ConfiguredGeneratedPuzzleGenerationUseCaseFactory
+import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationResult
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCase
+import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
+import org.cescfe.numpairs.feature.menu.ui.MenuScreenTestTags
+import org.cescfe.numpairs.ui.theme.NumPairsTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DailyMenuNavigationTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun calendar_never_prepares_daily_and_return_recaptures_the_new_local_date() {
+        val dateSource = MutableDateSource(LocalDate.of(2026, 7, 25))
+        val completedIdentity = identity(dateSource.currentDate)
+        val repository = MutableDailyRepository(
+            DailyState(
+                activeSession = null,
+                completedChallengeIds = listOf(completedIdentity)
+            )
+        )
+        val generationCounter = GenerationCounter()
+        setContent(
+            repository = repository,
+            dateSource = dateSource,
+            generationCounter = generationCounter
+        )
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_BUTTON)
+            .assertTextEquals(string(R.string.menu_daily_completed_button))
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_CALENDAR_BUTTON)
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+
+        composeTestRule.runOnIdle {
+            dateSource.currentDate = dateSource.currentDate.plusDays(1)
+        }
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.BACK_BUTTON)
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_BUTTON)
+            .assertTextEquals(string(R.string.menu_daily_start_button))
+        composeTestRule.runOnIdle {
+            assertEquals(0, generationCounter.count)
+            assertEquals(0, repository.mutationCount)
+        }
+    }
+
+    @Test
+    fun completed_primary_opens_the_lightweight_summary_and_back_returns_to_menu() {
+        val dateSource = MutableDateSource(LocalDate.of(2026, 7, 25))
+        val repository = MutableDailyRepository(
+            DailyState(
+                activeSession = null,
+                completedChallengeIds = listOf(identity(dateSource.currentDate))
+            )
+        )
+        val generationCounter = GenerationCounter()
+        setContent(
+            repository = repository,
+            dateSource = dateSource,
+            generationCounter = generationCounter
+        )
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_BUTTON)
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(DailyScreenTestTags.COMPLETION_SUMMARY)
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            composeTestRule.activity.onBackPressedDispatcher.onBackPressed()
+        }
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(0, generationCounter.count)
+            assertEquals(0, repository.mutationCount)
+        }
+    }
+
+    @Test
+    fun exact_current_snapshot_exposes_continue_and_restores_without_generation() {
+        val dateSource = MutableDateSource(LocalDate.of(2026, 7, 25))
+        val snapshot = generatedSnapshot(dateSource.currentDate)
+        val repository = MutableDailyRepository(
+            DailyState(
+                activeSession = snapshot,
+                completedChallengeIds = emptyList()
+            )
+        )
+        val generationCounter = GenerationCounter()
+        setContent(
+            repository = repository,
+            dateSource = dateSource,
+            generationCounter = generationCounter
+        )
+
+        composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_BUTTON)
+            .assertTextEquals(string(R.string.menu_daily_continue_button))
+            .performClick()
+        composeTestRule
+            .onNodeWithTag(GameScreenTestTags.SCREEN)
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(0, generationCounter.count)
+            assertEquals(0, repository.mutationCount)
+        }
+    }
+
+    @Test
+    fun start_primary_routes_to_one_daily_preparation_attempt() {
+        val dateSource = MutableDateSource(LocalDate.of(2026, 7, 25))
+        val repository = MutableDailyRepository(
+            DailyState(
+                activeSession = null,
+                completedChallengeIds = emptyList()
+            )
+        )
+        val generationCounter = GenerationCounter()
+        setContent(
+            repository = repository,
+            dateSource = dateSource,
+            generationCounter = generationCounter
+        )
+
+        val dailyAction = composeTestRule.onNodeWithTag(MenuScreenTestTags.DAILY_BUTTON)
+        dailyAction.performClick()
+        composeTestRule
+            .onNodeWithTag(DailyScreenTestTags.FAILURE)
+            .assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(1, generationCounter.count)
+            assertEquals(0, repository.mutationCount)
+        }
+    }
+
+    private fun setContent(
+        repository: MutableDailyRepository,
+        dateSource: MutableDateSource,
+        generationCounter: GenerationCounter
+    ) {
+        val generationFactory = GeneratedPuzzleGenerationUseCaseFactory {
+            GeneratedPuzzleGenerationUseCase { request ->
+                generationCounter.count += 1
+                GeneratedPuzzleGenerationResult.Generated(
+                    request = request,
+                    initialPuzzle = samplePuzzle
+                )
+            }
+        }
+        composeTestRule.setContent {
+            NumPairsTheme {
+                AppNavigation(
+                    onboardingRepository = FakeOnboardingRepository(),
+                    generatedSessionRepository = FakeGeneratedSessionRepository(),
+                    generatedDifficultySelectionRepository =
+                    FakeGeneratedDifficultySelectionRepository(),
+                    personalizationPreferencesRepository =
+                    FakePersonalizationPreferencesRepository(),
+                    topAppBarActionDiscoveryRepository =
+                    FakeTopAppBarActionDiscoveryRepository(),
+                    generatedChallengeCatalog = GeneratedModes.catalog,
+                    generatedPuzzleGenerationUseCaseFactory = generationFactory,
+                    dailyFeatureDependencies = DailyFeatureDependencies(
+                        dailySessionRepository = repository,
+                        deviceLocalDateSource = dateSource,
+                        generatedPuzzleGenerationUseCaseFactory = generationFactory
+                    )
+                )
+            }
+        }
+    }
+
+    private fun generatedSnapshot(date: LocalDate): DailySessionSnapshot {
+        val dateSource = DeviceLocalDateSource { date }
+        val currentResolver = CurrentDailyChallengeResolver(
+            localDateSource = dateSource
+        )
+        val result = runBlocking {
+            DailyPuzzleGenerationUseCase(
+                currentDailyChallengeResolver = currentResolver,
+                generatedPuzzleGenerationUseCaseFactory =
+                ConfiguredGeneratedPuzzleGenerationUseCaseFactory(
+                    challengeCatalog = GeneratedModes.catalog
+                )
+            ).generate()
+        } as DailyPuzzleGenerationResult.Generated
+        return DailySessionSnapshot(
+            sessionId = DailySessionId("daily-menu-continue"),
+            dailyChallengeId = result.identity,
+            candidateIndex = result.candidateIndex,
+            seed = result.seed,
+            initialPuzzle = result.initialPuzzle,
+            currentPuzzle = result.initialPuzzle
+        )
+    }
+
+    private fun identity(date: LocalDate): DailyChallengeId = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(date)
+
+    private fun string(resourceId: Int): String = composeTestRule.activity.getString(resourceId)
+}
+
+private class MutableDateSource(var currentDate: LocalDate) : DeviceLocalDateSource {
+    override fun currentDate(): LocalDate = currentDate
+}
+
+private class MutableDailyRepository(initialState: DailyState) : DailySessionRepository {
+    override val state = MutableStateFlow(initialState)
+
+    var mutationCount: Int = 0
+
+    override suspend fun replaceSession(snapshot: DailySessionSnapshot): DailySessionReplacementResult {
+        mutationCount += 1
+        state.value = state.value.copy(activeSession = snapshot)
+        return DailySessionReplacementResult.Replaced
+    }
+
+    override suspend fun updateCurrentPuzzle(
+        expectedSessionId: DailySessionId,
+        puzzle: Puzzle
+    ): DailySessionProgressUpdateResult {
+        mutationCount += 1
+        return DailySessionProgressUpdateResult.Updated
+    }
+
+    override suspend fun clearSession(expectedSessionId: DailySessionId): DailySessionClearResult {
+        mutationCount += 1
+        return DailySessionClearResult.Cleared
+    }
+
+    override suspend fun complete(
+        expectedSessionId: DailySessionId,
+        expectedDailyChallengeId: DailyChallengeId,
+        solvedPuzzle: Puzzle
+    ): DailySessionCompletionResult {
+        mutationCount += 1
+        return DailySessionCompletionResult.Completed
+    }
+}
+
+private class GenerationCounter {
+    var count: Int = 0
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/daily/CurrentDailyAvailabilityResolver.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/daily/CurrentDailyAvailabilityResolver.kt
@@ -3,6 +3,7 @@ package org.cescfe.numpairs.feature.daily
 import kotlinx.coroutines.flow.first
 import org.cescfe.numpairs.data.daily.session.DailySessionRepository
 import org.cescfe.numpairs.data.daily.session.DailySessionSnapshot
+import org.cescfe.numpairs.data.daily.session.DailyState
 import org.cescfe.numpairs.domain.daily.DailyChallengeId
 
 sealed interface CurrentDailyAvailability {
@@ -43,6 +44,13 @@ class CurrentDailyAvailabilityResolver(
     suspend fun resolve(): CurrentDailyAvailability {
         val currentDailyChallenge = currentDailyChallengeResolver.resolve()
         val dailyState = dailySessionRepository.state.first()
+        return resolve(
+            currentDailyChallenge = currentDailyChallenge,
+            dailyState = dailyState
+        )
+    }
+
+    fun resolve(currentDailyChallenge: CurrentDailyChallenge, dailyState: DailyState): CurrentDailyAvailability {
         val completion = dailyState.completedChallengeIds.singleOrNull { completedIdentity ->
             completedIdentity.localDate == currentDailyChallenge.identity.localDate
         }

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/DailyMenuActionGuard.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/DailyMenuActionGuard.kt
@@ -1,0 +1,13 @@
+package org.cescfe.numpairs.feature.menu
+
+internal class DailyMenuActionGuard {
+    private var isHandled: Boolean = false
+
+    fun handle(action: () -> Unit) {
+        if (isHandled) {
+            return
+        }
+        isHandled = true
+        action()
+    }
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/MenuRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/MenuRoute.kt
@@ -8,12 +8,18 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import java.io.IOException
 import kotlinx.coroutines.launch
+import org.cescfe.numpairs.data.daily.session.DailySessionRepository
 import org.cescfe.numpairs.data.generated.selection.GeneratedDifficultySelectionRepository
+import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
+import org.cescfe.numpairs.feature.daily.CurrentDailyAvailability
+import org.cescfe.numpairs.feature.daily.CurrentDailyAvailabilityResolver
+import org.cescfe.numpairs.feature.daily.CurrentDailyChallengeResolver
 import org.cescfe.numpairs.feature.generated.GeneratedChallenge
 import org.cescfe.numpairs.feature.generated.GeneratedChallengeCatalog
 import org.cescfe.numpairs.feature.generated.GeneratedModeConfiguration
 import org.cescfe.numpairs.feature.generated.GeneratedModes
 import org.cescfe.numpairs.feature.generated.localizedTitle
+import org.cescfe.numpairs.feature.menu.ui.DailyMenuUiState
 import org.cescfe.numpairs.feature.menu.ui.GeneratedDifficultyMenuOptionId
 import org.cescfe.numpairs.feature.menu.ui.GeneratedDifficultyMenuOptionUiState
 import org.cescfe.numpairs.feature.menu.ui.GeneratedModeMenuUiState
@@ -23,13 +29,30 @@ import org.cescfe.numpairs.feature.menu.ui.MenuScreen
 fun MenuRoute(
     generatedDifficultySelectionRepository: GeneratedDifficultySelectionRepository,
     generatedChallengeCatalog: GeneratedChallengeCatalog,
+    dailySessionRepository: DailySessionRepository? = null,
+    deviceLocalDateSource: DeviceLocalDateSource? = null,
     modifier: Modifier = Modifier,
     resumeChallengeName: String? = null,
     onResumeSelected: () -> Unit = {},
     onTutorialSelected: () -> Unit = {},
     onPersonalizationSelected: () -> Unit = {},
+    onDailySelected: (DailyMenuUiState) -> Unit = {},
+    onDailyCalendarSelected: () -> Unit = {},
     onGeneratedChallengeSelected: (GeneratedChallenge) -> Unit = {}
 ) {
+    require((dailySessionRepository == null) == (deviceLocalDateSource == null)) {
+        "Daily Menu composition requires both the repository and local-date source."
+    }
+    val dailyMenuState = dailySessionRepository?.let { repository ->
+        requireNotNull(deviceLocalDateSource)
+        currentDailyMenuState(
+            dailySessionRepository = repository,
+            deviceLocalDateSource = deviceLocalDateSource
+        )
+    }
+    if (dailySessionRepository != null && dailyMenuState == null) {
+        return
+    }
     val quickChallenge = generatedChallengeCatalog.resolveChallenge(GeneratedModes.THREE_PAIRS_LOW.id)
     val fourPairsMode = generatedChallengeCatalog.resolve(GeneratedModes.FOUR_PAIRS.id)
     val eightPairsMode = generatedChallengeCatalog.resolve(GeneratedModes.EIGHT_PAIRS.id)
@@ -40,6 +63,9 @@ fun MenuRoute(
         repository = generatedDifficultySelectionRepository
     ) ?: return
     val coroutineScope = rememberCoroutineScope()
+    val dailyActionGuard = remember(dailyMenuState) {
+        DailyMenuActionGuard()
+    }
     val selectDifficulty: (GeneratedModeConfiguration, GeneratedDifficultyMenuOptionId) -> Unit =
         { mode, optionId ->
             val challenge = mode.challengeFor(optionId)
@@ -57,7 +83,16 @@ fun MenuRoute(
 
     MenuScreen(
         modifier = modifier,
+        dailyChallenge = dailyMenuState,
         resumeChallengeName = resumeChallengeName,
+        onDailySelected = {
+            dailyMenuState?.let { currentState ->
+                dailyActionGuard.handle {
+                    onDailySelected(currentState)
+                }
+            }
+        },
+        onDailyCalendarSelected = onDailyCalendarSelected,
         onQuickSelected = {
             onGeneratedChallengeSelected(quickChallenge)
         },
@@ -84,6 +119,56 @@ fun MenuRoute(
         onEightPairsDifficultySelected = { optionId ->
             selectDifficulty(eightPairsMode, optionId)
         }
+    )
+}
+
+@Composable
+private fun currentDailyMenuState(
+    dailySessionRepository: DailySessionRepository,
+    deviceLocalDateSource: DeviceLocalDateSource
+): DailyMenuUiState? {
+    val currentDailyChallengeResolver = remember(deviceLocalDateSource) {
+        CurrentDailyChallengeResolver(localDateSource = deviceLocalDateSource)
+    }
+    val availabilityResolver = remember(
+        currentDailyChallengeResolver,
+        dailySessionRepository
+    ) {
+        CurrentDailyAvailabilityResolver(
+            currentDailyChallengeResolver = currentDailyChallengeResolver,
+            dailySessionRepository = dailySessionRepository
+        )
+    }
+    val capturedCurrentDailyChallenge = remember(currentDailyChallengeResolver) {
+        currentDailyChallengeResolver.resolve()
+    }
+    val dailyState by dailySessionRepository.state.collectAsState(initial = null)
+
+    return remember(
+        availabilityResolver,
+        capturedCurrentDailyChallenge,
+        dailyState
+    ) {
+        dailyState?.let { currentState ->
+            availabilityResolver.resolve(
+                currentDailyChallenge = capturedCurrentDailyChallenge,
+                dailyState = currentState
+            ).toMenuUiState()
+        }
+    }
+}
+
+private fun CurrentDailyAvailability.toMenuUiState(): DailyMenuUiState = when (this) {
+    is CurrentDailyAvailability.StartToday -> DailyMenuUiState.StartToday(
+        identity = currentDailyChallenge.identity
+    )
+
+    is CurrentDailyAvailability.ContinueToday -> DailyMenuUiState.ContinueToday(
+        identity = currentDailyChallenge.identity
+    )
+
+    is CurrentDailyAvailability.CompletedToday -> DailyMenuUiState.CompletedToday(
+        identity = completion
     )
 }
 

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/DailyMenuUiState.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/DailyMenuUiState.kt
@@ -1,0 +1,13 @@
+package org.cescfe.numpairs.feature.menu.ui
+
+import org.cescfe.numpairs.domain.daily.DailyChallengeId
+
+sealed interface DailyMenuUiState {
+    val identity: DailyChallengeId
+
+    data class StartToday(override val identity: DailyChallengeId) : DailyMenuUiState
+
+    data class ContinueToday(override val identity: DailyChallengeId) : DailyMenuUiState
+
+    data class CompletedToday(override val identity: DailyChallengeId) : DailyMenuUiState
+}

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreen.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreen.kt
@@ -50,8 +50,10 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import java.time.LocalDate
 import org.cescfe.numpairs.R
 import org.cescfe.numpairs.data.preferences.PersonalizationTheme
+import org.cescfe.numpairs.feature.daily.DailyRecipes
 import org.cescfe.numpairs.ui.theme.NumPairsComponents
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
 import org.cescfe.numpairs.ui.theme.NumPairsThemePreviewParameterProvider
@@ -61,7 +63,10 @@ fun MenuScreen(
     fourPairsMode: GeneratedModeMenuUiState,
     eightPairsMode: GeneratedModeMenuUiState,
     modifier: Modifier = Modifier,
+    dailyChallenge: DailyMenuUiState? = null,
     resumeChallengeName: String? = null,
+    onDailySelected: () -> Unit = {},
+    onDailyCalendarSelected: () -> Unit = {},
     onResumeSelected: () -> Unit = {},
     onQuickSelected: () -> Unit = {},
     onTutorialSelected: () -> Unit = {},
@@ -103,6 +108,13 @@ fun MenuScreen(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
+                    dailyChallenge?.let { state ->
+                        DailyMenuRow(
+                            state = state,
+                            onPrimaryClick = onDailySelected,
+                            onCalendarClick = onDailyCalendarSelected
+                        )
+                    }
                     resumeChallengeName?.let { challengeName ->
                         val resumeContentDescription = stringResource(
                             R.string.menu_resume_content_description,
@@ -174,6 +186,73 @@ fun MenuScreen(
             }
         }
     }
+}
+
+@Composable
+private fun DailyMenuRow(state: DailyMenuUiState, onPrimaryClick: () -> Unit, onCalendarClick: () -> Unit) {
+    val label = stringResource(
+        when (state) {
+            is DailyMenuUiState.StartToday -> R.string.menu_daily_start_button
+            is DailyMenuUiState.ContinueToday -> R.string.menu_daily_continue_button
+            is DailyMenuUiState.CompletedToday -> R.string.menu_daily_completed_button
+        }
+    )
+    val actionContentDescription = stringResource(
+        when (state) {
+            is DailyMenuUiState.StartToday -> R.string.menu_daily_start_content_description
+            is DailyMenuUiState.ContinueToday -> R.string.menu_daily_continue_content_description
+            is DailyMenuUiState.CompletedToday -> R.string.menu_daily_completed_content_description
+        }
+    )
+    val actionStateDescription = stringResource(
+        when (state) {
+            is DailyMenuUiState.StartToday -> R.string.menu_daily_not_started_state
+            is DailyMenuUiState.ContinueToday -> R.string.menu_daily_in_progress_state
+            is DailyMenuUiState.CompletedToday -> R.string.menu_daily_completed_state
+        }
+    )
+    val calendarContentDescription = stringResource(
+        R.string.menu_daily_calendar_content_description
+    )
+
+    NumPairsComponents.PrimarySplitCtaButton(
+        onPrimaryClick = onPrimaryClick,
+        onSecondaryClick = onCalendarClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(NumPairsComponents.ButtonHeight)
+            .testTag(MenuScreenTestTags.DAILY_SPLIT_CTA),
+        primaryActionModifier = Modifier
+            .semantics {
+                contentDescription = actionContentDescription
+                stateDescription = actionStateDescription
+                selected = state is DailyMenuUiState.CompletedToday
+            }
+            .testTag(MenuScreenTestTags.DAILY_BUTTON),
+        secondaryActionModifier = Modifier
+            .semantics {
+                contentDescription = calendarContentDescription
+            }
+            .testTag(MenuScreenTestTags.DAILY_CALENDAR_BUTTON),
+        primaryContentPadding = PaddingValues(
+            horizontal = MENU_GENERATED_MODE_BUTTON_HORIZONTAL_PADDING,
+            vertical = 0.dp
+        ),
+        primaryContent = {
+            MenuButtonText(
+                text = label,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1
+            )
+        },
+        secondaryContent = {
+            Icon(
+                painter = painterResource(R.drawable.ic_calendar),
+                contentDescription = null,
+                modifier = Modifier.size(MENU_GENERATED_MODE_ICON_SIZE)
+            )
+        }
+    )
 }
 
 @Composable
@@ -411,6 +490,11 @@ private fun MenuScreenPreview(
         val fourPairsName = stringResource(R.string.four_pairs_screen_title)
         val eightPairsName = stringResource(R.string.eight_pairs_screen_title)
         MenuScreen(
+            dailyChallenge = DailyMenuUiState.StartToday(
+                identity = DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(
+                    LocalDate.of(2026, 7, 25)
+                )
+            ),
             fourPairsMode = GeneratedModeMenuUiState(
                 modeName = fourPairsName,
                 challengeName = stringResource(

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTestTags.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTestTags.kt
@@ -2,6 +2,9 @@ package org.cescfe.numpairs.feature.menu.ui
 
 object MenuScreenTestTags {
     const val SCREEN = "menu_screen"
+    const val DAILY_SPLIT_CTA = "menu_daily_split_cta"
+    const val DAILY_BUTTON = "menu_daily_button"
+    const val DAILY_CALENDAR_BUTTON = "menu_daily_calendar_button"
     const val RESUME_BUTTON = "menu_resume_button"
     const val QUICK_BUTTON = "menu_quick_button"
     const val QUICK_DIFFICULTY_BUTTON = "menu_quick_difficulty_button"

--- a/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/cescfe/numpairs/ui/navigation/AppNavigation.kt
@@ -30,6 +30,7 @@ import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFac
 import org.cescfe.numpairs.feature.generated.localizedNewPuzzleName
 import org.cescfe.numpairs.feature.generated.localizedTitle
 import org.cescfe.numpairs.feature.menu.MenuRoute
+import org.cescfe.numpairs.feature.menu.ui.DailyMenuUiState
 import org.cescfe.numpairs.feature.menu.ui.GeneratedSessionChoiceDialog
 import org.cescfe.numpairs.feature.onboarding.OnboardingLoadingScreen
 import org.cescfe.numpairs.feature.onboarding.RequiredOnboardingRoute
@@ -166,9 +167,12 @@ private fun UnlockedAppNavigation(
 
     when (val destination = currentDestination) {
         AppDestination.Menu -> {
+            val dailyDependencies = dailyFeatureDependencies
             MenuRoute(
                 generatedDifficultySelectionRepository = generatedDifficultySelectionRepository,
                 generatedChallengeCatalog = generatedChallengeCatalog,
+                dailySessionRepository = dailyDependencies?.dailySessionRepository,
+                deviceLocalDateSource = dailyDependencies?.deviceLocalDateSource,
                 modifier = modifier,
                 resumeChallengeName = resumableSession?.challenge?.let { challenge ->
                     challenge.localizedTitle(generatedChallengeCatalog)
@@ -188,6 +192,21 @@ private fun UnlockedAppNavigation(
                 },
                 onPersonalizationSelected = {
                     currentDestination = AppDestination.Personalization
+                },
+                onDailySelected = { dailyState ->
+                    currentDestination = when (dailyState) {
+                        is DailyMenuUiState.StartToday,
+                        is DailyMenuUiState.ContinueToday -> AppDestination.DailyChallenge(
+                            identity = dailyState.identity
+                        )
+
+                        is DailyMenuUiState.CompletedToday -> AppDestination.DailyCompletedToday(
+                            identity = dailyState.identity
+                        )
+                    }
+                },
+                onDailyCalendarSelected = {
+                    currentDestination = AppDestination.DailyCalendar
                 },
                 onGeneratedChallengeSelected = onGeneratedChallengeSelected
             )

--- a/app/src/main/res/drawable/ic_calendar.xml
+++ b/app/src/main/res/drawable/ic_calendar.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,4h-1V2h-2v2H8V2H6v2H5c-1.11,0 -2,0.9 -2,2v13c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V6c0,-1.1 -0.9,-2 -2,-2zM19,19H5V9h14v10zM7,11h5v5H7z" />
+</vector>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -7,6 +7,16 @@
     <string name="menu_resume_button">Continua</string>
     <string name="menu_resume_content_description">Continua el puzle de %1$s</string>
     <string name="menu_play_quick_content_description">Juga al puzle %1$s, %2$s, dificultat %3$s</string>
+    <string name="menu_daily_start_button">Repte Daily</string>
+    <string name="menu_daily_continue_button">Continua Daily</string>
+    <string name="menu_daily_completed_button">Daily completat</string>
+    <string name="menu_daily_start_content_description">Comença el repte Daily de hui, 4 parelles, dificultat Baixa</string>
+    <string name="menu_daily_continue_content_description">Continua el repte Daily de hui, 4 parelles, dificultat Baixa</string>
+    <string name="menu_daily_completed_content_description">Obri el repte Daily completat de hui, 4 parelles, dificultat Baixa</string>
+    <string name="menu_daily_calendar_content_description">Mostra el calendari de finalitzacions Daily</string>
+    <string name="menu_daily_not_started_state">No començat hui</string>
+    <string name="menu_daily_in_progress_state">En curs hui</string>
+    <string name="menu_daily_completed_state">Completat hui</string>
     <string name="menu_tutorial_button">Com jugar</string>
     <string name="menu_settings_action_content_description">Configuració</string>
     <string name="menu_play_generated_challenge_content_description">Juga al puzle de %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7,6 +7,16 @@
     <string name="menu_resume_button">Continuar</string>
     <string name="menu_resume_content_description">Continuar puzle de %1$s</string>
     <string name="menu_play_quick_content_description">Jugar puzle %1$s, %2$s, dificultad %3$s</string>
+    <string name="menu_daily_start_button">Reto Daily</string>
+    <string name="menu_daily_continue_button">Continuar Daily</string>
+    <string name="menu_daily_completed_button">Daily completado</string>
+    <string name="menu_daily_start_content_description">Empezar el reto Daily de hoy, 4 pares, dificultad Baja</string>
+    <string name="menu_daily_continue_content_description">Continuar el reto Daily de hoy, 4 pares, dificultad Baja</string>
+    <string name="menu_daily_completed_content_description">Abrir el reto Daily completado de hoy, 4 pares, dificultad Baja</string>
+    <string name="menu_daily_calendar_content_description">Ver calendario de finalizaciones Daily</string>
+    <string name="menu_daily_not_started_state">No empezado hoy</string>
+    <string name="menu_daily_in_progress_state">En curso hoy</string>
+    <string name="menu_daily_completed_state">Completado hoy</string>
     <string name="menu_tutorial_button">Cómo jugar</string>
     <string name="menu_settings_action_content_description">Ajustes</string>
     <string name="menu_play_generated_challenge_content_description">Jugar puzle de %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,16 @@
     <string name="menu_resume_button">Resume</string>
     <string name="menu_resume_content_description">Resume %1$s puzzle</string>
     <string name="menu_play_quick_content_description">Play %1$s puzzle, %2$s, %3$s difficulty</string>
+    <string name="menu_daily_start_button">Daily challenge</string>
+    <string name="menu_daily_continue_button">Continue daily</string>
+    <string name="menu_daily_completed_button">Daily completed</string>
+    <string name="menu_daily_start_content_description">Start today’s Daily challenge, 4 pairs, Low difficulty</string>
+    <string name="menu_daily_continue_content_description">Continue today’s Daily challenge, 4 pairs, Low difficulty</string>
+    <string name="menu_daily_completed_content_description">Open today’s completed Daily challenge, 4 pairs, Low difficulty</string>
+    <string name="menu_daily_calendar_content_description">View Daily completion calendar</string>
+    <string name="menu_daily_not_started_state">Not started today</string>
+    <string name="menu_daily_in_progress_state">In progress today</string>
+    <string name="menu_daily_completed_state">Completed today</string>
     <string name="menu_tutorial_button">How to play</string>
     <string name="menu_settings_action_content_description">Settings</string>
     <string name="menu_play_generated_challenge_content_description">Play %1$s puzzle</string>

--- a/app/src/test/java/org/cescfe/numpairs/feature/daily/CurrentDailyAvailabilityResolverTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/daily/CurrentDailyAvailabilityResolverTest.kt
@@ -112,6 +112,41 @@ class CurrentDailyAvailabilityResolverTest {
         assertSame(retainedSnapshot, restored.snapshot)
         assertEquals(0, repository.mutationCount)
     }
+
+    @Test
+    fun supplied_state_is_resolved_against_one_captured_identity_after_the_clock_changes() {
+        var currentDate = LocalDate.of(2027, 4, 18)
+        val repository = FakeDailySessionRepository(
+            initialState = DailyState(
+                activeSession = null,
+                completedChallengeIds = emptyList()
+            )
+        )
+        val currentResolver = CurrentDailyChallengeResolver(
+            localDateSource = DeviceLocalDateSource { currentDate }
+        )
+        val resolver = CurrentDailyAvailabilityResolver(
+            currentDailyChallengeResolver = currentResolver,
+            dailySessionRepository = repository
+        )
+        val capturedChallenge = currentResolver.resolve()
+
+        currentDate = currentDate.plusDays(1)
+        val availability = resolver.resolve(
+            currentDailyChallenge = capturedChallenge,
+            dailyState = DailyState(
+                activeSession = null,
+                completedChallengeIds = listOf(capturedChallenge.identity)
+            )
+        )
+
+        assertTrue(availability is CurrentDailyAvailability.CompletedToday)
+        assertEquals(
+            LocalDate.of(2027, 4, 18),
+            availability.currentDailyChallenge.identity.localDate
+        )
+        assertEquals(0, repository.mutationCount)
+    }
 }
 
 private fun resolver(date: LocalDate, repository: DailySessionRepository): CurrentDailyAvailabilityResolver =

--- a/app/src/test/java/org/cescfe/numpairs/feature/menu/DailyMenuActionGuardTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/menu/DailyMenuActionGuardTest.kt
@@ -1,0 +1,20 @@
+package org.cescfe.numpairs.feature.menu
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DailyMenuActionGuardTest {
+    @Test
+    fun only_the_first_primary_activation_is_handled() {
+        val guard = DailyMenuActionGuard()
+        var actionCount = 0
+
+        repeat(3) {
+            guard.handle {
+                actionCount += 1
+            }
+        }
+
+        assertEquals(1, actionCount)
+    }
+}

--- a/docs/ui-behavior.md
+++ b/docs/ui-behavior.md
@@ -118,6 +118,9 @@ The Daily Challenge row uses the established unified split primary CTA geometry:
 - the trailing region uses a calendar icon whose localized action description is independent from
   the primary state
 
+Status: implemented in the unlocked Menu with state-aware primary navigation and an independent
+calendar region.
+
 The primary label and semantics resolve from one captured current local date:
 
 - no completion and no matching resumable Daily Session: `Daily challenge`
@@ -303,7 +306,7 @@ additional completion action.
 
 Status: application composition, gameplay, recoverable failure, immediate completion,
 completed-today summary, calendar return routing, and sharing integration implemented; the
-state-aware Menu entry remains planned.
+state-aware Menu entry is implemented.
 
 Daily gameplay reuses the generated Game screen and the `4 Pairs Low` challenge selected by its
 recipe. It does not expose a Daily difficulty selector or consult the remembered normal `4 Pairs`
@@ -350,7 +353,7 @@ returns to the normal menu.
 ### Daily Calendar
 
 Status: monthly calendar model, read-only Compose surface, application destination, and
-completion-surface return routing implemented; the trailing Menu action remains planned.
+completion-surface and trailing Menu return routing implemented.
 
 The Daily calendar is a dedicated local-history destination with:
 


### PR DESCRIPTION
## Related Issue

Resolves #611

## Summary

- Resolve one Daily identity per Menu entry and map aggregate emissions to start, continue, or completed without generation or mutation.
- Add the Daily split primary CTA first in the unlocked hierarchy, with independent state-aware and calendar actions.
- Route typed Daily identities to gameplay or completed summary, refresh the date after returning to Menu, and deduplicate primary activation.
- Preserve normal Resume, Quick, generated difficulty selectors, Tutorial, Settings, compact layouts, RTL, and localized accessibility semantics.

## UI Consistency

- Shared components or tokens reused: `NumPairsComponents.PrimarySplitCtaButton`, established button height, divider, typography, spacing, theme roles, and the existing scrollable Menu layout.
- Intentional deviations from established visual roles: the trailing Daily region uses a calendar glyph instead of a difficulty arrow because it is a stable history action, with an independent localized description.
