### PR TITLE
[306] Protect simplified play modes end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Players complete hidden expressions on a board by using numbers from a strip. Th
 
 ## Current Status
 
-### Current implemented product baseline: v10; active product contract: v11
+### Current implemented product baseline: v11
 
-- 🎮 [PRD v11 Simplified Play Modes](./docs/product/prd/prd-v11.md) defines the active delivery
-  contract for player-facing Quick and Classic generated play.
+- 🎮 [PRD v11 Simplified Play Modes](./docs/product/prd/prd-v11.md) defines the delivered
+  player-facing Quick and Classic generated-play contract.
 - 🗓️ [PRD v10 Quick Play & Daily Challenge](./docs/product/prd/prd-v10.md) defines the
-  implemented 3 Pairs Quick baseline and deterministic local Daily Challenge.
+  deterministic local Daily Challenge retained by v11.
 - 📈 [PRD v8 Difficulty Selection & Challenge Expansion](./docs/product/prd/prd-v8.md) defines
-  the current generated challenge catalog and mode-specific difficulty selection.
+  the size-based generated challenge catalog that v11 keeps as its internal foundation.
 - ✨ [PRD v9 Game Feel & Personalization](./docs/product/prd/prd-v9.md) defines the current color-personalization and generated-game feedback baseline.
 - 🔁 [PRD v7 Reliable Sessions & Replay Controls](./docs/product/prd/prd-v7.md) remains the foundation for the one-slot generated-session and safe-replay contract.
 - 🎓 [PRD v6 Guided First Run](./docs/product/prd/prd-v6.md) defines the focused, explicitly
@@ -26,9 +26,9 @@ and Ember. Typography, shapes, spacing, elevation, layout, controls, and gamepla
 remain shared across them.
 
 v11 groups normal generated play into Quick and Classic while preserving the stable internal
-3 Pairs, 4 Pairs, and 8 Pairs challenge identities. Quick will expose Low and Medium and select
-the matching 3 Pairs challenge 35% of the time and 4 Pairs challenge 65% of the time. Classic will
-expose the original full-board `8 Pairs Medium` and `8 Pairs Hard` challenges. Generated feedback
+3 Pairs, 4 Pairs, and 8 Pairs challenge identities. Quick exposes Low and Medium and selects
+the matching 3 Pairs challenge 35% of the time and 4 Pairs challenge 65% of the time. Classic
+exposes the original full-board `8 Pairs Medium` and `8 Pairs Hard` challenges. Generated feedback
 continues using subtle accepted-assignment haptics, newly-correct tile motion, a brief completion
 celebration, and a successor-ready replay transition.
 
@@ -38,10 +38,11 @@ normal generated session and one Daily Session may remain resumable at the same 
 state-aware Menu action, monthly completion calendar, and non-spoiling textual share result work
 without accounts or a server.
 
-### Active milestone: v11
+### Delivered milestone: v11
 
-- The documentation-first product and architecture contract is defined.
-- Implementation follows dependency-ordered atomic issues and Pull Requests.
+- The documentation-first product and architecture contract is implemented.
+- Quick and Classic are delivered through dependency-ordered atomic issues and Pull Requests.
+- Daily Challenge retains its deterministic v10 recipe and independent persistence boundary.
 
 Historical milestone snapshots:
 
@@ -56,7 +57,7 @@ PRDs preserve the product requirements and planning context for each milestone. 
 generated-mode and profile behavior is also documented in
 [puzzle-generation.md](./docs/product/puzzle-generation.md).
 
-The v10 baseline contains five implemented generated profiles; v11 adds a calibrated
+The generated catalog contains six implemented profiles, including the v11
 `3 Pairs Medium` profile. Normal generated play stores one exact
 resumable session shared by every generated challenge, restores committed progress after process
 death, and keeps the current puzzle visible until a validated successor is stored and ready.

--- a/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/DailyMenuNavigationTest.kt
+++ b/app/src/androidTest/java/org/cescfe/numpairs/ui/navigation/DailyMenuNavigationTest.kt
@@ -37,13 +37,16 @@ import org.cescfe.numpairs.feature.daily.DailyScreenTestTags
 import org.cescfe.numpairs.feature.daily.calendar.DailyCalendarScreenTestTags
 import org.cescfe.numpairs.feature.game.ui.screen.GameScreenTestTags
 import org.cescfe.numpairs.feature.generated.ConfiguredGeneratedPuzzleGenerationUseCaseFactory
+import org.cescfe.numpairs.feature.generated.GeneratedChallenge
 import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.generated.GeneratedPlayChallengeSelector
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationResult
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCase
 import org.cescfe.numpairs.feature.generated.GeneratedPuzzleGenerationUseCaseFactory
 import org.cescfe.numpairs.feature.menu.ui.MenuScreenTestTags
 import org.cescfe.numpairs.ui.theme.NumPairsTheme
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -169,7 +172,7 @@ class DailyMenuNavigationTest {
             )
         )
         val generationCounter = GenerationCounter()
-        setContent(
+        val difficultyRepository = setContent(
             repository = repository,
             dateSource = dateSource,
             generationCounter = generationCounter
@@ -182,6 +185,8 @@ class DailyMenuNavigationTest {
             .assertIsDisplayed()
         composeTestRule.runOnIdle {
             assertEquals(1, generationCounter.count)
+            assertEquals(listOf(GeneratedModes.FOUR_PAIRS_LOW), generationCounter.createdChallenges)
+            assertTrue(difficultyRepository.explicitSelections.isEmpty())
             assertEquals(0, repository.mutationCount)
         }
     }
@@ -190,8 +195,10 @@ class DailyMenuNavigationTest {
         repository: MutableDailyRepository,
         dateSource: MutableDateSource,
         generationCounter: GenerationCounter
-    ) {
-        val generationFactory = GeneratedPuzzleGenerationUseCaseFactory {
+    ): FakeGeneratedDifficultySelectionRepository {
+        val difficultyRepository = FakeGeneratedDifficultySelectionRepository()
+        val generationFactory = GeneratedPuzzleGenerationUseCaseFactory { challenge ->
+            generationCounter.createdChallenges += challenge
             GeneratedPuzzleGenerationUseCase { request ->
                 generationCounter.count += 1
                 GeneratedPuzzleGenerationResult.Generated(
@@ -205,13 +212,18 @@ class DailyMenuNavigationTest {
                 AppNavigation(
                     onboardingRepository = FakeOnboardingRepository(),
                     generatedSessionRepository = FakeGeneratedSessionRepository(),
-                    generatedDifficultySelectionRepository =
-                    FakeGeneratedDifficultySelectionRepository(),
+                    generatedDifficultySelectionRepository = difficultyRepository,
                     personalizationPreferencesRepository =
                     FakePersonalizationPreferencesRepository(),
                     topAppBarActionDiscoveryRepository =
                     FakeTopAppBarActionDiscoveryRepository(),
                     generatedChallengeCatalog = GeneratedModes.catalog,
+                    generatedPlayChallengeSelector = GeneratedPlayChallengeSelector(
+                        challengeCatalog = GeneratedModes.catalog,
+                        quickBucketSource = {
+                            error("Daily navigation must not consume Quick selection randomness.")
+                        }
+                    ),
                     generatedPuzzleGenerationUseCaseFactory = generationFactory,
                     dailyFeatureDependencies = DailyFeatureDependencies(
                         dailySessionRepository = repository,
@@ -221,6 +233,7 @@ class DailyMenuNavigationTest {
                 )
             }
         }
+        return difficultyRepository
     }
 
     private fun generatedSnapshot(date: LocalDate): DailySessionSnapshot {
@@ -292,4 +305,5 @@ private class MutableDailyRepository(initialState: DailyState) : DailySessionRep
 
 private class GenerationCounter {
     var count: Int = 0
+    val createdChallenges = mutableListOf<GeneratedChallenge>()
 }

--- a/app/src/test/java/org/cescfe/numpairs/V11LocalizationResourceParityTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/V11LocalizationResourceParityTest.kt
@@ -8,20 +8,20 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.w3c.dom.Element
 
-class V10LocalizationResourceParityTest {
+class V11LocalizationResourceParityTest {
     @Test
-    fun v10_strings_are_complete_and_format_compatible_in_every_supported_locale() {
+    fun current_quick_classic_and_daily_strings_are_complete_and_format_compatible_in_every_locale() {
         val resourcesDirectory = resourcesDirectory()
         val defaultStrings = readStrings(
             File(resourcesDirectory, "values/strings.xml")
-        ).filterKeys(::isV10String)
+        ).filterKeys(::isCurrentPlayString)
         val supportedLocales = listOf("values-es", "values-ca")
 
         assertTrue(defaultStrings.isNotEmpty())
         supportedLocales.forEach { localeDirectory ->
             val localizedStrings = readStrings(
                 File(resourcesDirectory, "$localeDirectory/strings.xml")
-            ).filterKeys(::isV10String)
+            ).filterKeys(::isCurrentPlayString)
 
             assertEquals(defaultStrings.keys, localizedStrings.keys)
             defaultStrings.forEach { (name, defaultValue) ->
@@ -58,11 +58,17 @@ class V10LocalizationResourceParityTest {
     ).firstOrNull(File::isDirectory)
         ?: error("Android resources directory was not found from ${File(".").absolutePath}.")
 
-    private fun isV10String(name: String): Boolean = name.startsWith("daily_") ||
+    private fun isCurrentPlayString(name: String): Boolean = name.startsWith("daily_") ||
         name.startsWith("menu_daily_") ||
         name.startsWith("quick_") ||
+        name.startsWith("classic_") ||
         name.startsWith("three_pairs_") ||
-        name == "menu_play_quick_content_description"
+        name.startsWith("generated_difficulty_") ||
+        name.startsWith("generated_challenge_") ||
+        name.startsWith("menu_generated_difficulty_") ||
+        name == "menu_play_generated_challenge_content_description" ||
+        name == "menu_choose_generated_difficulty_content_description" ||
+        name == "menu_close_generated_difficulty_content_description"
 
     private fun formatArguments(value: String): List<String> =
         FORMAT_ARGUMENT.findAll(value).map { match -> match.value }.toList()

--- a/app/src/test/java/org/cescfe/numpairs/ui/navigation/ResumableGeneratedSessionTest.kt
+++ b/app/src/test/java/org/cescfe/numpairs/ui/navigation/ResumableGeneratedSessionTest.kt
@@ -7,29 +7,49 @@ import org.cescfe.numpairs.domain.puzzle.model.Expression
 import org.cescfe.numpairs.domain.puzzle.model.Operator
 import org.cescfe.numpairs.domain.puzzle.model.Puzzle
 import org.cescfe.numpairs.feature.game.presentation.support.solvedPuzzleWithKnownStripAndAssignments
+import org.cescfe.numpairs.feature.generated.GeneratedChallenge
 import org.cescfe.numpairs.feature.generated.GeneratedModes
+import org.cescfe.numpairs.feature.generated.GeneratedPlayChallengeSelector
+import org.cescfe.numpairs.feature.generated.GeneratedPlayOptionConfiguration
+import org.cescfe.numpairs.feature.generated.GeneratedPlayOptions
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ResumableGeneratedSessionTest {
     @Test
-    fun `valid unfinished snapshot resolves its exact configured challenge`() {
+    fun `every legacy size snapshot resolves its exact challenge and current play option without migration`() {
         listOf(
-            snapshot() to GeneratedModes.FOUR_PAIRS_LOW,
-            snapshot(
-                modeId = GeneratedModes.THREE_PAIRS.id.value,
-                profileId = GeneratedModes.THREE_PAIRS_LOW.profile.id.value
-            ) to GeneratedModes.THREE_PAIRS_LOW
-        ).forEach { (snapshot, expectedChallenge) ->
-            assertEquals(
-                ResumableGeneratedSession(
-                    sessionId = snapshot.sessionId,
-                    challenge = expectedChallenge
-                ),
-                snapshot.toResumableGeneratedSessionOrNull(GeneratedModes.catalog)
-            )
+            GeneratedModes.THREE_PAIRS_LOW to GeneratedPlayOptions.QUICK,
+            GeneratedModes.THREE_PAIRS_MEDIUM to GeneratedPlayOptions.QUICK,
+            GeneratedModes.FOUR_PAIRS_LOW to GeneratedPlayOptions.QUICK,
+            GeneratedModes.FOUR_PAIRS_MEDIUM to GeneratedPlayOptions.QUICK,
+            GeneratedModes.EIGHT_PAIRS_MEDIUM to GeneratedPlayOptions.CLASSIC,
+            GeneratedModes.EIGHT_PAIRS_HARD to GeneratedPlayOptions.CLASSIC
+        ).forEach { (expectedChallenge, expectedOption) ->
+            assertSnapshotCompatibility(expectedChallenge, expectedOption)
         }
+    }
+
+    private fun assertSnapshotCompatibility(
+        expectedChallenge: GeneratedChallenge,
+        expectedOption: GeneratedPlayOptionConfiguration
+    ) {
+        val snapshot = snapshot(
+            modeId = expectedChallenge.modeId.value,
+            profileId = expectedChallenge.profile.id.value
+        )
+        assertEquals(
+            ResumableGeneratedSession(
+                sessionId = snapshot.sessionId,
+                challenge = expectedChallenge
+            ),
+            snapshot.toResumableGeneratedSessionOrNull(GeneratedModes.catalog)
+        )
+        assertEquals(
+            expectedOption,
+            GeneratedPlayChallengeSelector().optionFor(expectedChallenge)
+        )
     }
 
     @Test

--- a/docs/product/prd/prd-v11.md
+++ b/docs/product/prd/prd-v11.md
@@ -1,12 +1,14 @@
 # PRD - NumPairs 🎮 v11 Simplified Play Modes
 
 > Product contract for the `v11 - Simplified Play Modes` milestone.
-> The delivered v10 Quick Play and Daily Challenge product is the implementation baseline.
+> Status: delivered.
+> The v10 Quick Play and Daily Challenge product was the implementation baseline.
 
 ## Product Summary
 
-NumPairs generated play currently exposes implementation-shaped choices: Quick, 4 Pairs, and
-8 Pairs. v11 replaces those three normal-play entries with two player-facing play options:
+Before v11, NumPairs generated play exposed implementation-shaped choices: Quick, 4 Pairs, and
+8 Pairs. v11 replaces those three normal-play entries with two delivered player-facing play
+options:
 
 - `Quick`, for shorter generated puzzles using either 3 or 4 solution pairs
 - `Classic`, for the original full board using 8 solution pairs

--- a/docs/product/puzzle-generation.md
+++ b/docs/product/puzzle-generation.md
@@ -3,11 +3,10 @@
 ## Document Status
 
 - Status: product reference for generated puzzle construction
-- Implemented v10 profiles: generated `3 Pairs Low`, `4 Pairs Low`, `4 Pairs Medium`,
-  `8 Pairs Medium`, and `8 Pairs Hard`
-- v11 target profile: calibrated generated `3 Pairs Medium`
-- v11 play-option contract: Quick selects matching 3 Pairs and 4 Pairs challenges with a 35/65
-  split; Classic resolves the matching 8 Pairs challenge
+- Implemented profiles: generated `3 Pairs Low`, `3 Pairs Medium`, `4 Pairs Low`,
+  `4 Pairs Medium`, `8 Pairs Medium`, and `8 Pairs Hard`
+- Implemented v11 play-option contract: Quick selects matching 3 Pairs and 4 Pairs challenges
+  with a 35/65 split; Classic resolves the matching 8 Pairs challenge
 - Implemented v10 Daily Challenge: versioned identity, `4 Pairs Low` recipe resolution,
   deterministic four-candidate seed schedule, device-local date capture, ordered candidate
   execution, independent persistence, gameplay, calendar, completion, and sharing
@@ -309,7 +308,7 @@ demonstration or a separate ruleset.
 
 ### `3 Pairs Medium`
 
-Status: v11 target profile.
+Status: implemented in v11.
 
 v11 Quick Medium selects this exact challenge for 35% of confirmed new-puzzle requests.
 

--- a/docs/product/visual-design-system.md
+++ b/docs/product/visual-design-system.md
@@ -1,5 +1,7 @@
 # NumPairs Visual Design System
 
+> Status: implemented through `v11 - Simplified Play Modes`.
+
 ## Purpose
 
 This document defines the current NumPairs visual design system. It originated in the

--- a/docs/technical/generated-session-persistence.md
+++ b/docs/technical/generated-session-persistence.md
@@ -4,7 +4,7 @@
 
 - Status: implemented normal generated-session persistence with v11 play-option compatibility
 - Product contracts: `docs/product/prd/prd-v7.md`, `docs/product/prd/prd-v8.md`, and
-  `docs/product/prd/prd-v10.md`; active contract: `docs/product/prd/prd-v11.md`
+  `docs/product/prd/prd-v10.md`; current contract: `docs/product/prd/prd-v11.md`
 - Related generation reference: `docs/product/puzzle-generation.md`
 - Related domain decision: `docs/technical/adr/adr-005-model-sparse-generated-challenges.md`
 - Related play-option decision:

--- a/docs/ui-behavior.md
+++ b/docs/ui-behavior.md
@@ -1,5 +1,7 @@
 # NumPairs UI Behavior
 
+> Status: implemented interaction baseline through v11.
+
 ## Overview
 
 This document defines the v11 menu, Quick, Classic, Daily Challenge, generated


### PR DESCRIPTION
## Related Issue

Resolves #629

## Summary

- Add compatibility coverage for legacy 3 Pairs, 4 Pairs, and 8 Pairs snapshots resolving as Quick or Classic without schema migration.
- Guard Daily navigation against consuming Quick randomness or mutating generated-play difficulty preferences, while preserving exact 4 Pairs Low generation.
- Expand localization parity to the current Quick, Classic, Daily, and generated-play resources.
- Mark README and current product, generation, persistence, UI, and design-system references as delivered in v11.

## Validation

- `./gradlew spotlessApply`
- `./gradlew testDebugUnitTest`
- `./gradlew spotlessCheck`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew lintDebug`