### PR TITLE
[303] Introduce weighted Quick and Classic play options

### DIFF
--- a/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPlayOption.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/generated/GeneratedPlayOption.kt
@@ -1,0 +1,131 @@
+package org.cescfe.numpairs.feature.generated
+
+import java.util.concurrent.ThreadLocalRandom
+import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
+
+@JvmInline
+value class GeneratedPlayOptionId(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "Generated play option id must not be blank."
+        }
+    }
+}
+
+data class GeneratedPlayOptionConfiguration(val id: GeneratedPlayOptionId, val difficulties: List<DifficultyTier>) {
+    init {
+        require(difficulties.isNotEmpty()) {
+            "Generated play option ${id.value} must expose at least one difficulty."
+        }
+        require(difficulties.distinct().size == difficulties.size) {
+            "Generated play option ${id.value} difficulties must be unique."
+        }
+    }
+
+    fun supports(difficulty: DifficultyTier): Boolean = difficulty in difficulties
+}
+
+object GeneratedPlayOptions {
+    val QUICK: GeneratedPlayOptionConfiguration = GeneratedPlayOptionConfiguration(
+        id = GeneratedPlayOptionId("quick"),
+        difficulties = listOf(DifficultyTier.LOW, DifficultyTier.MEDIUM)
+    )
+    val CLASSIC: GeneratedPlayOptionConfiguration = GeneratedPlayOptionConfiguration(
+        id = GeneratedPlayOptionId("classic"),
+        difficulties = listOf(DifficultyTier.MEDIUM, DifficultyTier.HARD)
+    )
+    val ALL: List<GeneratedPlayOptionConfiguration> = listOf(QUICK, CLASSIC)
+
+    private val byId = ALL.associateBy(GeneratedPlayOptionConfiguration::id)
+
+    init {
+        require(byId.size == ALL.size) {
+            "Generated play option ids must be unique."
+        }
+    }
+
+    fun resolve(id: GeneratedPlayOptionId): GeneratedPlayOptionConfiguration = requireNotNull(byId[id]) {
+        "No generated play option is configured for id ${id.value}."
+    }
+}
+
+fun interface GeneratedQuickSelectionBucketSource {
+    fun nextBucket(): Int
+}
+
+internal object ThreadLocalGeneratedQuickSelectionBucketSource : GeneratedQuickSelectionBucketSource {
+    override fun nextBucket(): Int = ThreadLocalRandom.current().nextInt(QUICK_SELECTION_BUCKET_COUNT)
+}
+
+class GeneratedPlayChallengeSelector(
+    private val challengeCatalog: GeneratedChallengeCatalog = GeneratedModes.catalog,
+    private val quickBucketSource: GeneratedQuickSelectionBucketSource =
+        ThreadLocalGeneratedQuickSelectionBucketSource
+) {
+    init {
+        GeneratedPlayOptions.QUICK.difficulties.forEach { difficulty ->
+            challengeCatalog.resolveChallenge(
+                modeId = GeneratedModes.THREE_PAIRS.id,
+                difficulty = difficulty
+            )
+            challengeCatalog.resolveChallenge(
+                modeId = GeneratedModes.FOUR_PAIRS.id,
+                difficulty = difficulty
+            )
+        }
+        GeneratedPlayOptions.CLASSIC.difficulties.forEach { difficulty ->
+            challengeCatalog.resolveChallenge(
+                modeId = GeneratedModes.EIGHT_PAIRS.id,
+                difficulty = difficulty
+            )
+        }
+    }
+
+    fun select(optionId: GeneratedPlayOptionId, difficulty: DifficultyTier): GeneratedChallenge {
+        val option = GeneratedPlayOptions.resolve(optionId)
+        require(option.supports(difficulty)) {
+            "Difficulty ${difficulty.name} is not supported for generated play option ${option.id.value}."
+        }
+
+        return when (option.id) {
+            GeneratedPlayOptions.QUICK.id -> selectQuick(difficulty)
+            GeneratedPlayOptions.CLASSIC.id -> challengeCatalog.resolveChallenge(
+                modeId = GeneratedModes.EIGHT_PAIRS.id,
+                difficulty = difficulty
+            )
+
+            else -> error("Unsupported configured generated play option ${option.id.value}.")
+        }
+    }
+
+    fun optionFor(challenge: GeneratedChallenge): GeneratedPlayOptionConfiguration {
+        require(challengeCatalog.resolveChallenge(id = challenge.id) == challenge) {
+            "Generated challenge ${challenge.id.value} is not configured by this selector."
+        }
+
+        return when (challenge.modeId) {
+            GeneratedModes.THREE_PAIRS.id,
+            GeneratedModes.FOUR_PAIRS.id -> GeneratedPlayOptions.QUICK
+
+            GeneratedModes.EIGHT_PAIRS.id -> GeneratedPlayOptions.CLASSIC
+            else -> error("No generated play option owns challenge ${challenge.id.value}.")
+        }
+    }
+
+    private fun selectQuick(difficulty: DifficultyTier): GeneratedChallenge {
+        val bucket = quickBucketSource.nextBucket()
+        require(bucket in 0 until QUICK_SELECTION_BUCKET_COUNT) {
+            "Quick selection bucket must be between 0 and ${QUICK_SELECTION_BUCKET_COUNT - 1}."
+        }
+        val modeId = if (bucket < QUICK_THREE_PAIRS_BUCKET_COUNT) {
+            GeneratedModes.THREE_PAIRS.id
+        } else {
+            GeneratedModes.FOUR_PAIRS.id
+        }
+
+        return challengeCatalog.resolveChallenge(modeId = modeId, difficulty = difficulty)
+    }
+}
+
+private const val QUICK_SELECTION_BUCKET_COUNT = 100
+private const val QUICK_THREE_PAIRS_BUCKET_COUNT = 35

--- a/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedPlayChallengeSelectorTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/feature/generated/GeneratedPlayChallengeSelectorTest.kt
@@ -1,0 +1,125 @@
+package org.cescfe.numpairs.feature.generated
+
+import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class GeneratedPlayChallengeSelectorTest {
+    @Test
+    fun configured_play_options_have_stable_identities_and_supported_difficulties() {
+        assertEquals("quick", GeneratedPlayOptions.QUICK.id.value)
+        assertEquals(
+            listOf(DifficultyTier.LOW, DifficultyTier.MEDIUM),
+            GeneratedPlayOptions.QUICK.difficulties
+        )
+        assertEquals("classic", GeneratedPlayOptions.CLASSIC.id.value)
+        assertEquals(
+            listOf(DifficultyTier.MEDIUM, DifficultyTier.HARD),
+            GeneratedPlayOptions.CLASSIC.difficulties
+        )
+        assertEquals(
+            listOf(GeneratedPlayOptions.QUICK, GeneratedPlayOptions.CLASSIC),
+            GeneratedPlayOptions.ALL
+        )
+    }
+
+    @Test
+    fun quick_low_resolves_exactly_thirty_five_three_pairs_and_sixty_five_four_pairs_buckets() {
+        assertQuickDistribution(
+            difficulty = DifficultyTier.LOW,
+            threePairsChallenge = GeneratedModes.THREE_PAIRS_LOW,
+            fourPairsChallenge = GeneratedModes.FOUR_PAIRS_LOW
+        )
+    }
+
+    @Test
+    fun quick_medium_resolves_exactly_thirty_five_three_pairs_and_sixty_five_four_pairs_buckets() {
+        assertQuickDistribution(
+            difficulty = DifficultyTier.MEDIUM,
+            threePairsChallenge = GeneratedModes.THREE_PAIRS_MEDIUM,
+            fourPairsChallenge = GeneratedModes.FOUR_PAIRS_MEDIUM
+        )
+    }
+
+    @Test
+    fun classic_resolves_directly_without_consuming_a_quick_bucket() {
+        val selector = GeneratedPlayChallengeSelector(
+            quickBucketSource = GeneratedQuickSelectionBucketSource {
+                error("Classic selection must not request a Quick bucket.")
+            }
+        )
+
+        assertSame(
+            GeneratedModes.EIGHT_PAIRS_MEDIUM,
+            selector.select(GeneratedPlayOptions.CLASSIC.id, DifficultyTier.MEDIUM)
+        )
+        assertSame(
+            GeneratedModes.EIGHT_PAIRS_HARD,
+            selector.select(GeneratedPlayOptions.CLASSIC.id, DifficultyTier.HARD)
+        )
+    }
+
+    @Test
+    fun configured_challenges_map_back_to_their_player_facing_option() {
+        val selector = GeneratedPlayChallengeSelector()
+
+        listOf(
+            GeneratedModes.THREE_PAIRS_LOW,
+            GeneratedModes.THREE_PAIRS_MEDIUM,
+            GeneratedModes.FOUR_PAIRS_LOW,
+            GeneratedModes.FOUR_PAIRS_MEDIUM
+        ).forEach { challenge ->
+            assertSame(GeneratedPlayOptions.QUICK, selector.optionFor(challenge))
+        }
+        listOf(
+            GeneratedModes.EIGHT_PAIRS_MEDIUM,
+            GeneratedModes.EIGHT_PAIRS_HARD
+        ).forEach { challenge ->
+            assertSame(GeneratedPlayOptions.CLASSIC, selector.optionFor(challenge))
+        }
+    }
+
+    @Test
+    fun unknown_options_unsupported_difficulties_and_invalid_buckets_are_rejected() {
+        val selector = GeneratedPlayChallengeSelector()
+
+        assertThrows(IllegalArgumentException::class.java) {
+            selector.select(GeneratedPlayOptionId("unknown"), DifficultyTier.LOW)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            selector.select(GeneratedPlayOptions.QUICK.id, DifficultyTier.HARD)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            selector.select(GeneratedPlayOptions.CLASSIC.id, DifficultyTier.LOW)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            GeneratedPlayChallengeSelector(
+                quickBucketSource = GeneratedQuickSelectionBucketSource { 100 }
+            ).select(GeneratedPlayOptions.QUICK.id, DifficultyTier.LOW)
+        }
+    }
+
+    private fun assertQuickDistribution(
+        difficulty: DifficultyTier,
+        threePairsChallenge: GeneratedChallenge,
+        fourPairsChallenge: GeneratedChallenge
+    ) {
+        var bucket = 0
+        val selector = GeneratedPlayChallengeSelector(
+            quickBucketSource = GeneratedQuickSelectionBucketSource { bucket }
+        )
+        val selectedChallenges = (0 until 100).map { currentBucket ->
+            bucket = currentBucket
+            selector.select(GeneratedPlayOptions.QUICK.id, difficulty)
+        }
+
+        assertEquals(35, selectedChallenges.count { challenge -> challenge == threePairsChallenge })
+        assertEquals(65, selectedChallenges.count { challenge -> challenge == fourPairsChallenge })
+        assertEquals(
+            List(35) { threePairsChallenge } + List(65) { fourPairsChallenge },
+            selectedChallenges
+        )
+    }
+}


### PR DESCRIPTION
## Related Issue

Resolves #626

## Summary

- Add stable Quick and Classic generated-play option identities.
- Resolve Quick Low and Medium through exhaustive 35/65 selection buckets.
- Resolve Classic directly and map every configured challenge back to its player-facing option.
