### PR TITLE
[299] Complete the v10 UI quality pass

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/daily/DailyCompletionSurfaceTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/daily/DailyCompletionSurfaceTest.kt
@@ -57,6 +57,7 @@ import org.cescfe.numpairs.ui.navigation.AppNavigation
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -332,6 +333,51 @@ class DailyCompletionSurfaceTest {
             assertEquals(1, shareCount)
             assertEquals(1, calendarCount)
             assertEquals(1, backCount)
+        }
+    }
+
+    @Test
+    fun wide_completion_summary_caps_and_aligns_all_actions() {
+        composeTestRule.setContent {
+            NumPairsTheme {
+                Box(modifier = Modifier.size(width = 1_000.dp, height = 800.dp)) {
+                    DailyCompletionScreen(
+                        presentation = DailyChallengeTitle(
+                            visibleText = "Daily · Jul 25, 2026",
+                            accessibilityText = "Daily · Jul 25, 2026, 4 pairs · Low"
+                        ),
+                        onShareResult = {},
+                        onViewCalendar = {},
+                        onNavigateBack = {}
+                    )
+                }
+            }
+        }
+
+        val actionBounds = listOf(
+            DailyScreenTestTags.SHARE_RESULT,
+            DailyScreenTestTags.VIEW_CALENDAR,
+            DailyScreenTestTags.BACK_TO_MENU
+        ).map { tag ->
+            composeTestRule
+                .onNodeWithTag(tag)
+                .assertIsDisplayed()
+                .fetchSemanticsNode()
+                .boundsInRoot
+        }
+        val maximumActionWidth = with(composeTestRule.density) {
+            432.dp.toPx()
+        }
+        val minimumTouchTarget = with(composeTestRule.density) {
+            48.dp.toPx()
+        }
+        val firstBounds = actionBounds.first()
+
+        actionBounds.forEach { bounds ->
+            assertTrue(bounds.width <= maximumActionWidth)
+            assertTrue(bounds.height >= minimumTouchTarget)
+            assertEquals(firstBounds.left, bounds.left, 0.5f)
+            assertEquals(firstBounds.right, bounds.right, 0.5f)
         }
     }
 

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarScreenTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/daily/calendar/DailyCalendarScreenTest.kt
@@ -43,6 +43,7 @@ import org.cescfe.numpairs.domain.daily.DeviceLocalDateSource
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -225,6 +226,72 @@ class DailyCalendarScreenTest {
                     DateTimeFormatter.ofPattern("LLLL yyyy", Locale.forLanguageTag("ar"))
                 )
             )
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.PREVIOUS_MONTH_BUTTON)
+            .assertContentDescriptionEquals(
+                string(R.string.daily_calendar_previous_month_content_description)
+            )
+        composeTestRule
+            .onNodeWithTag(DailyCalendarScreenTestTags.NEXT_MONTH_BUTTON)
+            .assertContentDescriptionEquals(
+                string(R.string.daily_calendar_next_month_content_description)
+            )
+    }
+
+    @Test
+    fun wide_layout_caps_calendar_content_and_preserves_navigation_touch_targets() {
+        val currentDate = LocalDate.of(2026, 7, 25)
+        composeTestRule.setContent {
+            NumPairsTheme {
+                Box(modifier = Modifier.size(width = 1_000.dp, height = 800.dp)) {
+                    DailyCalendarScreen(
+                        calendarMonth = DailyCalendarMonth.create(
+                            capturedCurrentDate = currentDate,
+                            displayedMonth = YearMonth.of(2026, 6),
+                            locale = Locale.US
+                        ),
+                        locale = Locale.US,
+                        onPreviousMonth = {},
+                        onNextMonth = {},
+                        onNavigateBack = {}
+                    )
+                }
+            }
+        }
+
+        val navigationBounds = listOf(
+            DailyCalendarScreenTestTags.BACK_BUTTON,
+            DailyCalendarScreenTestTags.PREVIOUS_MONTH_BUTTON,
+            DailyCalendarScreenTestTags.NEXT_MONTH_BUTTON
+        ).associateWith { tag ->
+            composeTestRule
+                .onNodeWithTag(tag)
+                .assertIsDisplayed()
+                .fetchSemanticsNode()
+                .boundsInRoot
+        }
+        val minimumTouchTarget = with(composeTestRule.density) {
+            48.dp.toPx()
+        }
+        navigationBounds.values.forEach { bounds ->
+            assertTrue(bounds.width >= minimumTouchTarget)
+            assertTrue(bounds.height >= minimumTouchTarget)
+        }
+
+        val previousBounds = navigationBounds.getValue(
+            DailyCalendarScreenTestTags.PREVIOUS_MONTH_BUTTON
+        )
+        val nextBounds = navigationBounds.getValue(
+            DailyCalendarScreenTestTags.NEXT_MONTH_BUTTON
+        )
+        val expectedContentWidth = with(composeTestRule.density) {
+            480.dp.toPx()
+        }
+        assertEquals(
+            expectedContentWidth,
+            nextBounds.right - previousBounds.left,
+            0.5f
+        )
     }
 
     private fun setScreen(

--- a/app/src/androidTest/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/feature/menu/ui/MenuScreenTest.kt
@@ -169,6 +169,9 @@ class MenuScreenTest {
         assertEquals(quickBounds.right, dailyContainer.right, 0.5f)
         assertEquals(dailyContainer.left, dailyPrimary.left, 0.5f)
         assertEquals(dailyContainer.right, dailyCalendar.right, 0.5f)
+        assertEquals(dailyContainer.height, dailyPrimary.height, 0.5f)
+        assertEquals(dailyContainer.height, dailyCalendar.height, 0.5f)
+        assertTrue(dailyPrimary.right <= dailyCalendar.left)
         assertTrue(
             dailyCalendar.width >= with(composeTestRule.density) {
                 48.dp.toPx()
@@ -185,6 +188,39 @@ class MenuScreenTest {
             assertEquals(1, primaryCount)
             assertEquals(1, calendarCount)
         }
+    }
+
+    @Test
+    fun daily_split_actions_follow_logical_order_in_rtl() {
+        setContent(
+            width = 320.dp,
+            height = 640.dp,
+            fontScale = 2f,
+            layoutDirection = LayoutDirection.Rtl,
+            dailyChallenge = DailyMenuUiState.ContinueToday(
+                DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(
+                    LocalDate.of(2026, 7, 25)
+                )
+            )
+        )
+
+        val dailyPrimary = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_BUTTON)
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val dailyCalendar = composeTestRule
+            .onNodeWithTag(MenuScreenTestTags.DAILY_CALENDAR_BUTTON)
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+            .boundsInRoot
+
+        assertTrue(dailyCalendar.right <= dailyPrimary.left)
+        assertTrue(
+            dailyCalendar.width >= with(composeTestRule.density) {
+                48.dp.toPx()
+            }
+        )
     }
 
     @Test
@@ -581,6 +617,46 @@ class MenuScreenTest {
         assertEquals(fourPairsBounds.height, quickBounds.height, 0.5f)
         assertEquals(quickBounds.left, dailyBounds.left, 0.5f)
         assertEquals(quickBounds.right, dailyBounds.right, 0.5f)
+    }
+
+    @Test
+    fun wide_layout_caps_and_aligns_every_v10_menu_action() {
+        setContent(
+            width = 1_000.dp,
+            height = 800.dp,
+            dailyChallenge = DailyMenuUiState.StartToday(
+                DailyRecipes.FOUR_PAIRS_LOW_V1.identityFor(
+                    LocalDate.of(2026, 7, 25)
+                )
+            ),
+            resumeChallengeName = "Quick · Low"
+        )
+
+        val actionTags = listOf(
+            MenuScreenTestTags.DAILY_SPLIT_CTA,
+            MenuScreenTestTags.RESUME_BUTTON,
+            MenuScreenTestTags.QUICK_BUTTON,
+            MenuScreenTestTags.FOUR_PAIRS_SPLIT_CTA,
+            MenuScreenTestTags.EIGHT_PAIRS_SPLIT_CTA,
+            MenuScreenTestTags.TUTORIAL_BUTTON
+        )
+        val actionBounds = actionTags.map { tag ->
+            composeTestRule
+                .onNodeWithTag(tag)
+                .assertIsDisplayed()
+                .fetchSemanticsNode()
+                .boundsInRoot
+        }
+        val expectedWidth = with(composeTestRule.density) {
+            360.dp.toPx()
+        }
+        val firstBounds = actionBounds.first()
+
+        actionBounds.forEach { bounds ->
+            assertEquals(expectedWidth, bounds.width, 0.5f)
+            assertEquals(firstBounds.left, bounds.left, 0.5f)
+            assertEquals(firstBounds.right, bounds.right, 0.5f)
+        }
     }
 
     private fun assertSelectorEndAlignment(layoutDirection: LayoutDirection) {

--- a/app/src/test/java/org/cescfe/numpairs/V10LocalizationResourceParityTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/V10LocalizationResourceParityTest.kt
@@ -1,0 +1,73 @@
+package org.cescfe.numpairs
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+
+class V10LocalizationResourceParityTest {
+    @Test
+    fun v10_strings_are_complete_and_format_compatible_in_every_supported_locale() {
+        val resourcesDirectory = resourcesDirectory()
+        val defaultStrings = readStrings(
+            File(resourcesDirectory, "values/strings.xml")
+        ).filterKeys(::isV10String)
+        val supportedLocales = listOf("values-es", "values-ca")
+
+        assertTrue(defaultStrings.isNotEmpty())
+        supportedLocales.forEach { localeDirectory ->
+            val localizedStrings = readStrings(
+                File(resourcesDirectory, "$localeDirectory/strings.xml")
+            ).filterKeys(::isV10String)
+
+            assertEquals(defaultStrings.keys, localizedStrings.keys)
+            defaultStrings.forEach { (name, defaultValue) ->
+                val localizedValue = localizedStrings[name]
+                assertNotNull(localizedValue)
+                val requiredLocalizedValue = requireNotNull(localizedValue)
+                assertTrue("$localeDirectory/$name must not be blank", requiredLocalizedValue.isNotBlank())
+                assertEquals(
+                    "$localeDirectory/$name must preserve formatting arguments",
+                    formatArguments(defaultValue),
+                    formatArguments(requiredLocalizedValue)
+                )
+            }
+        }
+    }
+
+    private fun readStrings(file: File): Map<String, String> {
+        val documentBuilderFactory = DocumentBuilderFactory.newInstance().apply {
+            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        }
+        val document = documentBuilderFactory.newDocumentBuilder().parse(file)
+        return buildMap {
+            val nodes = document.getElementsByTagName("string")
+            repeat(nodes.length) { index ->
+                val element = nodes.item(index) as Element
+                put(element.getAttribute("name"), element.textContent)
+            }
+        }
+    }
+
+    private fun resourcesDirectory(): File = listOf(
+        File("src/main/res"),
+        File("app/src/main/res")
+    ).firstOrNull(File::isDirectory)
+        ?: error("Android resources directory was not found from ${File(".").absolutePath}.")
+
+    private fun isV10String(name: String): Boolean = name.startsWith("daily_") ||
+        name.startsWith("menu_daily_") ||
+        name.startsWith("quick_") ||
+        name.startsWith("three_pairs_") ||
+        name == "menu_play_quick_content_description"
+
+    private fun formatArguments(value: String): List<String> =
+        FORMAT_ARGUMENT.findAll(value).map { match -> match.value }.toList()
+
+    private companion object {
+        val FORMAT_ARGUMENT = Regex("%(?:\\d+\\$)?[a-zA-Z]")
+    }
+}


### PR DESCRIPTION
## Related Issue

Resolves #618

## Summary

- Enforce complete v10 string-key and formatting-argument parity across English, Spanish, and Valencian Catalan resources.
- Protect Daily split-action semantics and logical LTR/RTL ordering at compact width and increased text scale.
- Protect capped, aligned Menu, Daily completion, and calendar layouts at wide width.
- Verify calendar and completion controls preserve minimum touch targets and accessible logical navigation descriptions.

## UI Consistency

- Shared components or tokens reused: audited `PrimaryCtaButton`, `PrimarySplitCtaButton`, shared secondary button styling, icon-button colors, top-app-bar colors, semantic success roles, shapes, spacing, and typography across all v10 surfaces.
- Intentional deviations from established visual roles: no new deviation is introduced. Existing direct Material top app bars, calendar icon buttons, completion secondary/tertiary actions, and status dialogs remain appropriate standard controls and continue to use NumPairs tokens where a shared visual role exists.