### PR TITLE
[304] Migrate difficulty preferences to Quick and Classic

### DIFF
--- a/app/src/androidTest/java/org/cescfe/numpairs/data/generated/selection/FakeGeneratedDifficultySelectionRepository.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/data/generated/selection/FakeGeneratedDifficultySelectionRepository.kt
@@ -4,43 +4,39 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
-import org.cescfe.numpairs.feature.generated.GeneratedModeId
-import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.generated.GeneratedPlayOptionId
+import org.cescfe.numpairs.feature.generated.GeneratedPlayOptions
 
 class FakeGeneratedDifficultySelectionRepository(
-    initialSelections: Map<GeneratedModeId, DifficultyTier> = defaultSelections
+    initialSelections: Map<GeneratedPlayOptionId, DifficultyTier> = defaultSelections
 ) : GeneratedDifficultySelectionRepository {
-    private val selectionByMode = initialSelections.mapValues { (_, difficulty) ->
+    private val selectionByOption = initialSelections.mapValues { (_, difficulty) ->
         MutableStateFlow(difficulty)
     }.toMutableMap()
 
-    val explicitSelections = mutableListOf<Pair<GeneratedModeId, DifficultyTier>>()
+    val explicitSelections = mutableListOf<Pair<GeneratedPlayOptionId, DifficultyTier>>()
 
-    override fun selectedDifficulty(modeId: GeneratedModeId): Flow<DifficultyTier?> =
-        selectionByMode[modeId] ?: flowOf(null)
+    override fun selectedDifficulty(optionId: GeneratedPlayOptionId): Flow<DifficultyTier?> =
+        selectionByOption[optionId] ?: flowOf(null)
 
-    override suspend fun selectDifficulty(modeId: GeneratedModeId, difficulty: DifficultyTier) {
-        val selection = requireNotNull(selectionByMode[modeId]) {
-            "No fake difficulty selection is configured for mode ${modeId.value}."
+    override suspend fun selectDifficulty(optionId: GeneratedPlayOptionId, difficulty: DifficultyTier) {
+        val selection = requireNotNull(selectionByOption[optionId]) {
+            "No fake difficulty selection is configured for option ${optionId.value}."
         }
-        require(
-            GeneratedModes.catalog.allChallenges.any { challenge ->
-                challenge.modeId == modeId && challenge.difficulty == difficulty
-            }
-        ) {
-            "Difficulty ${difficulty.name} is not supported for fake mode ${modeId.value}."
+        require(GeneratedPlayOptions.resolve(optionId).supports(difficulty)) {
+            "Difficulty ${difficulty.name} is not supported for fake option ${optionId.value}."
         }
 
-        explicitSelections += modeId to difficulty
+        explicitSelections += optionId to difficulty
         selection.value = difficulty
     }
 
-    fun currentDifficulty(modeId: GeneratedModeId): DifficultyTier? = selectionByMode[modeId]?.value
+    fun currentDifficulty(optionId: GeneratedPlayOptionId): DifficultyTier? = selectionByOption[optionId]?.value
 
     private companion object {
         val defaultSelections = mapOf(
-            GeneratedModes.FOUR_PAIRS.id to DifficultyTier.LOW,
-            GeneratedModes.EIGHT_PAIRS.id to DifficultyTier.MEDIUM
+            GeneratedPlayOptions.QUICK.id to DifficultyTier.LOW,
+            GeneratedPlayOptions.CLASSIC.id to DifficultyTier.MEDIUM
         )
     }
 }

--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedDifficultySelectionNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/GeneratedDifficultySelectionNavigationTest.kt
@@ -31,6 +31,7 @@ import org.cescfe.numpairs.domain.puzzle.model.Tile
 import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
 import org.cescfe.numpairs.feature.generated.GeneratedChallenge
 import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.generated.GeneratedPlayOptions
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationResult
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCase
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
@@ -72,11 +73,11 @@ class GeneratedDifficultySelectionNavigationTest {
             assertTrue(fixture.generatedChallenges.isEmpty())
             assertEquals(
                 DifficultyTier.LOW,
-                fixture.difficultyRepository.currentDifficulty(GeneratedModes.FOUR_PAIRS.id)
+                fixture.difficultyRepository.currentDifficulty(GeneratedPlayOptions.QUICK.id)
             )
             assertEquals(
                 DifficultyTier.MEDIUM,
-                fixture.difficultyRepository.currentDifficulty(GeneratedModes.EIGHT_PAIRS.id)
+                fixture.difficultyRepository.currentDifficulty(GeneratedPlayOptions.CLASSIC.id)
             )
         }
     }
@@ -107,7 +108,7 @@ class GeneratedDifficultySelectionNavigationTest {
                 fixture.sessionRepository.session.value?.profileId
             )
             assertEquals(
-                listOf(GeneratedModes.FOUR_PAIRS.id to DifficultyTier.MEDIUM),
+                listOf(GeneratedPlayOptions.QUICK.id to DifficultyTier.MEDIUM),
                 fixture.difficultyRepository.explicitSelections
             )
         }
@@ -149,8 +150,8 @@ class GeneratedDifficultySelectionNavigationTest {
     fun menu_restores_independent_selections_and_primary_action_launches_them_directly() {
         val difficultyRepository = FakeGeneratedDifficultySelectionRepository(
             initialSelections = mapOf(
-                GeneratedModes.FOUR_PAIRS.id to DifficultyTier.MEDIUM,
-                GeneratedModes.EIGHT_PAIRS.id to DifficultyTier.HARD
+                GeneratedPlayOptions.QUICK.id to DifficultyTier.MEDIUM,
+                GeneratedPlayOptions.CLASSIC.id to DifficultyTier.HARD
             )
         )
         val fixture = setContent(difficultyRepository = difficultyRepository)
@@ -199,7 +200,7 @@ class GeneratedDifficultySelectionNavigationTest {
             assertTrue(fixture.difficultyRepository.explicitSelections.isEmpty())
             assertEquals(
                 DifficultyTier.MEDIUM,
-                fixture.difficultyRepository.currentDifficulty(GeneratedModes.EIGHT_PAIRS.id)
+                fixture.difficultyRepository.currentDifficulty(GeneratedPlayOptions.CLASSIC.id)
             )
             assertEquals(snapshot, fixture.sessionRepository.session.value)
         }

--- a/app/src/main/java/org/cescfe/numpairs/data/generated/selection/DataStoreGeneratedDifficultySelectionRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/generated/selection/DataStoreGeneratedDifficultySelectionRepository.kt
@@ -14,26 +14,45 @@ import kotlinx.coroutines.flow.map
 import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
 import org.cescfe.numpairs.feature.generated.GeneratedChallengeCatalog
 import org.cescfe.numpairs.feature.generated.GeneratedModeId
+import org.cescfe.numpairs.feature.generated.GeneratedPlayOptionConfiguration
+import org.cescfe.numpairs.feature.generated.GeneratedPlayOptionId
 
 class DataStoreGeneratedDifficultySelectionRepository(
     private val dataStore: DataStore<Preferences>,
     private val catalog: GeneratedChallengeCatalog,
-    private val fallbackDifficultyByMode: Map<GeneratedModeId, DifficultyTier>
+    playOptions: Collection<GeneratedPlayOptionConfiguration>,
+    private val fallbackDifficultyByOption: Map<GeneratedPlayOptionId, DifficultyTier>,
+    private val legacyModeByOption: Map<GeneratedPlayOptionId, GeneratedModeId>
 ) : GeneratedDifficultySelectionRepository {
+    private val optionsById = playOptions.associateBy(GeneratedPlayOptionConfiguration::id)
+
     init {
-        val configuredModeIds = catalog.all.map { mode -> mode.id }.toSet()
-        require(fallbackDifficultyByMode.keys.all(configuredModeIds::contains)) {
-            "Every difficulty fallback must belong to a configured generated mode."
+        require(optionsById.size == playOptions.size) {
+            "Generated difficulty selection options must have unique ids."
         }
-        fallbackDifficultyByMode.forEach { (modeId, difficulty) ->
-            require(catalog.supports(modeId = modeId, difficulty = difficulty)) {
-                "The fallback for mode ${modeId.value} must be a supported difficulty."
+        require(fallbackDifficultyByOption.keys == optionsById.keys) {
+            "Every generated play option must have exactly one difficulty fallback."
+        }
+        require(legacyModeByOption.keys == optionsById.keys) {
+            "Every generated play option must have exactly one legacy mode mapping."
+        }
+        fallbackDifficultyByOption.forEach { (optionId, difficulty) ->
+            require(optionsById.getValue(optionId).supports(difficulty)) {
+                "The fallback for option ${optionId.value} must be a supported difficulty."
+            }
+        }
+        legacyModeByOption.forEach { (optionId, modeId) ->
+            val option = optionsById.getValue(optionId)
+            require(option.difficulties.all { difficulty -> catalog.supports(modeId, difficulty) }) {
+                "Legacy mode ${modeId.value} must support every difficulty for option ${optionId.value}."
             }
         }
     }
 
-    override fun selectedDifficulty(modeId: GeneratedModeId): Flow<DifficultyTier?> {
-        val fallback = fallbackDifficultyByMode[modeId] ?: return flowOf(null)
+    override fun selectedDifficulty(optionId: GeneratedPlayOptionId): Flow<DifficultyTier?> {
+        val option = optionsById[optionId] ?: return flowOf(null)
+        val fallback = fallbackDifficultyByOption.getValue(optionId)
+        val legacyModeId = legacyModeByOption.getValue(optionId)
 
         return dataStore.data
             .catch { throwable ->
@@ -44,29 +63,39 @@ class DataStoreGeneratedDifficultySelectionRepository(
                 }
             }
             .map { preferences ->
-                preferences[difficultyPreferenceKey(modeId)]
-                    .toDifficultyTierOrNull()
-                    ?.takeIf { difficulty -> catalog.supports(modeId = modeId, difficulty = difficulty) }
-                    ?: fallback
+                val storedOptionValue = preferences[difficultyPreferenceKey(optionId)]
+                if (storedOptionValue != null) {
+                    storedOptionValue.toDifficultyTierOrNull()
+                        ?.takeIf(option::supports)
+                        ?: fallback
+                } else {
+                    preferences[legacyDifficultyPreferenceKey(legacyModeId)]
+                        .toDifficultyTierOrNull()
+                        ?.takeIf(option::supports)
+                        ?: fallback
+                }
             }
             .distinctUntilChanged()
     }
 
-    override suspend fun selectDifficulty(modeId: GeneratedModeId, difficulty: DifficultyTier) {
-        require(modeId in fallbackDifficultyByMode) {
-            "Generated mode ${modeId.value} does not support remembered difficulty selection."
+    override suspend fun selectDifficulty(optionId: GeneratedPlayOptionId, difficulty: DifficultyTier) {
+        val option = requireNotNull(optionsById[optionId]) {
+            "Generated play option ${optionId.value} does not support remembered difficulty selection."
         }
-        require(catalog.supports(modeId = modeId, difficulty = difficulty)) {
-            "Difficulty ${difficulty.name} is not supported for generated mode ${modeId.value}."
+        require(option.supports(difficulty)) {
+            "Difficulty ${difficulty.name} is not supported for generated play option ${optionId.value}."
         }
 
         dataStore.edit { preferences ->
-            preferences[difficultyPreferenceKey(modeId)] = difficulty.persistedValue
+            preferences[difficultyPreferenceKey(optionId)] = difficulty.persistedValue
         }
     }
 }
 
-internal fun difficultyPreferenceKey(modeId: GeneratedModeId): Preferences.Key<String> =
+internal fun difficultyPreferenceKey(optionId: GeneratedPlayOptionId): Preferences.Key<String> =
+    stringPreferencesKey("generated_selected_difficulty_${optionId.value}")
+
+internal fun legacyDifficultyPreferenceKey(modeId: GeneratedModeId): Preferences.Key<String> =
     stringPreferencesKey("generated_selected_difficulty_${modeId.value}")
 
 private fun GeneratedChallengeCatalog.supports(modeId: GeneratedModeId, difficulty: DifficultyTier): Boolean =

--- a/app/src/main/java/org/cescfe/numpairs/data/generated/selection/GeneratedDifficultySelectionRepository.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/generated/selection/GeneratedDifficultySelectionRepository.kt
@@ -2,10 +2,10 @@ package org.cescfe.numpairs.data.generated.selection
 
 import kotlinx.coroutines.flow.Flow
 import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
-import org.cescfe.numpairs.feature.generated.GeneratedModeId
+import org.cescfe.numpairs.feature.generated.GeneratedPlayOptionId
 
 interface GeneratedDifficultySelectionRepository {
-    fun selectedDifficulty(modeId: GeneratedModeId): Flow<DifficultyTier?>
+    fun selectedDifficulty(optionId: GeneratedPlayOptionId): Flow<DifficultyTier?>
 
-    suspend fun selectDifficulty(modeId: GeneratedModeId, difficulty: DifficultyTier)
+    suspend fun selectDifficulty(optionId: GeneratedPlayOptionId, difficulty: DifficultyTier)
 }

--- a/app/src/main/java/org/cescfe/numpairs/data/generated/selection/GeneratedDifficultySelectionRepositoryFactory.kt
+++ b/app/src/main/java/org/cescfe/numpairs/data/generated/selection/GeneratedDifficultySelectionRepositoryFactory.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStore
 import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.generated.GeneratedPlayOptions
 
 fun createGeneratedDifficultySelectionRepository(context: Context): GeneratedDifficultySelectionRepository {
     val applicationContext = context.applicationContext
@@ -12,9 +13,14 @@ fun createGeneratedDifficultySelectionRepository(context: Context): GeneratedDif
     return DataStoreGeneratedDifficultySelectionRepository(
         dataStore = applicationContext.generatedDifficultySelectionDataStore,
         catalog = GeneratedModes.catalog,
-        fallbackDifficultyByMode = mapOf(
-            GeneratedModes.FOUR_PAIRS.id to GeneratedModes.FOUR_PAIRS_LOW.difficulty,
-            GeneratedModes.EIGHT_PAIRS.id to GeneratedModes.EIGHT_PAIRS_MEDIUM.difficulty
+        playOptions = GeneratedPlayOptions.ALL,
+        fallbackDifficultyByOption = mapOf(
+            GeneratedPlayOptions.QUICK.id to GeneratedModes.FOUR_PAIRS_LOW.difficulty,
+            GeneratedPlayOptions.CLASSIC.id to GeneratedModes.EIGHT_PAIRS_MEDIUM.difficulty
+        ),
+        legacyModeByOption = mapOf(
+            GeneratedPlayOptions.QUICK.id to GeneratedModes.FOUR_PAIRS.id,
+            GeneratedPlayOptions.CLASSIC.id to GeneratedModes.EIGHT_PAIRS.id
         )
     )
 }

--- a/app/src/main/java/org/cescfe/numpairs/feature/menu/MenuRoute.kt
+++ b/app/src/main/java/org/cescfe/numpairs/feature/menu/MenuRoute.kt
@@ -18,6 +18,8 @@ import org.cescfe.numpairs.feature.generated.GeneratedChallenge
 import org.cescfe.numpairs.feature.generated.GeneratedChallengeCatalog
 import org.cescfe.numpairs.feature.generated.GeneratedModeConfiguration
 import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.generated.GeneratedPlayOptionConfiguration
+import org.cescfe.numpairs.feature.generated.GeneratedPlayOptions
 import org.cescfe.numpairs.feature.generated.localizedTitle
 import org.cescfe.numpairs.feature.menu.ui.DailyMenuUiState
 import org.cescfe.numpairs.feature.menu.ui.GeneratedDifficultyMenuOptionId
@@ -57,22 +59,25 @@ fun MenuRoute(
     val fourPairsMode = generatedChallengeCatalog.resolve(GeneratedModes.FOUR_PAIRS.id)
     val eightPairsMode = generatedChallengeCatalog.resolve(GeneratedModes.EIGHT_PAIRS.id)
     val fourPairsChallenge = fourPairsMode.selectedChallenge(
-        repository = generatedDifficultySelectionRepository
+        repository = generatedDifficultySelectionRepository,
+        playOption = GeneratedPlayOptions.QUICK
     ) ?: return
     val eightPairsChallenge = eightPairsMode.selectedChallenge(
-        repository = generatedDifficultySelectionRepository
+        repository = generatedDifficultySelectionRepository,
+        playOption = GeneratedPlayOptions.CLASSIC
     ) ?: return
     val coroutineScope = rememberCoroutineScope()
     val dailyActionGuard = remember(dailyMenuState) {
         DailyMenuActionGuard()
     }
-    val selectDifficulty: (GeneratedModeConfiguration, GeneratedDifficultyMenuOptionId) -> Unit =
-        { mode, optionId ->
+    val selectDifficulty:
+        (GeneratedModeConfiguration, GeneratedPlayOptionConfiguration, GeneratedDifficultyMenuOptionId) -> Unit =
+        { mode, playOption, optionId ->
             val challenge = mode.challengeFor(optionId)
             coroutineScope.launch {
                 try {
                     generatedDifficultySelectionRepository.selectDifficulty(
-                        modeId = mode.id,
+                        optionId = playOption.id,
                         difficulty = challenge.difficulty
                     )
                 } catch (_: IOException) {
@@ -114,10 +119,10 @@ fun MenuRoute(
             onGeneratedChallengeSelected(eightPairsChallenge)
         },
         onFourPairsDifficultySelected = { optionId ->
-            selectDifficulty(fourPairsMode, optionId)
+            selectDifficulty(fourPairsMode, GeneratedPlayOptions.QUICK, optionId)
         },
         onEightPairsDifficultySelected = { optionId ->
-            selectDifficulty(eightPairsMode, optionId)
+            selectDifficulty(eightPairsMode, GeneratedPlayOptions.CLASSIC, optionId)
         }
     )
 }
@@ -174,10 +179,11 @@ private fun CurrentDailyAvailability.toMenuUiState(): DailyMenuUiState = when (t
 
 @Composable
 private fun GeneratedModeConfiguration.selectedChallenge(
-    repository: GeneratedDifficultySelectionRepository
+    repository: GeneratedDifficultySelectionRepository,
+    playOption: GeneratedPlayOptionConfiguration
 ): GeneratedChallenge? {
-    val selectedDifficultyFlow = remember(repository, id) {
-        repository.selectedDifficulty(modeId = id)
+    val selectedDifficultyFlow = remember(repository, playOption.id) {
+        repository.selectedDifficulty(optionId = playOption.id)
     }
     val selectedDifficulty by selectedDifficultyFlow.collectAsState(initial = null)
 

--- a/app/src/test/java/org/cescfe/numpairs/data/generated/selection/DataStoreGeneratedDifficultySelectionRepositoryTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/data/generated/selection/DataStoreGeneratedDifficultySelectionRepositoryTest.kt
@@ -17,8 +17,9 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.cescfe.numpairs.domain.generated.profile.DifficultyTier
-import org.cescfe.numpairs.feature.generated.GeneratedModeId
 import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.generated.GeneratedPlayOptionId
+import org.cescfe.numpairs.feature.generated.GeneratedPlayOptions
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -40,51 +41,56 @@ class DataStoreGeneratedDifficultySelectionRepositoryTest {
     }
 
     @Test
-    fun fresh_preferences_expose_mode_specific_fallbacks_without_persisting_them() = runBlocking {
+    fun fresh_preferences_expose_option_fallbacks_without_persisting_them() = runBlocking {
         val fixture = createRepository()
 
-        assertNull(fixture.repository.selectedDifficulty(GeneratedModes.THREE_PAIRS.id).first())
         assertEquals(
             DifficultyTier.LOW,
-            fixture.repository.selectedDifficulty(GeneratedModes.FOUR_PAIRS.id).first()
+            fixture.repository.selectedDifficulty(GeneratedPlayOptions.QUICK.id).first()
         )
         assertEquals(
             DifficultyTier.MEDIUM,
-            fixture.repository.selectedDifficulty(GeneratedModes.EIGHT_PAIRS.id).first()
+            fixture.repository.selectedDifficulty(GeneratedPlayOptions.CLASSIC.id).first()
         )
         assertTrue(fixture.dataStore.data.first().asMap().isEmpty())
     }
 
     @Test
-    fun quick_has_no_remembered_difficulty_selection_or_writable_preference() {
+    fun legacy_mode_preferences_supply_initial_quick_and_classic_selections_without_rewriting() = runBlocking {
         val fixture = createRepository()
-
-        assertThrows(IllegalArgumentException::class.java) {
-            runBlocking {
-                fixture.repository.selectDifficulty(
-                    GeneratedModes.THREE_PAIRS.id,
-                    DifficultyTier.LOW
-                )
-            }
+        val legacyQuickKey = legacyDifficultyPreferenceKey(GeneratedModes.FOUR_PAIRS.id)
+        val legacyClassicKey = legacyDifficultyPreferenceKey(GeneratedModes.EIGHT_PAIRS.id)
+        fixture.dataStore.edit { preferences ->
+            preferences[legacyQuickKey] = "medium"
+            preferences[legacyClassicKey] = "hard"
         }
 
-        runBlocking {
-            assertNull(fixture.repository.selectedDifficulty(GeneratedModes.THREE_PAIRS.id).first())
-            assertTrue(fixture.dataStore.data.first().asMap().isEmpty())
-        }
+        assertEquals(
+            DifficultyTier.MEDIUM,
+            fixture.repository.selectedDifficulty(GeneratedPlayOptions.QUICK.id).first()
+        )
+        assertEquals(
+            DifficultyTier.HARD,
+            fixture.repository.selectedDifficulty(GeneratedPlayOptions.CLASSIC.id).first()
+        )
+        val storedPreferences = fixture.dataStore.data.first()
+        assertEquals("medium", storedPreferences[legacyQuickKey])
+        assertEquals("hard", storedPreferences[legacyClassicKey])
+        assertNull(storedPreferences[difficultyPreferenceKey(GeneratedPlayOptions.QUICK.id)])
+        assertNull(storedPreferences[difficultyPreferenceKey(GeneratedPlayOptions.CLASSIC.id)])
     }
 
     @Test
-    fun explicit_supported_selections_persist_independently_across_recreation() = runBlocking {
+    fun explicit_option_selections_persist_independently_across_recreation() = runBlocking {
         val dataStoreFile = createDataStoreFile()
         val firstFixture = createRepository(dataStoreFile)
 
         firstFixture.repository.selectDifficulty(
-            modeId = GeneratedModes.FOUR_PAIRS.id,
+            optionId = GeneratedPlayOptions.QUICK.id,
             difficulty = DifficultyTier.MEDIUM
         )
         firstFixture.repository.selectDifficulty(
-            modeId = GeneratedModes.EIGHT_PAIRS.id,
+            optionId = GeneratedPlayOptions.CLASSIC.id,
             difficulty = DifficultyTier.HARD
         )
         firstFixture.close()
@@ -93,74 +99,69 @@ class DataStoreGeneratedDifficultySelectionRepositoryTest {
 
         assertEquals(
             DifficultyTier.MEDIUM,
-            secondFixture.repository.selectedDifficulty(GeneratedModes.FOUR_PAIRS.id).first()
+            secondFixture.repository.selectedDifficulty(GeneratedPlayOptions.QUICK.id).first()
         )
         assertEquals(
             DifficultyTier.HARD,
-            secondFixture.repository.selectedDifficulty(GeneratedModes.EIGHT_PAIRS.id).first()
+            secondFixture.repository.selectedDifficulty(GeneratedPlayOptions.CLASSIC.id).first()
         )
     }
 
     @Test
-    fun changing_one_mode_does_not_overwrite_the_other_mode() = runBlocking {
+    fun explicit_option_value_takes_precedence_over_legacy_mode_value() = runBlocking {
         val fixture = createRepository()
-        fixture.repository.selectDifficulty(GeneratedModes.FOUR_PAIRS.id, DifficultyTier.MEDIUM)
-
-        assertEquals(
-            DifficultyTier.MEDIUM,
-            fixture.repository.selectedDifficulty(GeneratedModes.FOUR_PAIRS.id).first()
-        )
-        assertEquals(
-            DifficultyTier.MEDIUM,
-            fixture.repository.selectedDifficulty(GeneratedModes.EIGHT_PAIRS.id).first()
-        )
-
-        fixture.repository.selectDifficulty(GeneratedModes.EIGHT_PAIRS.id, DifficultyTier.HARD)
-
-        assertEquals(
-            DifficultyTier.MEDIUM,
-            fixture.repository.selectedDifficulty(GeneratedModes.FOUR_PAIRS.id).first()
-        )
-        assertEquals(
-            DifficultyTier.HARD,
-            fixture.repository.selectedDifficulty(GeneratedModes.EIGHT_PAIRS.id).first()
-        )
-    }
-
-    @Test
-    fun unknown_future_and_unsupported_values_fall_back_without_rewriting_storage() = runBlocking {
-        val fixture = createRepository()
-        val fourPairsKey = difficultyPreferenceKey(GeneratedModes.FOUR_PAIRS.id)
-        val eightPairsKey = difficultyPreferenceKey(GeneratedModes.EIGHT_PAIRS.id)
         fixture.dataStore.edit { preferences ->
-            preferences[fourPairsKey] = "hard"
-            preferences[eightPairsKey] = "future-difficulty"
+            preferences[legacyDifficultyPreferenceKey(GeneratedModes.FOUR_PAIRS.id)] = "medium"
+        }
+        fixture.repository.selectDifficulty(GeneratedPlayOptions.QUICK.id, DifficultyTier.LOW)
+
+        assertEquals(
+            DifficultyTier.LOW,
+            fixture.repository.selectedDifficulty(GeneratedPlayOptions.QUICK.id).first()
+        )
+        assertEquals(
+            "medium",
+            fixture.dataStore.data.first()[legacyDifficultyPreferenceKey(GeneratedModes.FOUR_PAIRS.id)]
+        )
+    }
+
+    @Test
+    fun invalid_new_and_legacy_values_fall_back_without_rewriting_storage() = runBlocking {
+        val fixture = createRepository()
+        val quickKey = difficultyPreferenceKey(GeneratedPlayOptions.QUICK.id)
+        val classicLegacyKey = legacyDifficultyPreferenceKey(GeneratedModes.EIGHT_PAIRS.id)
+        fixture.dataStore.edit { preferences ->
+            preferences[quickKey] = "hard"
+            preferences[legacyDifficultyPreferenceKey(GeneratedModes.FOUR_PAIRS.id)] = "medium"
+            preferences[classicLegacyKey] = "future-difficulty"
         }
 
         assertEquals(
             DifficultyTier.LOW,
-            fixture.repository.selectedDifficulty(GeneratedModes.FOUR_PAIRS.id).first()
+            fixture.repository.selectedDifficulty(GeneratedPlayOptions.QUICK.id).first()
         )
         assertEquals(
             DifficultyTier.MEDIUM,
-            fixture.repository.selectedDifficulty(GeneratedModes.EIGHT_PAIRS.id).first()
+            fixture.repository.selectedDifficulty(GeneratedPlayOptions.CLASSIC.id).first()
         )
         val storedPreferences = fixture.dataStore.data.first()
-        assertEquals("hard", storedPreferences[fourPairsKey])
-        assertEquals("future-difficulty", storedPreferences[eightPairsKey])
+        assertEquals("hard", storedPreferences[quickKey])
+        assertEquals("future-difficulty", storedPreferences[classicLegacyKey])
     }
 
     @Test
-    fun unknown_mode_is_ignored_and_exposes_no_invented_fallback() = runBlocking {
+    fun unknown_option_is_ignored_and_exposes_no_invented_fallback() = runBlocking {
         val fixture = createRepository()
-        val unknownMode = GeneratedModeId("future-mode")
-        val unknownModeKey = stringPreferencesKey("generated_selected_difficulty_${unknownMode.value}")
+        val unknownOption = GeneratedPlayOptionId("future-option")
+        val unknownOptionKey = stringPreferencesKey(
+            "generated_selected_difficulty_${unknownOption.value}"
+        )
         fixture.dataStore.edit { preferences ->
-            preferences[unknownModeKey] = "hard"
+            preferences[unknownOptionKey] = "hard"
         }
 
-        assertNull(fixture.repository.selectedDifficulty(unknownMode).first())
-        assertEquals("hard", fixture.dataStore.data.first()[unknownModeKey])
+        assertNull(fixture.repository.selectedDifficulty(unknownOption).first())
+        assertEquals("hard", fixture.dataStore.data.first()[unknownOptionKey])
     }
 
     @Test
@@ -169,12 +170,15 @@ class DataStoreGeneratedDifficultySelectionRepositoryTest {
 
         assertThrows(IllegalArgumentException::class.java) {
             runBlocking {
-                fixture.repository.selectDifficulty(GeneratedModes.FOUR_PAIRS.id, DifficultyTier.HARD)
+                fixture.repository.selectDifficulty(GeneratedPlayOptions.QUICK.id, DifficultyTier.HARD)
             }
         }
         assertThrows(IllegalArgumentException::class.java) {
             runBlocking {
-                fixture.repository.selectDifficulty(GeneratedModeId("future-mode"), DifficultyTier.LOW)
+                fixture.repository.selectDifficulty(
+                    GeneratedPlayOptionId("future-option"),
+                    DifficultyTier.LOW
+                )
             }
         }
 
@@ -184,7 +188,7 @@ class DataStoreGeneratedDifficultySelectionRepositoryTest {
     }
 
     @Test
-    fun corrupt_preferences_file_recovers_to_safe_fallbacks() = runBlocking {
+    fun corrupt_preferences_file_recovers_to_safe_option_fallbacks() = runBlocking {
         val dataStoreFile = createDataStoreFile().apply {
             parentFile?.mkdirs()
             writeBytes(byteArrayOf(1, 2, 3, 4))
@@ -193,11 +197,11 @@ class DataStoreGeneratedDifficultySelectionRepositoryTest {
 
         assertEquals(
             DifficultyTier.LOW,
-            fixture.repository.selectedDifficulty(GeneratedModes.FOUR_PAIRS.id).first()
+            fixture.repository.selectedDifficulty(GeneratedPlayOptions.QUICK.id).first()
         )
         assertEquals(
             DifficultyTier.MEDIUM,
-            fixture.repository.selectedDifficulty(GeneratedModes.EIGHT_PAIRS.id).first()
+            fixture.repository.selectedDifficulty(GeneratedPlayOptions.CLASSIC.id).first()
         )
     }
 
@@ -216,9 +220,14 @@ class DataStoreGeneratedDifficultySelectionRepositoryTest {
             repository = DataStoreGeneratedDifficultySelectionRepository(
                 dataStore = dataStore,
                 catalog = GeneratedModes.catalog,
-                fallbackDifficultyByMode = mapOf(
-                    GeneratedModes.FOUR_PAIRS.id to DifficultyTier.LOW,
-                    GeneratedModes.EIGHT_PAIRS.id to DifficultyTier.MEDIUM
+                playOptions = GeneratedPlayOptions.ALL,
+                fallbackDifficultyByOption = mapOf(
+                    GeneratedPlayOptions.QUICK.id to DifficultyTier.LOW,
+                    GeneratedPlayOptions.CLASSIC.id to DifficultyTier.MEDIUM
+                ),
+                legacyModeByOption = mapOf(
+                    GeneratedPlayOptions.QUICK.id to GeneratedModes.FOUR_PAIRS.id,
+                    GeneratedPlayOptions.CLASSIC.id to GeneratedModes.EIGHT_PAIRS.id
                 )
             ),
             dataStore = dataStore,


### PR DESCRIPTION
## Related Issue

Resolves #627

## Summary

- Persist remembered difficulty by the player-facing Quick and Classic identities.
- Inherit supported legacy 4 Pairs and 8 Pairs preferences when the new key is absent.
- Keep safe defaults and recover from invalid, unsupported, or corrupt stored values.
- Update menu wiring and navigation test fakes to use play-option preferences.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`

## Checklist

- [x] The change is limited to one atomic issue.
- [x] Unit tests cover preference migration, persistence, independence, and fallbacks.
- [x] Instrumented tests compile.
- [x] Formatting checks pass.