### PR TITLE
[302] Add the 3 Pairs Medium generated challenge

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfiles.kt
+++ b/app/src/main/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfiles.kt
@@ -5,12 +5,20 @@ import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficulty
 
 object GeneratedPuzzleProfiles {
     val THREE_PAIRS_LOW: GeneratedPuzzleProfile = threePairsLow()
+    val THREE_PAIRS_MEDIUM: GeneratedPuzzleProfile = threePairsMedium()
     val FOUR_PAIRS_LOW: GeneratedPuzzleProfile = fourPairsLow()
     val FOUR_PAIRS_MEDIUM: GeneratedPuzzleProfile = fourPairsMedium()
     val EIGHT_PAIRS_MEDIUM: GeneratedPuzzleProfile = eightPairsMedium()
     val EIGHT_PAIRS_HARD: GeneratedPuzzleProfile = eightPairsHard()
     val ALL: List<GeneratedPuzzleProfile> =
-        listOf(THREE_PAIRS_LOW, FOUR_PAIRS_LOW, FOUR_PAIRS_MEDIUM, EIGHT_PAIRS_MEDIUM, EIGHT_PAIRS_HARD)
+        listOf(
+            THREE_PAIRS_LOW,
+            THREE_PAIRS_MEDIUM,
+            FOUR_PAIRS_LOW,
+            FOUR_PAIRS_MEDIUM,
+            EIGHT_PAIRS_MEDIUM,
+            EIGHT_PAIRS_HARD
+        )
 
     private fun threePairsLow(): GeneratedPuzzleProfile {
         val size = GeneratedPuzzleSize(pairCount = 3)
@@ -44,6 +52,74 @@ object GeneratedPuzzleProfiles {
                     ),
                     minimumInitialPlausibleCandidateCount = 3,
                     minimumInitialForcedDeductionCount = 3,
+                    minimumFirstForcedDeductionDepth = 1,
+                    minimumPlausibleDecoyCount = 0,
+                    minimumValidSolutionCount = 1
+                )
+            )
+        ).getOrThrow()
+    }
+
+    private fun threePairsMedium(): GeneratedPuzzleProfile {
+        val size = GeneratedPuzzleSize(pairCount = 3)
+
+        return GeneratedPuzzleProfile.create(
+            definition = GeneratedPuzzleProfileDefinition(
+                id = GeneratedPuzzleProfileId("3-pairs-medium"),
+                difficulty = DifficultyTier.MEDIUM,
+                size = size,
+                stripValuePolicy = StripValuePolicy(
+                    valueRange = 1..30,
+                    maxOccurrencesPerValue = 2,
+                    maxRepeatedValueGroupCount = 1
+                ),
+                resultConstraints = ResultConstraints(
+                    maxMultiplicationResult = 225,
+                    allowsDuplicateBoardResults = false,
+                    productAnchorMix = ProductAnchorMix(
+                        productResultGreaterThan = 60,
+                        countRange = 1..1
+                    )
+                ),
+                initialStripMaskPolicy = InitialStripMaskPolicy(
+                    knownEntryCountRange = 2..2,
+                    requiredAnchors = emptySet(),
+                    distributionPolicy = StripKnownEntryDistributionPolicy.Unrestricted,
+                    maxConsecutiveHiddenEntries = 3
+                ),
+                generationPolicy = GenerationPolicy(
+                    isBoardTileShufflingEnabled = true,
+                    maxAttempts = 160,
+                    maxSearchWork = 500_000
+                ),
+                varietyPolicy = GeneratedPuzzleVarietyPolicy(
+                    highValueMaskTargets = listOf(
+                        HighValueMaskTarget(
+                            rankFromHighest = 1,
+                            targetHiddenProbability = ProbabilityPercent(80)
+                        ),
+                        HighValueMaskTarget(
+                            rankFromHighest = 2,
+                            targetHiddenProbability = ProbabilityPercent(80)
+                        )
+                    ),
+                    primeProductDecoyTarget = PrimeProductDecoyTarget(
+                        targetPuzzlePercent = ProbabilityPercent(30),
+                        targetPairCount = 1,
+                        pairPattern = PrimeProductDecoyPairPattern.ONE_AND_PRIME
+                    ),
+                    repeatedValueGroupTarget = RepeatedValueGroupTarget(
+                        targetPuzzlePercent = ProbabilityPercent(35),
+                        targetGroupCount = 1
+                    )
+                ),
+                difficultyAssessmentPolicy = GeneratedPuzzleDifficultyAssessmentPolicy(
+                    executionPolicy = GeneratedPuzzleDifficultyAssessmentExecutionPolicy(
+                        maxCandidateExpansions = 15_000,
+                        validSolutionCountLimit = 12
+                    ),
+                    minimumInitialPlausibleCandidateCount = 3,
+                    minimumInitialForcedDeductionCount = 1,
                     minimumFirstForcedDeductionDepth = 1,
                     minimumPlausibleDecoyCount = 0,
                     minimumValidSolutionCount = 1

--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeConfiguration.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedModeConfiguration.kt
@@ -143,6 +143,12 @@ object GeneratedModes {
         difficulty = DifficultyTier.LOW,
         profile = GeneratedPuzzleProfiles.THREE_PAIRS_LOW
     )
+    val THREE_PAIRS_MEDIUM: GeneratedChallenge = GeneratedChallenge(
+        id = GeneratedChallengeId("three-pairs-medium"),
+        modeId = threePairsId,
+        difficulty = DifficultyTier.MEDIUM,
+        profile = GeneratedPuzzleProfiles.THREE_PAIRS_MEDIUM
+    )
     val FOUR_PAIRS_LOW: GeneratedChallenge = GeneratedChallenge(
         id = GeneratedChallengeId("four-pairs-low"),
         modeId = fourPairsId,
@@ -170,7 +176,7 @@ object GeneratedModes {
     val THREE_PAIRS: GeneratedModeConfiguration = GeneratedModeConfiguration(
         id = threePairsId,
         size = GeneratedPuzzleProfiles.THREE_PAIRS_LOW.size,
-        challenges = listOf(THREE_PAIRS_LOW)
+        challenges = listOf(THREE_PAIRS_LOW, THREE_PAIRS_MEDIUM)
     )
     val FOUR_PAIRS: GeneratedModeConfiguration = GeneratedModeConfiguration(
         id = fourPairsId,

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleProfileContractTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/GeneratedPuzzleProfileContractTest.kt
@@ -21,7 +21,14 @@ class GeneratedPuzzleProfileContractTest {
     @Test
     fun every_registered_profile_satisfies_the_shared_generation_contract() {
         assertEquals(
-            listOf("3-pairs-low", "4-pairs-low", "4-pairs-medium", "8-pairs-medium", "8-pairs-hard"),
+            listOf(
+                "3-pairs-low",
+                "3-pairs-medium",
+                "4-pairs-low",
+                "4-pairs-medium",
+                "8-pairs-medium",
+                "8-pairs-hard"
+            ),
             GeneratedPuzzleProfiles.ALL.map { profile -> profile.id.value }
         )
 

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/ThreePairsMediumGeneratedPairsPuzzleGeneratorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/generation/ThreePairsMediumGeneratedPairsPuzzleGeneratorTest.kt
@@ -1,0 +1,285 @@
+package org.cescfe.numpairs.domain.generated.generation
+
+import kotlin.math.abs
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPairsDifficultyAssessor
+import org.cescfe.numpairs.domain.generated.assessment.GeneratedPuzzleDifficultyAssessmentOutcome
+import org.cescfe.numpairs.domain.generated.profile.GeneratedPuzzleProfiles
+import org.cescfe.numpairs.domain.generated.profile.ProbabilityPercent
+import org.cescfe.numpairs.domain.generated.puzzle.GeneratedPairsPuzzle
+import org.cescfe.numpairs.domain.puzzle.model.StripItem
+import org.cescfe.numpairs.domain.puzzle.model.Tile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThreePairsMediumGeneratedPairsPuzzleGeneratorTest {
+    @Test
+    fun three_pairs_medium_generation_satisfies_the_documented_profile() {
+        val generatedPuzzle = generatedPuzzle(
+            profile = GeneratedPuzzleProfiles.THREE_PAIRS_MEDIUM,
+            seed = 42
+        )
+
+        assertDocumentedProfile(generatedPuzzle)
+    }
+
+    private fun assertDocumentedProfile(generatedPuzzle: GeneratedPairsPuzzle) {
+        val profile = GeneratedPuzzleProfiles.THREE_PAIRS_MEDIUM
+        val solvedPuzzle = generatedPuzzle.solvedPuzzle
+        val initialPuzzle = generatedPuzzle.initialPuzzle
+        val solvedValues = solvedPuzzle.requireKnownStripValues()
+        val repeatedValueGroupCount = solvedValues.groupingBy { value -> value }
+            .eachCount()
+            .values
+            .count { occurrenceCount -> occurrenceCount > 1 }
+        val anchorMix = requireNotNull(profile.resultConstraints.productAnchorMix)
+        val productAnchorCount = solvedPuzzle.multiplicationTiles().count { tile ->
+            tile.result > anchorMix.productResultGreaterThan
+        }
+
+        assertEquals(3, profile.size.pairCount)
+        assertEquals(6, solvedPuzzle.strip.entries.size)
+        assertEquals(6, solvedPuzzle.board.tiles.size)
+        assertEquals(solvedValues.sorted(), solvedValues)
+        assertTrue(solvedValues.all { value -> value in 1..30 })
+        assertTrue(
+            solvedValues.groupingBy { value -> value }.eachCount().values
+                .all { occurrenceCount -> occurrenceCount <= 2 }
+        )
+        assertTrue(repeatedValueGroupCount <= 1)
+        assertTrue(solvedPuzzle.multiplicationTiles().all { tile -> tile.result <= 225 })
+        assertEquals(6, solvedPuzzle.board.tiles.map(Tile::result).toSet().size)
+        assertEquals(1, productAnchorCount)
+
+        assertEquals(2, initialPuzzle.knownEntryIds().size)
+        assertEquals(4, initialPuzzle.strip.entries.count { entry -> entry.item == StripItem.Hidden })
+        assertTrue(initialPuzzle.knownEntryIds().maxConsecutiveHiddenEntries(6) <= 3)
+        assertGeneratedInitialPuzzleStructure(puzzle = initialPuzzle, profile = profile)
+    }
+
+    @Test
+    fun three_pairs_medium_generation_is_deterministic_for_the_same_seed() {
+        val profile = GeneratedPuzzleProfiles.THREE_PAIRS_MEDIUM
+
+        assertEquals(
+            generatedPuzzle(profile = profile, seed = 1234),
+            generatedPuzzle(profile = profile, seed = 1234)
+        )
+    }
+
+    @Test
+    fun three_pairs_medium_meets_documented_population_targets() {
+        val profile = GeneratedPuzzleProfiles.THREE_PAIRS_MEDIUM
+        val generatedPuzzles = CORPUS_SEEDS.map { seed ->
+            generatedPuzzle(profile = profile, seed = seed)
+        }
+        val repeatedTarget = requireNotNull(profile.varietyPolicy.repeatedValueGroupTarget)
+        val repeatedPuzzleCount = generatedPuzzles.count { puzzle ->
+            puzzle.solvedPuzzle.requireKnownStripValues().groupingBy { value -> value }
+                .eachCount()
+                .values
+                .count { occurrenceCount -> occurrenceCount > 1 } == repeatedTarget.targetGroupCount
+        }
+        val decoyTarget = requireNotNull(profile.varietyPolicy.primeProductDecoyTarget)
+        val primeProductDecoyPuzzleCount = generatedPuzzles.count { puzzle ->
+            puzzle.solvedPuzzle.multiplicationTiles().count(Tile::isPrimeProductDecoy) ==
+                decoyTarget.targetPairCount
+        }
+
+        assertFrequencyWithinTarget(
+            actualCount = repeatedPuzzleCount,
+            targetPercentage = repeatedTarget.targetPuzzlePercent
+        )
+        assertFrequencyWithinTarget(
+            actualCount = primeProductDecoyPuzzleCount,
+            targetPercentage = decoyTarget.targetPuzzlePercent
+        )
+        profile.varietyPolicy.highValueMaskTargets.forEach { target ->
+            val targetEntryIndex = profile.size.stripEntryCount - target.rankFromHighest
+            val hiddenPuzzleCount = generatedPuzzles.count { puzzle ->
+                puzzle.initialPuzzle.strip.entries[targetEntryIndex].item == StripItem.Hidden
+            }
+            assertFrequencyWithinTarget(
+                actualCount = hiddenPuzzleCount,
+                targetPercentage = target.targetHiddenProbability
+            )
+        }
+    }
+
+    @Test
+    fun corpus_characterizes_reliable_generation_and_medium_difficulty_assessment() {
+        val profile = GeneratedPuzzleProfiles.THREE_PAIRS_MEDIUM
+        val assessmentPolicy = requireNotNull(profile.difficultyAssessmentPolicy)
+        val assessor = GeneratedPairsDifficultyAssessor()
+        val observations = CORPUS_SEEDS.map { seed ->
+            val outcome = GeneratedPairsPuzzleGenerator(profile).generate(
+                request = GeneratedPuzzleGenerationRequest(profile = profile, seed = seed)
+            )
+            val generated = checkNotNull(outcome as? GeneratedPairsPuzzleGenerationOutcome.Generated) {
+                "Expected generated puzzle for seed $seed, but received $outcome."
+            }
+            assertDocumentedProfile(generated.puzzle)
+            val assessed = assessor.assess(
+                initialPuzzle = generated.puzzle.initialPuzzle,
+                profile = profile,
+                executionPolicy = assessmentPolicy.executionPolicy
+            ) as GeneratedPuzzleDifficultyAssessmentOutcome.Assessed
+
+            assertTrue(
+                "Assessment policy must accept seed $seed.",
+                assessmentPolicy.evaluate(assessed.report).isAccepted
+            )
+            assertFalse(
+                "Assessment solution count must stay below the configured limit for seed $seed.",
+                assessed.report.isValidSolutionCountLimitReached
+            )
+            MediumCorpusObservation(
+                attemptsUsed = generated.attemptsUsed,
+                searchWorkConsumed = generated.searchWorkConsumed,
+                assessmentWorkConsumed = assessed.workConsumed,
+                initialPlausibleCandidateCount = assessed.report.initialPlausibleCandidateCount,
+                initialForcedDeductionCount = assessed.report.initialForcedDeductionCount,
+                forcedDeductionCount = assessed.report.forcedDeductionCount,
+                plausibleDecoyCount = assessed.report.structuralObservations.plausibleDecoyCount,
+                boundedValidSolutionCount = assessed.report.boundedValidSolutionCount,
+                knownStripAnchorCount = assessed.report.structuralObservations.knownStripAnchorCount,
+                unambiguousResultAnchorCount =
+                assessed.report.structuralObservations.unambiguousResultAnchorCount,
+                longestHiddenRun = assessed.report.structuralObservations.longestHiddenRun
+            )
+        }
+
+        assertEquals(
+            MediumCorpusCharacterization(
+                attemptsUsed = 1..160,
+                searchWorkConsumed = 18..6344,
+                assessmentWorkConsumed = 468..470,
+                initialPlausibleCandidateCount = 3..6,
+                initialForcedDeductionCount = 1..3,
+                forcedDeductionCount = 2..3,
+                plausibleDecoyCount = 0..3,
+                boundedValidSolutionCount = 1..2,
+                knownStripAnchorCount = 0..0,
+                unambiguousResultAnchorCount = 1..6,
+                longestHiddenRun = 2..3
+            ),
+            observations.characterization()
+        )
+        val lowOpeningCandidateAverage = CORPUS_SEEDS.map { seed ->
+            val lowPuzzle = generatedPuzzle(profile = GeneratedPuzzleProfiles.THREE_PAIRS_LOW, seed = seed)
+            val lowAssessment = assessor.assess(
+                initialPuzzle = lowPuzzle.initialPuzzle,
+                profile = GeneratedPuzzleProfiles.THREE_PAIRS_LOW
+            ) as GeneratedPuzzleDifficultyAssessmentOutcome.Assessed
+            lowAssessment.report.initialPlausibleCandidateCount
+        }.average()
+        assertTrue(
+            observations.map(MediumCorpusObservation::initialPlausibleCandidateCount).average() >
+                lowOpeningCandidateAverage
+        )
+        assertTrue(observations.map(MediumCorpusObservation::initialForcedDeductionCount).average() < 3.0)
+    }
+
+    @Test
+    fun three_pairs_medium_preserves_bounded_failure_and_cancellation() {
+        val profile = GeneratedPuzzleProfiles.THREE_PAIRS_MEDIUM
+        val budgetFailure = GeneratedPairsPuzzleGenerator(profile).generate(
+            request = GeneratedPuzzleGenerationRequest(
+                profile = profile,
+                seed = 2026,
+                executionPolicy = GeneratedPuzzleGenerationExecutionPolicy(
+                    maxAttempts = 1,
+                    maxSearchWork = 1
+                )
+            )
+        ) as GeneratedPairsPuzzleGenerationOutcome.Failed
+        assertEquals(GeneratedPairsPuzzleGenerationFailureReason.SearchBudgetExhausted, budgetFailure.reason)
+
+        val cancellation = GeneratedPairsPuzzleGenerator(profile).generate(
+            request = GeneratedPuzzleGenerationRequest(profile = profile, seed = 2026),
+            cancellation = { true }
+        ) as GeneratedPairsPuzzleGenerationOutcome.Failed
+        assertEquals(GeneratedPairsPuzzleGenerationFailureReason.Cancelled, cancellation.reason)
+        assertEquals(0, cancellation.searchWorkConsumed)
+    }
+
+    private fun assertFrequencyWithinTarget(actualCount: Int, targetPercentage: ProbabilityPercent) {
+        val actualPercentage = actualCount * 100.0 / CORPUS_SEEDS.count()
+        assertTrue(
+            "Expected ${targetPercentage.value}% within ±$VARIETY_TOLERANCE_PERCENTAGE_POINTS points, " +
+                "but observed $actualPercentage% ($actualCount/${CORPUS_SEEDS.count()}).",
+            abs(actualPercentage - targetPercentage.value) <= VARIETY_TOLERANCE_PERCENTAGE_POINTS
+        )
+    }
+
+    private companion object {
+        const val VARIETY_TOLERANCE_PERCENTAGE_POINTS = 5
+        val CORPUS_SEEDS = 1..500
+    }
+}
+
+private data class MediumCorpusObservation(
+    val attemptsUsed: Int,
+    val searchWorkConsumed: Int,
+    val assessmentWorkConsumed: Int,
+    val initialPlausibleCandidateCount: Int,
+    val initialForcedDeductionCount: Int,
+    val forcedDeductionCount: Int,
+    val plausibleDecoyCount: Int,
+    val boundedValidSolutionCount: Int,
+    val knownStripAnchorCount: Int,
+    val unambiguousResultAnchorCount: Int,
+    val longestHiddenRun: Int
+)
+
+private data class MediumCorpusCharacterization(
+    val attemptsUsed: IntRange,
+    val searchWorkConsumed: IntRange,
+    val assessmentWorkConsumed: IntRange,
+    val initialPlausibleCandidateCount: IntRange,
+    val initialForcedDeductionCount: IntRange,
+    val forcedDeductionCount: IntRange,
+    val plausibleDecoyCount: IntRange,
+    val boundedValidSolutionCount: IntRange,
+    val knownStripAnchorCount: IntRange,
+    val unambiguousResultAnchorCount: IntRange,
+    val longestHiddenRun: IntRange
+)
+
+private fun List<MediumCorpusObservation>.characterization(): MediumCorpusCharacterization =
+    MediumCorpusCharacterization(
+        attemptsUsed = minOf(MediumCorpusObservation::attemptsUsed)..maxOf(MediumCorpusObservation::attemptsUsed),
+        searchWorkConsumed =
+        minOf(MediumCorpusObservation::searchWorkConsumed)..maxOf(MediumCorpusObservation::searchWorkConsumed),
+        assessmentWorkConsumed =
+        minOf(MediumCorpusObservation::assessmentWorkConsumed)..maxOf(
+            MediumCorpusObservation::assessmentWorkConsumed
+        ),
+        initialPlausibleCandidateCount =
+        minOf(MediumCorpusObservation::initialPlausibleCandidateCount)..maxOf(
+            MediumCorpusObservation::initialPlausibleCandidateCount
+        ),
+        initialForcedDeductionCount =
+        minOf(MediumCorpusObservation::initialForcedDeductionCount)..maxOf(
+            MediumCorpusObservation::initialForcedDeductionCount
+        ),
+        forcedDeductionCount =
+        minOf(MediumCorpusObservation::forcedDeductionCount)..maxOf(MediumCorpusObservation::forcedDeductionCount),
+        plausibleDecoyCount =
+        minOf(MediumCorpusObservation::plausibleDecoyCount)..maxOf(MediumCorpusObservation::plausibleDecoyCount),
+        boundedValidSolutionCount =
+        minOf(MediumCorpusObservation::boundedValidSolutionCount)..maxOf(
+            MediumCorpusObservation::boundedValidSolutionCount
+        ),
+        knownStripAnchorCount =
+        minOf(MediumCorpusObservation::knownStripAnchorCount)..maxOf(
+            MediumCorpusObservation::knownStripAnchorCount
+        ),
+        unambiguousResultAnchorCount =
+        minOf(MediumCorpusObservation::unambiguousResultAnchorCount)..maxOf(
+            MediumCorpusObservation::unambiguousResultAnchorCount
+        ),
+        longestHiddenRun =
+        minOf(MediumCorpusObservation::longestHiddenRun)..maxOf(MediumCorpusObservation::longestHiddenRun)
+    )

--- a/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfilesTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/domain/generated/profile/GeneratedPuzzleProfilesTest.kt
@@ -53,6 +53,68 @@ class GeneratedPuzzleProfilesTest {
     }
 
     @Test
+    fun three_pairs_medium_profile_matches_documented_rules() {
+        val profile = GeneratedPuzzleProfiles.THREE_PAIRS_MEDIUM
+
+        assertEquals(GeneratedPuzzleProfileId("3-pairs-medium"), profile.id)
+        assertEquals(DifficultyTier.MEDIUM, profile.difficulty)
+        assertEquals(3, profile.size.pairCount)
+        assertEquals(6, profile.size.stripEntryCount)
+        assertEquals(6, profile.size.boardTileCount)
+
+        assertEquals(1..30, profile.stripValuePolicy.valueRange)
+        assertEquals(2, profile.stripValuePolicy.maxOccurrencesPerValue)
+        assertEquals(1, profile.stripValuePolicy.maxRepeatedValueGroupCount)
+        assertTrue(profile.stripValuePolicy.allowsOne)
+
+        assertEquals(225, profile.resultConstraints.maxMultiplicationResult)
+        assertFalse(profile.resultConstraints.allowsDuplicateBoardResults)
+        val anchorMix = requireNotNull(profile.resultConstraints.productAnchorMix)
+        assertEquals(60, anchorMix.productResultGreaterThan)
+        assertEquals(1..1, anchorMix.countRange)
+
+        assertEquals(2..2, profile.initialStripMaskPolicy.knownEntryCountRange)
+        assertEquals(4..4, profile.hiddenEntryCountRange)
+        assertTrue(profile.initialStripMaskPolicy.requiredAnchors.isEmpty())
+        assertEquals(
+            StripKnownEntryDistributionPolicy.Unrestricted,
+            profile.initialStripMaskPolicy.distributionPolicy
+        )
+        assertEquals(3, profile.initialStripMaskPolicy.maxConsecutiveHiddenEntries)
+
+        assertEquals(
+            listOf(
+                HighValueMaskTarget(1, ProbabilityPercent(80)),
+                HighValueMaskTarget(2, ProbabilityPercent(80))
+            ),
+            profile.varietyPolicy.highValueMaskTargets
+        )
+        val decoyTarget = requireNotNull(profile.varietyPolicy.primeProductDecoyTarget)
+        assertEquals(ProbabilityPercent(30), decoyTarget.targetPuzzlePercent)
+        assertEquals(1, decoyTarget.targetPairCount)
+        assertEquals(PrimeProductDecoyPairPattern.ONE_AND_PRIME, decoyTarget.pairPattern)
+        assertEquals(
+            RepeatedValueGroupTarget(
+                targetPuzzlePercent = ProbabilityPercent(35),
+                targetGroupCount = 1
+            ),
+            profile.varietyPolicy.repeatedValueGroupTarget
+        )
+
+        assertTrue(profile.generationPolicy.isBoardTileShufflingEnabled)
+        assertEquals(160, profile.generationPolicy.maxAttempts)
+        assertEquals(500_000, profile.generationPolicy.maxSearchWork)
+        val assessmentPolicy = requireNotNull(profile.difficultyAssessmentPolicy)
+        assertEquals(15_000, assessmentPolicy.executionPolicy.maxCandidateExpansions)
+        assertEquals(12, assessmentPolicy.executionPolicy.validSolutionCountLimit)
+        assertEquals(3, assessmentPolicy.minimumInitialPlausibleCandidateCount)
+        assertEquals(1, assessmentPolicy.minimumInitialForcedDeductionCount)
+        assertEquals(1, assessmentPolicy.minimumFirstForcedDeductionDepth)
+        assertEquals(0, assessmentPolicy.minimumPlausibleDecoyCount)
+        assertEquals(1, assessmentPolicy.minimumValidSolutionCount)
+    }
+
+    @Test
     fun four_pairs_low_profile_matches_documented_rules() {
         val profile = GeneratedPuzzleProfiles.FOUR_PAIRS_LOW
 

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedChallengeCatalogTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedChallengeCatalogTest.kt
@@ -27,6 +27,7 @@ class GeneratedChallengeCatalogTest {
             DifficultyTier.entries
         )
         assertEquals(DifficultyTier.LOW, GeneratedPuzzleProfiles.THREE_PAIRS_LOW.difficulty)
+        assertEquals(DifficultyTier.MEDIUM, GeneratedPuzzleProfiles.THREE_PAIRS_MEDIUM.difficulty)
         assertEquals(DifficultyTier.LOW, GeneratedPuzzleProfiles.FOUR_PAIRS_LOW.difficulty)
         assertEquals(DifficultyTier.MEDIUM, GeneratedPuzzleProfiles.FOUR_PAIRS_MEDIUM.difficulty)
         assertEquals(DifficultyTier.MEDIUM, GeneratedPuzzleProfiles.EIGHT_PAIRS_MEDIUM.difficulty)
@@ -40,6 +41,8 @@ class GeneratedChallengeCatalogTest {
         assertEquals("eight-pairs", GeneratedModes.EIGHT_PAIRS.id.value)
         assertEquals("three-pairs-low", GeneratedModes.THREE_PAIRS_LOW.id.value)
         assertEquals("3-pairs-low", GeneratedModes.THREE_PAIRS_LOW.profile.id.value)
+        assertEquals("three-pairs-medium", GeneratedModes.THREE_PAIRS_MEDIUM.id.value)
+        assertEquals("3-pairs-medium", GeneratedModes.THREE_PAIRS_MEDIUM.profile.id.value)
         assertEquals("4-pairs-low", GeneratedModes.FOUR_PAIRS_LOW.profile.id.value)
         assertEquals("4-pairs-medium", GeneratedModes.FOUR_PAIRS_MEDIUM.profile.id.value)
         assertEquals("8-pairs-medium", GeneratedModes.EIGHT_PAIRS_MEDIUM.profile.id.value)
@@ -47,6 +50,7 @@ class GeneratedChallengeCatalogTest {
         assertEquals(
             listOf(
                 GeneratedModes.THREE_PAIRS_LOW,
+                GeneratedModes.THREE_PAIRS_MEDIUM,
                 GeneratedModes.FOUR_PAIRS_LOW,
                 GeneratedModes.FOUR_PAIRS_MEDIUM,
                 GeneratedModes.EIGHT_PAIRS_MEDIUM,
@@ -58,13 +62,23 @@ class GeneratedChallengeCatalogTest {
             listOf(GeneratedModes.THREE_PAIRS, GeneratedModes.FOUR_PAIRS, GeneratedModes.EIGHT_PAIRS),
             GeneratedModes.catalog.all
         )
-        assertEquals(listOf(GeneratedModes.THREE_PAIRS_LOW), GeneratedModes.THREE_PAIRS.challenges)
+        assertEquals(
+            listOf(GeneratedModes.THREE_PAIRS_LOW, GeneratedModes.THREE_PAIRS_MEDIUM),
+            GeneratedModes.THREE_PAIRS.challenges
+        )
         assertEquals(3, GeneratedModes.THREE_PAIRS.size.pairCount)
         assertSame(
             GeneratedModes.THREE_PAIRS_LOW,
             GeneratedModes.catalog.resolveChallenge(
                 modeId = GeneratedModes.THREE_PAIRS.id,
                 difficulty = DifficultyTier.LOW
+            )
+        )
+        assertSame(
+            GeneratedModes.THREE_PAIRS_MEDIUM,
+            GeneratedModes.catalog.resolveChallenge(
+                modeId = GeneratedModes.THREE_PAIRS.id,
+                difficulty = DifficultyTier.MEDIUM
             )
         )
         assertSame(
@@ -233,12 +247,6 @@ class GeneratedChallengeCatalogTest {
     fun unsupported_mode_difficulty_profile_and_challenge_resolutions_are_rejected() {
         assertThrows(IllegalArgumentException::class.java) {
             GeneratedModes.catalog.resolveChallenge(GeneratedChallengeId("unknown"))
-        }
-        assertThrows(IllegalArgumentException::class.java) {
-            GeneratedModes.catalog.resolveChallenge(
-                modeId = GeneratedModes.THREE_PAIRS.id,
-                difficulty = DifficultyTier.MEDIUM
-            )
         }
         assertThrows(IllegalArgumentException::class.java) {
             GeneratedModes.catalog.resolveChallenge(

--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -341,16 +341,17 @@ Initial masking:
 - known strip entries: 2
 - hidden strip entries: 4
 - required fixed anchors: none
-- pair distribution: known entries must belong to at least 2 distinct solution pairs
+- pair distribution: unrestricted
 - hidden run limit: no more than 3 consecutive hidden strip entries
 - high-value mask bias:
-  - last strip entry hidden target: 40%
-  - second-last strip entry hidden target: 55%
+  - last strip entry hidden target: 80%
+  - second-last strip entry hidden target: 80%
 
 Generation expectations:
 
 - deterministic generation support for tests: required
 - bounded attempts, shared search work, failure, and cancellation: required
+- generation uses at most `160` attempts and `500,000` shared search-work units
 - board tile shuffling: enabled
 - prime-product decoy target: around 30% of generated puzzles should include exactly 1 solution
   pair made of `1` and a prime number
@@ -364,12 +365,18 @@ Assessment and characterization expectations:
 - assessment uses at most `15,000` candidate expansions and counts at most `12` valid solution
   equivalence classes
 - at least 1 valid solution equivalence class must exist; uniqueness is not required
-- at least 4 plausible opening candidates must exist
+- at least 3 plausible opening candidates must exist
 - at least 1 opening fact must be derivable without speculative commitment
-- at least 1 locally plausible decoy must remain after direct arithmetic filtering
 - the first forced fact must require at least 1 propagation layer
 - characterization must demonstrate greater opening ambiguity and fewer forced opening facts than
   `3 Pairs Low` without exceeding the bounded Medium envelope
+- the implemented corpus completes in 1 to 160 attempts and consumes 18 to 6,344 generation-search
+  units per puzzle
+- assessment consumes 468 to 470 candidate expansions, reports 3 to 6 opening plausible
+  candidates, and initially forces 1 to 3 solution-pair facts
+- the bounded valid-solution count is 1 to 2 without reaching the configured count limit
+- known-strip anchors remain absent, unambiguous result anchors range from 1 to 6, and the longest
+  hidden run is 2 to 3
 
 Validation expectations:
 
@@ -379,7 +386,8 @@ Validation expectations:
 - assessment satisfies the documented Medium acceptance policy
 
 These constraints keep Quick Medium short while removing the fixed highest-value anchor, allowing
-limited repetition and `1`, and requiring a non-trivial decoy.
+limited repetition and `1`, and producing more opening ambiguity with fewer initially forced facts
+across the deterministic corpus than `3 Pairs Low`.
 
 ---
 


### PR DESCRIPTION
## Related Issue

Resolves #625

## Summary

- Add and register a stable calibrated `3 Pairs Medium` profile and challenge.
- Characterize deterministic generation, bounded assessment, and population variety over 500 seeds.
- Protect the sparse catalog and shared generated-profile contract with focused unit coverage.
